### PR TITLE
add xml templates to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
             '../README.rst',
             'static/*/*',
             'translations/*/*/*',
+            'templates/*.xml',
             'templates/*.html',
             'templates/result_templates/*.html',
         ],


### PR DESCRIPTION
this is a bugfix, opensearch templates where not found when installing through pypi
