### PR TITLE
Add non exclusif bang

### DIFF
--- a/searx/query.py
+++ b/searx/query.py
@@ -38,6 +38,7 @@ class Query(object):
         self.query_parts = []
         self.engines = []
         self.languages = []
+        self.specific = False
 
     # parse query, if tags are set, which
     # change the serch engine or search-language
@@ -83,7 +84,7 @@ class Query(object):
                         break
 
             # this force a engine or category
-            if query_part[0] == '!':
+            if query_part[0] == '!' or query_part[0] == '?':
                 prefix = query_part[1:].replace('_', ' ')
 
                 # check if prefix is equal with engine shortcut
@@ -109,6 +110,9 @@ class Query(object):
                                         'name': engine.name}
                                         for engine in categories[prefix]
                                         if engine not in self.blocked_engines)
+
+            if query_part[0] == '!':
+                self.specific = True
 
             # append query part to query_part list
             self.query_parts.append(query_part)

--- a/searx/search.py
+++ b/searx/search.py
@@ -371,7 +371,7 @@ class Search(object):
 
         # if engines are calculated from query,
         # set categories by using that informations
-        if self.engines:
+        if self.engines and query_obj.specific:
             self.categories = list(set(engine['category']
                                        for engine in self.engines))
 


### PR DESCRIPTION
Allow to perform a search while adding an engine (or a category) without adding it "officially" to the request.
'?' is used to add an engine without modifying anything else to the request. For example, you can perform a search in the 'general' category, and if you add '?tw' the result from Twitter will be added to the originals results.

Solve #154
'?' was chosen because '-' can be used to eliminate search terms from the majority of search engines.
