### PR TITLE
add Spell checker

### DIFF
--- a/searx/__init__.py
+++ b/searx/__init__.py
@@ -58,4 +58,10 @@ if settings.get('server', {}).get('https_rewrite'):
     from searx.https_rewrite import load_https_rules
     load_https_rules(https_rewrite_path)
 
+# load https rules only if https rewrite is enabled
+if settings.get('server', {}).get('suggestion_wordlist', False):
+    # loade https rules
+    from searx.spellchecker import import_wordlist
+    import_wordlist(settings['server']['suggestion_wordlist'])
+
 logger.info('Initialisation done')

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -10,6 +10,7 @@ server:
     useragent_suffix : "" # suffix of searx_useragent, could contain informations like an email address to the administrator
     image_proxy : False # Proxying image results through searx
     default_locale : "" # Default interface locale - leave blank to detect from browser information or use codes from the 'locales' config section
+    spell_suggestion : True # using suggestions to check spell of search-query
 
 engines:
   - name : wikipedia

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -11,6 +11,8 @@ server:
     image_proxy : False # Proxying image results through searx
     default_locale : "" # Default interface locale - leave blank to detect from browser information or use codes from the 'locales' config section
     spell_suggestion : True # using suggestions to check spell of search-query
+    suggestion_distance : 2 # maximum levenshtein distance for spell-checking
+    suggestion_wordlist : False # IN DEVELOPMENT: using wordlist for spelling correction, ATTENTION: For example: '/usr/share/dict/words' require more than 1GB RAM on every thread if used!
 
 engines:
   - name : wikipedia

--- a/searx/spellchecker.py
+++ b/searx/spellchecker.py
@@ -111,7 +111,7 @@ def corrections_from_suggestions(query, suggestions):
         new_query = new_query + sorted_corrections[0][0]
 
     # if the new_query differ from the query, add to spell_suggestions
-    if new_query != query:
+    if new_query.lower() != query.lower():
         spell_suggestions.append(new_query)
 
     # return spell suggestions

--- a/searx/spellchecker.py
+++ b/searx/spellchecker.py
@@ -1,0 +1,118 @@
+'''
+searx is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+searx is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with searx. If not, see < http://www.gnu.org/licenses/ >.
+
+(C) 2015- by Thomas Pointhuber
+'''
+
+from sets import Set
+import operator
+import re
+
+
+# Source:
+# https://en.wikibooks.org/wiki/Algorithm_Implementation/Strings/Levenshtein_distance#Python
+def levenshtein(s, t):
+    ''' From Wikipedia article; Iterative with two matrix rows. '''
+    # for this conditions, the result is easily computable
+    if s == t:
+        return 0
+    elif len(s) == 0:
+        return len(t)
+    elif len(t) == 0:
+        return len(s)
+
+    v0 = [None] * (len(t) + 1)
+    v1 = [None] * (len(t) + 1)
+
+    for i in range(len(v0)):
+        v0[i] = i
+    for i in range(len(s)):
+        v1[0] = i + 1
+        for j in range(len(t)):
+            cost = 0 if s[i] == t[j] else 1
+            v1[j + 1] = min(v1[j] + 1, v0[j + 1] + 1, v0[j] + cost)
+        for j in range(len(v0)):
+            v0[j] = v1[j]
+
+    return v1[len(t)]
+
+
+def spell_corrections(query, dictionary, max_distance=3):
+    ''' get all possible spell corrections from query using a provided dictionary '''
+    corrections = {}
+
+    for word in Set(dictionary):
+        # if the lenght of dictionary and query differ to much, skip
+        if abs(len(query)-len(word)) > max_distance:
+            continue
+
+        # calculate distance between query and word
+        distance = levenshtein(query, word)
+
+        # if distance is small enough, add to dictionary
+        if distance <= max_distance:
+            corrections[word] = distance
+
+    # return spell corrections
+    return corrections
+
+
+def corrections_from_suggestions(query, suggestions):
+    ''' get good spell corrections using suggestions '''
+    dictionary = Set()
+
+    # create dictionary from single suggestion words
+    for suggestion in suggestions:
+        words = suggestion.split()
+        dictionary.update(words)
+
+    spell_suggestions = []
+
+    # split query, including whitespaces
+    raw_query_parts = re.split(r'(\s+)', query)
+
+    # TODO: currently, generating only one spell suggestions
+    new_query = ''
+    for query_part in raw_query_parts:
+        # if query part contain less than 3 letters or only spaces, skip spell correction
+        if len(query_part) < 3 or query_part.isspace():
+            new_query = new_query + query_part
+            continue
+
+        # allowing bigger distance if query_part is long enought
+        if len(query_part) < 10:
+            max_distance = 2
+        else:
+            max_distance = 3
+
+        # calculate spell corrections for this query part
+        corrections = spell_corrections(query_part, dictionary, max_distance)
+
+        # if no corrections is provided, use typed query_part
+        if not len(corrections):
+            new_query = new_query + query_part
+            continue
+
+        # sort corrections by distance
+        sorted_corrections = sorted(corrections.items(), key=operator.itemgetter(1))
+
+        # add best corrections to new query
+        new_query = new_query + sorted_corrections[0][0]
+
+    # if the new_query differ from the query, add to spell_suggestions
+    if new_query != query:
+        spell_suggestions.append(new_query)
+
+    # return spell suggestions
+    return spell_suggestions

--- a/searx/templates/courgette/results.html
+++ b/searx/templates/courgette/results.html
@@ -31,6 +31,21 @@
         </div>
     </div>
     
+    {% if spell_suggestions %}
+    <div id="suggestions">
+        <span>{{ _('Instead search for:') }}</span>
+        {% set first = true %}
+        {% for spell_suggestion in spell_suggestions %}
+        {% if not first %} &bull; {% endif %}
+        <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}">
+            <input type="hidden" name="q" value="{{ spell_suggestion }}">
+            <input type="submit" value="{{ spell_suggestion }}" />
+        </form>
+        {% set first = false %}
+        {% endfor %}
+    </div>
+    {% endif %}
+    
     {% if answers %}
     <div id="answers" class=""><span>{{ _('Answers') }}</span>
         {% for answer in answers %}

--- a/searx/templates/default/results.html
+++ b/searx/templates/default/results.html
@@ -31,6 +31,21 @@
         </div>
     </div>
 
+    {% if spell_suggestions %}
+    <div id="suggestions">
+        <span id="suggestions-title">{{ _('Instead search for:') }}</span>
+        {% set first = true %}
+        {% for spell_suggestion in spell_suggestions %}
+        {% if not first %} &bull; {% endif %}
+        <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}">
+            <input type="hidden" name="q" value="{{ spell_suggestion }}">
+            <input type="submit" class="suggestion" value="{{ spell_suggestion }}" />
+        </form>
+        {% set first = false %}
+        {% endfor %}
+    </div>
+    {% endif %}
+
     {% if answers %}
     <div id="answers"><span>{{ _('Answers') }}</span>
         {% for answer in answers %}

--- a/searx/templates/oscar/results.html
+++ b/searx/templates/oscar/results.html
@@ -7,6 +7,18 @@
             <h1 class="sr-only">{{ _('Search results') }}</h1>
             {% include 'oscar/search.html' %}
 
+            {% if spell_suggestions %}
+            <div class="result spell_suggestions form-inline">
+                <span class="text-muted form-inline pull-left">{{ _('Instead search for:') }}</span>
+                {% for spell_suggestion in spell_suggestions %}
+                    <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}" role="navigation" class="form-inline pull-left suggestion_item">
+                        <input type="hidden" name="q" value="{{ spell_suggestion }}">
+                        <button type="submit" class="btn btn-default btn-xs">{{ spell_suggestion }}</button>
+                    </form>
+                {% endfor %}
+            </div>
+            {% endif %}
+
             {% if answers %}
             {% for answer in answers %}
             <div class="result well">

--- a/searx/templates/oscar/results.html
+++ b/searx/templates/oscar/results.html
@@ -8,10 +8,10 @@
             {% include 'oscar/search.html' %}
 
             {% if spell_suggestions %}
-            <div class="result spell_suggestions form-inline">
-                <span class="text-muted form-inline pull-left">{{ _('Instead search for:') }}</span>
+            <div style="overflow: auto;" class="result spell_suggestions">
+                <span class="text-muted pull-left">{{ _('Instead search for:') }}</span>
                 {% for spell_suggestion in spell_suggestions %}
-                    <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}" role="navigation" class="form-inline pull-left suggestion_item">
+                    <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}" role="navigation" style="margin: 0 5px;" class="pull-left">
                         <input type="hidden" name="q" value="{{ spell_suggestion }}">
                         <button type="submit" class="btn btn-default btn-xs">{{ spell_suggestion }}</button>
                     </form>

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -50,6 +50,7 @@ from searx.https_rewrite import https_url_rewrite
 from searx.search import Search
 from searx.query import Query
 from searx.autocomplete import searx_bang, backends as autocomplete_backends
+from searx.spellchecker import corrections_from_suggestions
 from searx import logger
 try:
     from pygments import highlight
@@ -304,6 +305,12 @@ def index():
     search.results, search.suggestions,\
         search.answers, search.infoboxes = search.search(request)
 
+    # calculate spell_suggestions if possible and necessary
+    if search.suggestions and search.query:
+        spell_suggestions = corrections_from_suggestions(search.query, search.suggestions)
+    else:
+        spell_suggestions = None
+
     for result in search.results:
 
         if not search.paging and engines[result['engine']].paging:
@@ -384,6 +391,7 @@ def index():
         pageno=search.pageno,
         base_url=get_base_url(),
         suggestions=search.suggestions,
+        spell_suggestions=spell_suggestions,
         answers=search.answers,
         infoboxes=search.infoboxes,
         theme=get_current_theme_name(),

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -27,6 +27,7 @@ import cStringIO
 import os
 import hashlib
 
+from sets import Set
 from datetime import datetime, timedelta
 from requests import get as http_get
 from itertools import chain
@@ -50,7 +51,7 @@ from searx.https_rewrite import https_url_rewrite
 from searx.search import Search
 from searx.query import Query
 from searx.autocomplete import searx_bang, backends as autocomplete_backends
-from searx.spellchecker import corrections_from_suggestions
+from searx.spellchecker import corrections_from_suggestions, corrections_from_wordlist
 from searx import logger
 try:
     from pygments import highlight
@@ -309,7 +310,11 @@ def index():
     if settings['server'].get('spell_suggestion') and\
        search.suggestions and search.query:
         # TODO, add query parts back to suggestions (like engine selector)
-        spell_suggestions = corrections_from_suggestions(search.query, search.suggestions)
+        # get spell corrections from suggestions
+        spell_suggestions = Set(corrections_from_suggestions(search.query, search.suggestions))
+
+        # get spell corrections from wordlist
+        spell_suggestions.update(corrections_from_wordlist(search.query))
     else:
         spell_suggestions = None
 

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -305,8 +305,10 @@ def index():
     search.results, search.suggestions,\
         search.answers, search.infoboxes = search.search(request)
 
-    # calculate spell_suggestions if possible and necessary
-    if search.suggestions and search.query:
+    # calculate spell_suggestions if possible
+    if settings['server'].get('spell_suggestion') and\
+       search.suggestions and search.query:
+        # TODO, add query parts back to suggestions (like engine selector)
         spell_suggestions = corrections_from_suggestions(search.query, search.suggestions)
     else:
         spell_suggestions = None


### PR DESCRIPTION
I have add a spell checker, like descibed int #189.

It is currently only using provided suggestions. I think we could improve them if we are also using the autocompleter-results. But I'm not sure how big the performance impact would be, if there are several thousands words in the database, so we have to test this first.

I'm sure we can improve the current code, to use same techiques like [farroo](http://blog.faroo.com/2012/06/07/improved-edit-distance-based-spelling-correction/) with has a runtime of O(1), using hashmaps. But I haven't figured out yet, how they have done that. So currently, we are only using the suggestions, which are including a very small subset of possible words.

Later we could use wordlists, generated from wikipedia or from other sources, to create a full offline spellchecker, and probably also autocompleter
