### PR TITLE
Detect favicons

### DIFF
--- a/searx/templates/courgette/result_templates/default.html
+++ b/searx/templates/courgette/result_templates/default.html
@@ -1,7 +1,7 @@
 <div class="result {{ result.class }}">
 
-  {% if result['favicon'] %}
-    <img width="14" height="14" class="favicon" src="static/{{theme}}/img/icon_{{result['favicon']}}.ico" />
+  {% if "icon_"~result.engine~".ico" in favicons %}
+    <img width="14" height="14" class="favicon" src="static/{{theme}}/img/icon_{{result.engine}}.ico" alt="{{result.engine}}" />
   {% endif %}
 
   <div>

--- a/searx/templates/courgette/result_templates/map.html
+++ b/searx/templates/courgette/result_templates/map.html
@@ -1,7 +1,7 @@
 <div class="result {{ result.class }}">
 
-  {% if result['favicon'] %}
-    <img width="14" height="14" class="favicon" src="static/{{theme}}/img/icon_{{result['favicon']}}.ico" />
+  {% if "icon_"~result.engine~".ico" in favicons %}
+    <img width="14" height="14" class="favicon" src="static/{{theme}}/img/icon_{{result.engine}}.ico" alt="{{result.engine}}" />
   {% endif %}
 
   <div>

--- a/searx/templates/courgette/result_templates/videos.html
+++ b/searx/templates/courgette/result_templates/videos.html
@@ -1,12 +1,10 @@
 <div class="result">
-  {% if result['favicon'] %}
-    <img width="14" height="14" class="favicon" src="static/{{theme}}/img/icon_{{result['favicon']}}.ico" />
+  {% if "icon_"~result.engine~".ico" in favicons %}
+    <img width="14" height="14" class="favicon" src="static/{{theme}}/img/icon_{{result.engine}}.ico" alt="{{result.engine}}" />
   {% endif %}
 
-    <p>
       <h3 class="result_title"><a href="{{ result.url }}">{{ result.title|safe }}</a></h3>
       {% if result.publishedDate %}<p class="published_date">{{ result.publishedDate }}</p>{% endif %}
-      <a href="{{ result.url }}"><img width="400px" src="{{ result.thumbnail }}" title={{ result.title }} alt=" {{ result.title }}"/></a>
+      <a href="{{ result.url }}"><img width="400" src="{{ result.thumbnail }}" title="{{ result.title|striptags }}" alt="{{ result.title|striptags }}"/></a>
       <p class="url">{{ result.url }}</p>
-    </p>
 </div>

--- a/searx/templates/default/result_templates/default.html
+++ b/searx/templates/default/result_templates/default.html
@@ -1,5 +1,5 @@
 <div class="result {{ result.class }}">
-    <h3 class="result_title"> {% if result['favicon'] %}<img width="14" height="14" class="favicon" src="static/{{theme}}/img/icon_{{result['favicon']}}.ico" />{% endif %}<a href="{{ result.url }}">{{ result.title|safe }}</a></h3>
+    <h3 class="result_title">{% if "icon_"~result.engine~".ico" in favicons %}<img width="14" height="14" class="favicon" src="static/{{theme}}/img/icon_{{result.engine}}.ico" alt="{{result.engine}}" />{% endif %}<a href="{{ result.url }}">{{ result.title|safe }}</a></h3>
     <p class="url">{{ result.pretty_url }} <a class="cache_link" href="https://web.archive.org/web/{{ result.url }}">cached</a></p>
     {% if result.publishedDate %}<p class="published_date">{{ result.publishedDate }}</p>{% endif %}
     <p class="content">{% if result.img_src %}<img src="{{ result.img_src }}" class="image" />{% endif %}{% if result.content %}{{ result.content|safe }}<br class="last"/>{% endif %}</p>

--- a/searx/templates/default/result_templates/map.html
+++ b/searx/templates/default/result_templates/map.html
@@ -1,7 +1,7 @@
 <div class="result {{ result.class }}">
 
-  {% if result['favicon'] %}
-    <img width="14" height="14" class="favicon" src="static/{{theme}}/img/icon_{{result['favicon']}}.ico" />
+  {% if "icon_"~result.engine~".ico" in favicons %}
+    <img width="14" height="14" class="favicon" src="static/{{theme}}/img/icon_{{result.engine}}.ico" alt="{{result.engine}}" />
   {% endif %}
 
   <div>

--- a/searx/templates/default/result_templates/videos.html
+++ b/searx/templates/default/result_templates/videos.html
@@ -1,8 +1,6 @@
 <div class="result">
-    <p>
-      <h3 class="result_title"> {% if result['favicon'] %}<img width="14" height="14" class="favicon" src="static/{{theme}}/img/icon_{{result['favicon']}}.ico" />{% endif %}<a href="{{ result.url }}">{{ result.title|safe }}</a></h3>
+      <h3 class="result_title">{% if "icon_"~result.engine~".ico" in favicons %}<img width="14" height="14" class="favicon" src="static/{{theme}}/img/icon_{{result.engine}}.ico" alt="{{result.engine}}" />{% endif %}<a href="{{ result.url }}">{{ result.title|safe }}</a></h3>
       {% if result.publishedDate %}<p class="published_date">{{ result.publishedDate }}</p>{% endif %}
-      <a href="{{ result.url }}"><img class="thumbnail" src="{{ result.thumbnail }}" title={{ result.title }} alt=" {{ result.title }}"/></a>
+      <a href="{{ result.url }}"><img class="thumbnail" src="{{ result.thumbnail }}" title="{{ result.title|striptags }}" alt="{{ result.title|striptags }}"/></a>
       <p class="url">{{ result.url }}</p>
-    </p>
 </div>

--- a/searx/templates/oscar/result_templates/default.html
+++ b/searx/templates/oscar/result_templates/default.html
@@ -1,6 +1,6 @@
 {% from 'oscar/macros.html' import icon %}
 
-<h4 class="result_header">{% if result['favicon']~".png" in favicons %}<img width="32" height="32" class="favicon" src="static/{{ theme }}/img/icons/{{ result['favicon'] }}.png" alt="{{ result['favicon'] }}" /> {% endif %}<a href="{{ result.url }}">{{ result.title|safe }}</a></h4>
+<h4 class="result_header">{% if result.engine~".png" in favicons %}<img width="32" height="32" class="favicon" src="static/{{ theme }}/img/icons/{{ result.engine }}.png" alt="{{ result.engine }}" /> {% endif %}<a href="{{ result.url }}">{{ result.title|safe }}</a></h4>
 
 {% if result.publishedDate %}<time class="text-muted" datetime="{{ result.pubdate }}" >{{ result.publishedDate }}</time>{% endif %}
 <small><a class="text-info" href="https://web.archive.org/web/{{ result.url }}">{{ icon('link') }} {{ _('cached') }}</a></small>

--- a/searx/templates/oscar/result_templates/default.html
+++ b/searx/templates/oscar/result_templates/default.html
@@ -1,6 +1,6 @@
 {% from 'oscar/macros.html' import icon %}
 
-<h4 class="result_header">{% if result['favicon'] %}<img width="32" height="32" class="favicon" src="static/{{ theme }}/img/icons/{{ result['favicon'] }}.png" alt="{{ result['favicon'] }}" /> {% endif %}<a href="{{ result.url }}">{{ result.title|safe }}</a></h4>
+<h4 class="result_header">{% if result['favicon']~".png" in favicons %}<img width="32" height="32" class="favicon" src="static/{{ theme }}/img/icons/{{ result['favicon'] }}.png" alt="{{ result['favicon'] }}" /> {% endif %}<a href="{{ result.url }}">{{ result.title|safe }}</a></h4>
 
 {% if result.publishedDate %}<time class="text-muted" datetime="{{ result.pubdate }}" >{{ result.publishedDate }}</time>{% endif %}
 <small><a class="text-info" href="https://web.archive.org/web/{{ result.url }}">{{ icon('link') }} {{ _('cached') }}</a></small>

--- a/searx/templates/oscar/result_templates/images.html
+++ b/searx/templates/oscar/result_templates/images.html
@@ -7,7 +7,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-                <h4 class="modal-title">{% if result['favicon'] %}<img width="32" height="32" class="favicon" src="static/{{ theme }}/img/icons/{{ result['favicon'] }}.png" alt="{{ result['favicon'] }}" /> {% endif %}{{ result.title|striptags }}</h4>
+                <h4 class="modal-title">{% if result['favicon']~".png" in favicons %}<img width="32" height="32" class="favicon" src="static/{{ theme }}/img/icons/{{ result['favicon'] }}.png" alt="{{ result['favicon'] }}" /> {% endif %}{{ result.title|striptags }}</h4>
             </div>
             <div class="modal-body">
                 <img class="img-responsive center-block" src="{{ result.img_src }}" alt="{{ result.title }}">

--- a/searx/templates/oscar/result_templates/images.html
+++ b/searx/templates/oscar/result_templates/images.html
@@ -7,7 +7,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-                <h4 class="modal-title">{% if result['favicon']~".png" in favicons %}<img width="32" height="32" class="favicon" src="static/{{ theme }}/img/icons/{{ result['favicon'] }}.png" alt="{{ result['favicon'] }}" /> {% endif %}{{ result.title|striptags }}</h4>
+                <h4 class="modal-title">{% if result.engine~".png" in favicons %}<img width="32" height="32" class="favicon" src="static/{{ theme }}/img/icons/{{ result.engine }}.png" alt="{{ result.engine }}" /> {% endif %}{{ result.title|striptags }}</h4>
             </div>
             <div class="modal-body">
                 <img class="img-responsive center-block" src="{{ result.img_src }}" alt="{{ result.title }}">

--- a/searx/templates/oscar/result_templates/map.html
+++ b/searx/templates/oscar/result_templates/map.html
@@ -1,6 +1,6 @@
 {% from 'oscar/macros.html' import icon %}
 
-<h4 class="result_header">{% if result['favicon']~".png" in favicons %}<img width="32" height="32" class="favicon" src="static/{{ theme }}/img/icons/{{ result['favicon'] }}.png" alt="{{ result['favicon'] }}" /> {% endif %}<a href="{{ result.url }}">{{ result.title|safe }}</a></h4>
+<h4 class="result_header">{% if result.engine~".png" in favicons %}<img width="32" height="32" class="favicon" src="static/{{ theme }}/img/icons/{{ result.engine }}.png" alt="{{ result.engine }}" /> {% endif %}<a href="{{ result.url }}">{{ result.title|safe }}</a></h4>
 
 {% if result.publishedDate %}<time class="text-muted" datetime="{{ result.pubdate }}" >{{ result.publishedDate }}</time>{% endif %}
 

--- a/searx/templates/oscar/result_templates/map.html
+++ b/searx/templates/oscar/result_templates/map.html
@@ -1,6 +1,6 @@
 {% from 'oscar/macros.html' import icon %}
 
-<h4 class="result_header">{% if result['favicon'] %}<img width="32" height="32" class="favicon" src="static/{{ theme }}/img/icons/{{ result['favicon'] }}.png" alt="{{ result['favicon'] }}" /> {% endif %}<a href="{{ result.url }}">{{ result.title|safe }}</a></h4>
+<h4 class="result_header">{% if result['favicon']~".png" in favicons %}<img width="32" height="32" class="favicon" src="static/{{ theme }}/img/icons/{{ result['favicon'] }}.png" alt="{{ result['favicon'] }}" /> {% endif %}<a href="{{ result.url }}">{{ result.title|safe }}</a></h4>
 
 {% if result.publishedDate %}<time class="text-muted" datetime="{{ result.pubdate }}" >{{ result.publishedDate }}</time>{% endif %}
 

--- a/searx/templates/oscar/result_templates/torrent.html
+++ b/searx/templates/oscar/result_templates/torrent.html
@@ -1,6 +1,6 @@
 {% from 'oscar/macros.html' import icon %}
 
-<h4 class="result_header">{% if result['favicon']~".png" in favicons %}<img width="32" height="32" class="favicon" src="static/{{ theme }}/img/icons/{{ result['favicon'] }}.png" alt="{{ result['favicon'] }}" /> {% endif %}<a href="{{ result.url }}">{{ result.title|safe }}</a></h4>
+<h4 class="result_header">{% if result.engine~".png" in favicons %}<img width="32" height="32" class="favicon" src="static/{{ theme }}/img/icons/{{ result.engine }}.png" alt="{{ result.engine }}" /> {% endif %}<a href="{{ result.url }}">{{ result.title|safe }}</a></h4>
 
 {% if result.publishedDate %}<time class="text-muted" datetime="{{ result.pubdate }}" >{{ result.publishedDate }}</time>{% endif %}
 <small><a class="text-info" href="https://web.archive.org/web/{{ result.url }}">{{ icon('link') }} {{ _('cached') }}</a></small>

--- a/searx/templates/oscar/result_templates/torrent.html
+++ b/searx/templates/oscar/result_templates/torrent.html
@@ -1,6 +1,6 @@
 {% from 'oscar/macros.html' import icon %}
 
-<h4 class="result_header">{% if result['favicon'] %}<img width="32" height="32" class="favicon" src="static/{{ theme }}/img/icons/{{ result['favicon'] }}.png" alt="{{ result['favicon'] }}" /> {% endif %}<a href="{{ result.url }}">{{ result.title|safe }}</a></h4>
+<h4 class="result_header">{% if result['favicon']~".png" in favicons %}<img width="32" height="32" class="favicon" src="static/{{ theme }}/img/icons/{{ result['favicon'] }}.png" alt="{{ result['favicon'] }}" /> {% endif %}<a href="{{ result.url }}">{{ result.title|safe }}</a></h4>
 
 {% if result.publishedDate %}<time class="text-muted" datetime="{{ result.pubdate }}" >{{ result.publishedDate }}</time>{% endif %}
 <small><a class="text-info" href="https://web.archive.org/web/{{ result.url }}">{{ icon('link') }} {{ _('cached') }}</a></small>

--- a/searx/templates/oscar/result_templates/videos.html
+++ b/searx/templates/oscar/result_templates/videos.html
@@ -1,6 +1,6 @@
 {% from 'oscar/macros.html' import icon %}
 
-<h4 class="result_header">{% if result['favicon'] %}<img width="32" height="32" class="favicon" src="static/{{ theme }}/img/icons/{{ result['favicon'] }}.png" alt="{{ result['favicon'] }}" /> {% endif %}<a href="{{ result.url }}">{{ result.title|safe }}</a></h4>
+<h4 class="result_header">{% if result['favicon']~".png" in favicons %}<img width="32" height="32" class="favicon" src="static/{{ theme }}/img/icons/{{ result['favicon'] }}.png" alt="{{ result['favicon'] }}" /> {% endif %}<a href="{{ result.url }}">{{ result.title|safe }}</a></h4>
     
 {% if result.publishedDate %}<time class="text-muted" datetime="{{ result.pubdate }}" >{{ result.publishedDate }}</time>{% endif %}
 <small><a class="text-info" href="https://web.archive.org/web/{{ result.url }}">{{ icon('link') }} {{ _('cached') }}</a></small>

--- a/searx/templates/oscar/result_templates/videos.html
+++ b/searx/templates/oscar/result_templates/videos.html
@@ -1,13 +1,13 @@
 {% from 'oscar/macros.html' import icon %}
 
-<h4 class="result_header">{% if result['favicon']~".png" in favicons %}<img width="32" height="32" class="favicon" src="static/{{ theme }}/img/icons/{{ result['favicon'] }}.png" alt="{{ result['favicon'] }}" /> {% endif %}<a href="{{ result.url }}">{{ result.title|safe }}</a></h4>
+<h4 class="result_header">{% if result.engine~".png" in favicons %}<img width="32" height="32" class="favicon" src="static/{{ theme }}/img/icons/{{ result.engine }}.png" alt="{{ result.engine }}" /> {% endif %}<a href="{{ result.url }}">{{ result.title|safe }}</a></h4>
     
 {% if result.publishedDate %}<time class="text-muted" datetime="{{ result.pubdate }}" >{{ result.publishedDate }}</time>{% endif %}
 <small><a class="text-info" href="https://web.archive.org/web/{{ result.url }}">{{ icon('link') }} {{ _('cached') }}</a></small>
 
 <div class="container-fluid">
     <div class="row">
-        <img class="thumbnail col-xs-6 col-sm-4 col-md-4 result-content" src="{{ result.thumbnail|safe }}" alt="{{ result.title|urlencode }} {{ result['favicon'] }}" />
+        <a href="{{ result.url }}"><img class="thumbnail col-xs-6 col-sm-4 col-md-4 result-content" src="{{ result.thumbnail|safe }}" alt="{{ result.title|striptags }} {{ result.engine }}" /></a>
         {% if result.content %}<p class="col-xs-12 col-sm-8 col-md-8 result-content">{{ result.content|safe }}</p>{% endif %}
     </div>
 </div>

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -71,6 +71,13 @@ babel = Babel(app)
 #TODO configurable via settings.yml
 favicons = ['wikipedia', 'youtube', 'vimeo', 'dailymotion', 'soundcloud',
             'twitter', 'stackoverflow', 'github', 'deviantart']
+            
+global_favicons = []
+for indice,theme in enumerate(themes):
+    global_favicons.append([])
+    theme_img_path = searx_dir+"/static/"+theme+"/img/"
+    for (dirpath, dirnames, filenames) in os.walk(theme_img_path):
+        global_favicons[indice].extend(filenames)
 
 cookie_max_age = 60 * 60 * 24 * 365 * 23  # 23 years
 
@@ -292,11 +299,6 @@ def index():
             if engine in favicons:
                 result['favicon'] = engine
                 
-        mypath = searx_dir+"/static/"+get_current_theme_name()+"/img/"
-        favs=[]
-        for (dirpath, dirnames, filenames) in os.walk(mypath):
-            favs.extend(filenames)
-
         # TODO, check if timezone is calculated right
         if 'publishedDate' in result:
             result['pubdate'] = result['publishedDate'].strftime('%Y-%m-%d %H:%M:%S%z')
@@ -350,7 +352,7 @@ def index():
         answers=search.answers,
         infoboxes=search.infoboxes,
         theme=get_current_theme_name(),
-        favicons=favs
+        favicons=global_favicons[themes.index(get_current_theme_name())]
     )
 
 

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -291,6 +291,11 @@ def index():
         for engine in result['engines']:
             if engine in favicons:
                 result['favicon'] = engine
+                
+        mypath = searx_dir+"/static/"+get_current_theme_name()+"/img/"
+        favs=[]
+        for (dirpath, dirnames, filenames) in os.walk(mypath):
+            favs.extend(filenames)
 
         # TODO, check if timezone is calculated right
         if 'publishedDate' in result:
@@ -344,7 +349,8 @@ def index():
         suggestions=search.suggestions,
         answers=search.answers,
         infoboxes=search.infoboxes,
-        theme=get_current_theme_name()
+        theme=get_current_theme_name(),
+        favicons=favs
     )
 
 

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -68,10 +68,6 @@ app.secret_key = settings['server']['secret_key']
 
 babel = Babel(app)
 
-#TODO configurable via settings.yml
-favicons = ['wikipedia', 'youtube', 'vimeo', 'dailymotion', 'soundcloud',
-            'twitter', 'stackoverflow', 'github', 'deviantart']
-            
 global_favicons = []
 for indice,theme in enumerate(themes):
     global_favicons.append([])
@@ -294,10 +290,6 @@ def index():
             result['pretty_url'] = u'{0}[...]{1}'.format(*url_parts)
         else:
             result['pretty_url'] = result['url']
-
-        for engine in result['engines']:
-            if engine in favicons:
-                result['favicon'] = engine
                 
         # TODO, check if timezone is calculated right
         if 'publishedDate' in result:


### PR DESCRIPTION
I finded the way engines icons were found a bit counter productive : if a theme creator wanted to add or remove an icon, he had to modify the python source, and it would apply to all themes.

With this pull request, the list of engines can be deleted (I didn't do it, I will explain later) : a new array is created containing all images names in the '{theme}/img' folder, and passed to the template to test if the favicon searched (in the format of the theme) is in the list.
I modified Oscar to represent that.

I left default and courgette as is because of two things : I have already a pull request on those, and didn't want to experience conflicts...
And two, because there is a possibility in those theme to do something like that and didn't know if it should be done :
if favicon in list:use favicon
else: use {result_host}/favicon.ico

I didn't delete the engine array to keep a backward compatibility with themes in the wild.
When we will be ready, we delete the array, and put 'result['favicon'] = engine' outside of the for and if and we will be good to go.

BTW, the path to icons is currently '{theme}/img' because themes don't use the same folder across the board. A bit of cleaning should be done to use '{theme}/img/icons'
