### PR TITLE
add application as alias

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -483,5 +483,8 @@ def run():
     )
 
 
+application = app
+
+
 if __name__ == "__main__":
     run()


### PR DESCRIPTION
`application` is the default callable, so `gunicorn mymodule` just works if there's a callable named `application`. This also works in uWSGI.
