### PR TITLE
[enh] make version of searx readable

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -7,6 +7,7 @@ server:
     themes_path : "" # Custom ui themes path
     default_theme : default # ui theme
     https_rewrite : True # Force rewrite result urls. See searx/https_rewrite.py
+    useragent_suffix : "" # suffix of searx_useragent, could contain informations like an email address to the administrator
 
 engines:
   - name : wikipedia

--- a/searx/templates/courgette/base.html
+++ b/searx/templates/courgette/base.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="description" content="Searx - a privacy-respecting, hackable metasearch engine" />
     <meta name="keywords" content="searx, search, search engine, metasearch, meta search" />
+    <meta name="generator" content="searx/{{ searx_version }}">
     <meta name="viewport" content="width=device-width, maximum-scale=1.0, user-scalable=1" />
     <title>{% block title %}{% endblock %}searx</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}" type="text/css" media="screen" />

--- a/searx/templates/default/base.html
+++ b/searx/templates/default/base.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="description" content="Searx - a privacy-respecting, hackable metasearch engine" />
     <meta name="keywords" content="searx, search, search engine, metasearch, meta search" />
+    <meta name="generator" content="searx/{{ searx_version }}">
     <meta name="viewport" content="width=device-width, maximum-scale=1.0, user-scalable=1" />
     <title>{% block title %}{% endblock %}searx</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}" type="text/css" media="screen" />

--- a/searx/templates/oscar/base.html
+++ b/searx/templates/oscar/base.html
@@ -5,6 +5,7 @@
     <meta name="description" content="Searx - a privacy-respecting, hackable metasearch engine" />
     <meta name="keywords" content="searx, search, search engine, metasearch, meta search" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="generator" content="searx/{{ searx_version }}">
     <meta name="viewport" content="width=device-width, initial-scale=1 , maximum-scale=1.0, user-scalable=1" />
     <title>{% block title %}{% endblock %}searx</title>
     
@@ -64,7 +65,7 @@
         <div class="container">
             {% block footer %}
             {% endblock %}
-            <p class="text-muted">{{ _('Powered by') }} <a href="https://github.com/asciimoo/searx">Searx</a> - {{ _('a privacy-respecting, hackable metasearch engine') }}</p>
+            <p class="text-muted">{{ _('Powered by') }} <a href="https://github.com/asciimoo/searx">searx</a> - {{ searx_version }} - {{ _('a privacy-respecting, hackable metasearch engine') }}</p>
         </div>
     </div>
     <script src="{{ url_for('static', filename='js/jquery-1.11.1.min.js') }}"></script>

--- a/searx/utils.py
+++ b/searx/utils.py
@@ -3,6 +3,9 @@ from codecs import getincrementalencoder
 from HTMLParser import HTMLParser
 from random import choice
 
+from searx.version import VERSION_STRING
+from searx import settings
+
 import cStringIO
 import csv
 import os
@@ -21,7 +24,8 @@ def gen_useragent():
 
 
 def searx_useragent():
-    return 'searx'
+    return 'searx/{searx_version} {suffix}'.format(searx_version=VERSION_STRING,
+                                          suffix=settings['server'].get('useragent_suffix', ''))
 
 
 def highlight_content(content, query):

--- a/searx/version.py
+++ b/searx/version.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+'''
+searx is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+searx is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with searx. If not, see < http://www.gnu.org/licenses/ >.
+
+(C) 2013- by Adam Tauber, <asciimoo@gmail.com>
+'''
+
+# version of searx
+VERSION_MAJOR = 0
+VERSION_MINOR = 4
+VERSION_BUILD = 0
+
+VERSION_STRING = "%d.%d.%d" % (VERSION_MAJOR,VERSION_MINOR,VERSION_BUILD)

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -44,6 +44,7 @@ from searx.engines import (
 from searx.utils import (
     UnicodeWriter, highlight_content, html_to_text, get_themes
 )
+from searx.version import VERSION_STRING
 from searx.https_rewrite import https_rules
 from searx.languages import language_codes
 from searx.search import Search
@@ -170,6 +171,8 @@ def render(template_name, override_theme=None, **kwargs):
 
     if 'autocomplete' not in kwargs:
         kwargs['autocomplete'] = autocomplete
+
+    kwargs['searx_version'] = VERSION_STRING
 
     kwargs['method'] = request.cookies.get('method', 'POST')
 

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,10 @@ from setuptools import find_packages
 
 import os
 
+# required to load VERSION_STRING constant
+sys.path.insert(0, './searx')
+from version import VERSION_STRING
+
 
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
@@ -15,7 +19,7 @@ long_description = read('README.rst')
 
 setup(
     name='searx',
-    version="0.4.0",
+    version=VERSION_STRING,
     description="A privacy-respecting, hackable metasearch engine",
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
I have modified searx, to read and display the current version of searx in the template, and in the searx_useragent string.
