### PR TITLE
focus on search input

### DIFF
--- a/searx/static/js/searx.js
+++ b/searx/static/js/searx.js
@@ -17,7 +17,7 @@
 
     addListener(w, 'load', function () {
         var qinput = d.getElementById('q');
-        if (qinput !== null) {
+        if (qinput !== null && qinput.value === "") {
             addListener(qinput, 'focus', placeCursorAtEnd);
             qinput.focus();
         }

--- a/searx/templates/search.html
+++ b/searx/templates/search.html
@@ -1,6 +1,6 @@
 <form method="post" action="/" id="search_form">
 <div id="search_wrapper">
-    <input type="text" class="q" name="q" tabindex="1" autocomplete="off" {% if q %}value="{{ q }}"{% endif %}/>
+    <input type="text" id="q" class="q" name="q" tabindex="1" autocomplete="off" {% if q %}value="{{ q }}"{% endif %}/>
     <input type="submit" value="" id="search_submit" />
 </div>
     <div>


### PR DESCRIPTION
- bug fix (missing id="q" attribute)
- do it only on the index page : on mobile phone if the search input gets the focus, half of the results are hidden by the keyboard.
