### PR TITLE
Minor fixes

### DIFF
--- a/searx/engines/digg.py
+++ b/searx/engines/digg.py
@@ -44,6 +44,9 @@ def response(resp):
 
     search_result = loads(resp.text)
 
+    if search_result['html'] == '':
+        return results
+
     dom = html.fromstring(search_result['html'])
 
     # parse results


### PR DESCRIPTION
Few digg and vimeo bug fixes.

Note that the Vimeo bug was due of a HTTP 301 redirect from https to http from Vimeo, which wasn't handled by searx.
I tried to add an allow_redirects in the GET params, but as the engines rewrite the response(), it wasn't working.
I think it could be useful to handle this kind of redirects. Maybe by extending the original response() function instead of rewriting it. But I have no idea of doing this...
