### PR TITLE
Python 3.4 and 2.7 support, together

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 flask
 flask-babel
+future
 requests
 lxml
 pyyaml

--- a/searx/__init__.py
+++ b/searx/__init__.py
@@ -14,6 +14,8 @@ along with searx. If not, see < http://www.gnu.org/licenses/ >.
 
 (C) 2013- by Adam Tauber, <asciimoo@gmail.com>
 '''
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
 import logging
 from os import environ

--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -14,16 +14,22 @@ along with searx. If not, see < http://www.gnu.org/licenses/ >.
 
 (C) 2013- by Adam Tauber, <asciimoo@gmail.com>
 '''
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import map
 
 
 from lxml import etree
 from json import loads
-from urllib import urlencode
+from urllib.parse import urlencode
 from searx.languages import language_codes
 from searx.engines import (
     categories, engines, engine_shortcuts
 )
 from searx.poolrequests import get
+from six.moves import map
 
 
 def searx_bang(full_query):
@@ -73,7 +79,7 @@ def searx_bang(full_query):
             engine_query = full_query.getSearchQuery()[1:]
 
             for lc in language_codes:
-                lang_id, lang_name, country = map(str.lower, lc)
+                lang_id, lang_name, country = list(map(str.lower, lc))
 
                 # check if query starts with language-id
                 if lang_id.startswith(engine_query):

--- a/searx/engines/500px.py
+++ b/searx/engines/500px.py
@@ -10,9 +10,13 @@
 #
 # @todo        rewrite to api
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
 
-from urllib import urlencode
-from urlparse import urljoin
+from urllib.parse import urlencode
+from urllib.parse import urljoin
 from lxml import html
 import re
 

--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -15,6 +15,11 @@ along with searx. If not, see < http://www.gnu.org/licenses/ >.
 
 (C) 2013- by Adam Tauber, <asciimoo@gmail.com>
 '''
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import unicode_literals
+from builtins import map, str
+from past.utils import old_div
 
 from os.path import realpath, dirname, splitext, join
 import sys
@@ -23,6 +28,7 @@ from flask.ext.babel import gettext
 from operator import itemgetter
 from searx import settings
 from searx import logger
+from six.moves import map
 
 
 logger = logger.getChild('engines')
@@ -57,8 +63,8 @@ def load_engine(engine_data):
             if engine_data['categories'] == 'none':
                 engine.categories = []
             else:
-                engine.categories = map(
-                    str.strip, engine_data['categories'].split(','))
+                engine.categories = list(map(
+                    str.strip, engine_data['categories'].split(',')))
             continue
         setattr(engine, param_name, engine_data[param_name])
 
@@ -121,15 +127,15 @@ def get_engines_stats():
     scores_per_result = []
 
     max_pageload = max_results = max_score = max_errors = max_score_per_result = 0  # noqa
-    for engine in engines.values():
+    for engine in list(engines.values()):
         if engine.stats['search_count'] == 0:
             continue
         results_num = \
-            engine.stats['result_count'] / float(engine.stats['search_count'])
-        load_times = engine.stats['page_load_time'] / float(engine.stats['search_count'])  # noqa
+            old_div(engine.stats['result_count'], float(engine.stats['search_count']))
+        load_times = old_div(engine.stats['page_load_time'], float(engine.stats['search_count']))  # noqa
         if results_num:
-            score = engine.stats['score_count'] / float(engine.stats['search_count'])  # noqa
-            score_per_result = score / results_num
+            score = old_div(engine.stats['score_count'], float(engine.stats['search_count']))  # noqa
+            score_per_result = old_div(score, results_num)
         else:
             score = score_per_result = 0.0
         max_results = max(results_num, max_results)

--- a/searx/engines/bing.py
+++ b/searx/engines/bing.py
@@ -11,7 +11,12 @@
 #
 # @todo        publishedDate
 
-from urllib import urlencode
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
+from urllib.parse import urlencode
 from cgi import escape
 from lxml import html
 

--- a/searx/engines/bing_images.py
+++ b/searx/engines/bing_images.py
@@ -13,7 +13,12 @@
 #              because bing does not parse count=10.
 #              limited response to 10 images
 
-from urllib import urlencode
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
+from urllib.parse import urlencode
 from lxml import html
 from yaml import load
 import re

--- a/searx/engines/bing_news.py
+++ b/searx/engines/bing_news.py
@@ -9,7 +9,12 @@
 # @stable      no (HTML can change)
 # @parse       url, title, content, publishedDate
 
-from urllib import urlencode
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
+from urllib.parse import urlencode
 from cgi import escape
 from lxml import html
 from datetime import datetime, timedelta
@@ -92,7 +97,7 @@ def response(resp):
             try:
                 # FIXME use params['language'] to parse either mm/dd or dd/mm
                 publishedDate = parser.parse(publishedDate, dayfirst=False)
-            except TypeError:
+            except (TypeError, ValueError):
                 # FIXME
                 publishedDate = datetime.now()
 

--- a/searx/engines/btdigg.py
+++ b/searx/engines/btdigg.py
@@ -8,9 +8,14 @@
 # @stable      no (HTML can change)
 # @parse       url, title, content, seed, leech, magnetlink
 
-from urlparse import urljoin
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
+from urllib.parse import urljoin
 from cgi import escape
-from urllib import quote
+from urllib.parse import quote
 from lxml import html
 from operator import itemgetter
 from searx.engines.xpath import extract_text

--- a/searx/engines/currency_convert.py
+++ b/searx/engines/currency_convert.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
 from datetime import datetime
 import re
 
@@ -5,7 +7,7 @@ categories = []
 url = 'http://finance.yahoo.com/d/quotes.csv?e=.csv&f=sl1d1t1&s={query}=X'
 weight = 100
 
-parser_re = re.compile(r'^\W*(\d+(?:\.\d+)?)\W*([a-z]{3})\W*(?:in)?\W*([a-z]{3})\W*$', re.I)  # noqa
+parser_re = re.compile(b'^\W*(\d+(?:\.\d+)?)\W*([a-z]{3})\W*(?:in)?\W*([a-z]{3})\W*$', re.I)  # noqa
 
 
 def request(query, params):

--- a/searx/engines/dailymotion.py
+++ b/searx/engines/dailymotion.py
@@ -10,7 +10,12 @@
 #
 # @todo        set content-parameter with correct data
 
-from urllib import urlencode
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
+from urllib.parse import urlencode
 from json import loads
 from cgi import escape
 from datetime import datetime

--- a/searx/engines/deezer.py
+++ b/searx/engines/deezer.py
@@ -8,8 +8,13 @@
 # @stable      yes
 # @parse       url, title, content, embedded
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
 from json import loads
-from urllib import urlencode
+from urllib.parse import urlencode
 
 # engine dependent config
 categories = ['music']

--- a/searx/engines/deviantart.py
+++ b/searx/engines/deviantart.py
@@ -10,8 +10,13 @@
 #
 # @todo        rewrite to api
 
-from urllib import urlencode
-from urlparse import urljoin
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
+from urllib.parse import urlencode
+from urllib.parse import urljoin
 from lxml import html
 import re
 

--- a/searx/engines/digg.py
+++ b/searx/engines/digg.py
@@ -8,7 +8,12 @@
 # @stable      no (HTML can change)
 # @parse       url, title, content, publishedDate, thumbnail
 
-from urllib import quote_plus
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
+from urllib.parse import quote_plus
 from json import loads
 from lxml import html
 from cgi import escape

--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -13,7 +13,12 @@
 # @todo        language support
 #              (the current used site does not support language-change)
 
-from urllib import urlencode
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
+from urllib.parse import urlencode
 from lxml.html import fromstring
 from searx.utils import html_to_text
 

--- a/searx/engines/duckduckgo_definitions.py
+++ b/searx/engines/duckduckgo_definitions.py
@@ -1,5 +1,10 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
 import json
-from urllib import urlencode
+from urllib.parse import urlencode
 from lxml import html
 from searx.utils import html_to_text
 from searx.engines.xpath import extract_text

--- a/searx/engines/dummy.py
+++ b/searx/engines/dummy.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 ## Dummy
 #
 # @results     empty array

--- a/searx/engines/faroo.py
+++ b/searx/engines/faroo.py
@@ -8,7 +8,14 @@
 # @stable      yes
 # @parse       url, title, content, publishedDate, img_src
 
-from urllib import urlencode
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from past.utils import old_div
+
+from urllib.parse import urlencode
 from json import loads
 import datetime
 from searx.utils import searx_useragent
@@ -88,7 +95,7 @@ def response(resp):
     for result in search_res['results']:
         if result['news']:
             # timestamp (milliseconds since 1970)
-            publishedDate = datetime.datetime.fromtimestamp(result['date']/1000.0)  # noqa
+            publishedDate = datetime.datetime.fromtimestamp(old_div(result['date'],1000.0))  # noqa
 
             # append news result
             results.append({'url': result['url'],

--- a/searx/engines/filecrop.py
+++ b/searx/engines/filecrop.py
@@ -1,5 +1,10 @@
-from urllib import urlencode
-from HTMLParser import HTMLParser
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
+from urllib.parse import urlencode
+from six.moves.html_parser import HTMLParser
 
 url = 'http://www.filecrop.com/'
 search_url = url + '/search.php?{query}&size_i=0&size_f=100000000&engine_r=1&engine_d=1&engine_e=1&engine_4=1&engine_m=1&pos={index}'  # noqa

--- a/searx/engines/flickr-noapi.py
+++ b/searx/engines/flickr-noapi.py
@@ -10,7 +10,12 @@
 # @stable      no
 # @parse       url, title, thumbnail, img_src
 
-from urllib import urlencode
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
+from urllib.parse import urlencode
 from json import loads
 import re
 

--- a/searx/engines/flickr.py
+++ b/searx/engines/flickr.py
@@ -11,7 +11,12 @@
 # @parse       url, title, thumbnail, img_src
 #More info on api-key : https://www.flickr.com/services/apps/create/
 
-from urllib import urlencode
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
+from urllib.parse import urlencode
 from json import loads
 
 categories = ['images']

--- a/searx/engines/generalfile.py
+++ b/searx/engines/generalfile.py
@@ -10,6 +10,9 @@
 #
 # @todo        detect torrents?
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
 from lxml import html
 
 # engine dependent config

--- a/searx/engines/github.py
+++ b/searx/engines/github.py
@@ -8,7 +8,12 @@
 # @stable      yes (using api)
 # @parse       url, title, content
 
-from urllib import urlencode
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
+from urllib.parse import urlencode
 from json import loads
 from cgi import escape
 

--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -8,8 +8,13 @@
 # @stable      no (HTML can change)
 # @parse       url, title, content, suggestion
 
-from urllib import urlencode
-from urlparse import urlparse, parse_qsl
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
+from urllib.parse import urlencode
+from urllib.parse import urlparse, parse_qsl
 from lxml import html
 from searx.poolrequests import get
 from searx.engines.xpath import extract_text, extract_url

--- a/searx/engines/google_images.py
+++ b/searx/engines/google_images.py
@@ -9,7 +9,12 @@
 # @stable      yes (but deprecated)
 # @parse       url, title, img_src
 
-from urllib import urlencode, unquote
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
+from urllib.parse import urlencode, unquote
 from json import loads
 
 # engine dependent config

--- a/searx/engines/google_news.py
+++ b/searx/engines/google_news.py
@@ -9,7 +9,12 @@
 # @stable      yes (but deprecated)
 # @parse       url, title, content, publishedDate
 
-from urllib import urlencode
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
+from urllib.parse import urlencode
 from json import loads
 from dateutil import parser
 

--- a/searx/engines/json_engine.py
+++ b/searx/engines/json_engine.py
@@ -1,6 +1,15 @@
-from urllib import urlencode
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import zip
+from builtins import str
+
+from urllib.parse import urlencode
 from json import loads
 from collections import Iterable
+import six
+from six.moves import zip
 
 search_url = None
 url_query = None
@@ -11,7 +20,7 @@ title_query = None
 
 def iterate(iterable):
     if type(iterable) == dict:
-        it = iterable.iteritems()
+        it = six.iteritems(iterable)
 
     else:
         it = enumerate(iterable)
@@ -22,7 +31,7 @@ def iterate(iterable):
 def is_iterable(obj):
     if type(obj) == str:
         return False
-    if type(obj) == unicode:
+    if type(obj) == six.text_type:
         return False
     return isinstance(obj, Iterable)
 

--- a/searx/engines/kickass.py
+++ b/searx/engines/kickass.py
@@ -8,11 +8,17 @@
 # @stable      yes (HTML can change)
 # @parse       url, title, content, seed, leech, magnetlink
 
-from urlparse import urljoin
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
+from urllib.parse import urljoin
 from cgi import escape
-from urllib import quote
+from urllib.parse import quote
 from lxml import html
 from operator import itemgetter
+from searx.engines.xpath import extract_text
 
 # engine dependent config
 categories = ['videos', 'music', 'files']
@@ -57,8 +63,7 @@ def response(resp):
         link = result.xpath('.//a[@class="cellMainLink"]')[0]
         href = urljoin(url, link.attrib['href'])
         title = ' '.join(link.xpath('.//text()'))
-        content = escape(html.tostring(result.xpath(content_xpath)[0],
-                                       method="text"))
+        content = extract_text(result.xpath(content_xpath)[0])
         seed = result.xpath('.//td[contains(@class, "green")]/text()')[0]
         leech = result.xpath('.//td[contains(@class, "red")]/text()')[0]
         filesize = result.xpath('.//td[contains(@class, "nobr")]/text()')[0]

--- a/searx/engines/mediawiki.py
+++ b/searx/engines/mediawiki.py
@@ -10,9 +10,14 @@
 #
 # @todo        content
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
 from json import loads
 from string import Formatter
-from urllib import urlencode, quote
+from urllib.parse import urlencode, quote
 
 # engine dependent config
 categories = ['general']

--- a/searx/engines/mixcloud.py
+++ b/searx/engines/mixcloud.py
@@ -8,8 +8,13 @@
 # @stable      yes
 # @parse       url, title, content, embedded, publishedDate
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
 from json import loads
-from urllib import urlencode
+from urllib.parse import urlencode
 from dateutil import parser
 
 # engine dependent config

--- a/searx/engines/openstreetmap.py
+++ b/searx/engines/openstreetmap.py
@@ -8,6 +8,9 @@
 # @stable      yes
 # @parse       url, title
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
 from json import loads
 from searx.utils import searx_useragent
 

--- a/searx/engines/photon.py
+++ b/searx/engines/photon.py
@@ -8,7 +8,12 @@
 # @stable      yes
 # @parse       url, title
 
-from urllib import urlencode
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
+from urllib.parse import urlencode
 from json import loads
 from searx.utils import searx_useragent
 

--- a/searx/engines/piratebay.py
+++ b/searx/engines/piratebay.py
@@ -8,9 +8,14 @@
 # @stable      yes (HTML can change)
 # @parse       url, title, content, seed, leech, magnetlink
 
-from urlparse import urljoin
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
+from urllib.parse import urljoin
 from cgi import escape
-from urllib import quote
+from urllib.parse import quote
 from lxml import html
 from operator import itemgetter
 

--- a/searx/engines/searchcode_code.py
+++ b/searx/engines/searchcode_code.py
@@ -8,7 +8,12 @@
 # @stable      yes
 # @parse       url, title, content
 
-from urllib import urlencode
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
+from urllib.parse import urlencode
 from json import loads
 
 
@@ -48,7 +53,7 @@ def response(resp):
         repo = result['repo']
 
         lines = dict()
-        for line, code in result['lines'].items():
+        for line, code in list(result['lines'].items()):
             lines[int(line)] = code
 
         code_language = code_endings.get(

--- a/searx/engines/searchcode_doc.py
+++ b/searx/engines/searchcode_doc.py
@@ -8,7 +8,12 @@
 # @stable      yes
 # @parse       url, title, content
 
-from urllib import urlencode
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
+from urllib.parse import urlencode
 from json import loads
 
 # engine dependent config

--- a/searx/engines/soundcloud.py
+++ b/searx/engines/soundcloud.py
@@ -8,8 +8,13 @@
 # @stable      yes
 # @parse       url, title, content, publishedDate, embedded
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
 from json import loads
-from urllib import urlencode, quote_plus
+from urllib.parse import urlencode, quote_plus
 from dateutil import parser
 
 # engine dependent config

--- a/searx/engines/stackoverflow.py
+++ b/searx/engines/stackoverflow.py
@@ -8,9 +8,14 @@
 # @stable      no (HTML can change)
 # @parse       url, title, content
 
-from urlparse import urljoin
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
+from urllib.parse import urljoin
 from cgi import escape
-from urllib import urlencode
+from urllib.parse import urlencode
 from lxml import html
 
 # engine dependent config

--- a/searx/engines/startpage.py
+++ b/searx/engines/startpage.py
@@ -10,6 +10,9 @@
 #
 # @todo        paging
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
 from lxml import html
 from cgi import escape
 import re

--- a/searx/engines/subtitleseeker.py
+++ b/searx/engines/subtitleseeker.py
@@ -8,10 +8,16 @@
 # @stable      no (HTML can change)
 # @parse       url, title, content
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
 from cgi import escape
-from urllib import quote_plus
+from urllib.parse import quote_plus
 from lxml import html
 from searx.languages import language_codes
+from searx.engines.xpath import extract_text
 
 # engine dependent config
 categories = ['videos']
@@ -44,7 +50,7 @@ def response(resp):
     if resp.search_params['language'] != 'all':
         search_lang = [lc[1]
                        for lc in language_codes
-                       if lc[0][:2] == resp.search_params['language']][0]
+                       if lc[0][:2] == resp.search_params['language'][:2]][0]
 
     # parse results
     for result in dom.xpath(results_xpath):
@@ -61,7 +67,7 @@ def response(resp):
         content = result.xpath('.//div[contains(@class,"red")]//text()')[0]
         content = content + " - "
         text = result.xpath('.//div[contains(@class,"grey-web")]')[0]
-        content = content + html.tostring(text, method='text')
+        content = content + extract_text(text)
 
         if result.xpath(".//span") != []:
             content = content +\

--- a/searx/engines/twitter.py
+++ b/searx/engines/twitter.py
@@ -10,8 +10,13 @@
 #
 # @todo        publishedDate
 
-from urlparse import urljoin
-from urllib import urlencode
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
+from urllib.parse import urljoin
+from urllib.parse import urlencode
 from lxml import html
 from cgi import escape
 from datetime import datetime

--- a/searx/engines/vimeo.py
+++ b/searx/engines/vimeo.py
@@ -12,9 +12,14 @@
 # @todo        rewrite to api
 # @todo        set content-parameter with correct data
 
-from urllib import urlencode
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
+from urllib.parse import urlencode
 from lxml import html
-from HTMLParser import HTMLParser
+from six.moves.html_parser import HTMLParser
 from searx.engines.xpath import extract_text
 from dateutil import parser
 

--- a/searx/engines/wikidata.py
+++ b/searx/engines/wikidata.py
@@ -1,5 +1,11 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+
 import json
-from urllib import urlencode
+from urllib.parse import urlencode
 from searx.poolrequests import get
 from searx.utils import format_date_by_locale
 
@@ -41,7 +47,7 @@ def response(resp):
                                             'languages': language + '|en'}))
 
     htmlresponse = get(url)
-    jsonresponse = json.loads(htmlresponse.content)
+    jsonresponse = json.loads(htmlresponse.text)
     for wikidata_id in wikidata_ids:
         results = results + getDetail(jsonresponse, wikidata_id, language, resp.search_params['language'])
 
@@ -299,7 +305,7 @@ def get_wikilink(result, wikiid):
 
 
 def get_wiki_firstlanguage(result, wikipatternid):
-    for k in result.get('sitelinks', {}).keys():
+    for k in list(result.get('sitelinks', {}).keys()):
         if k.endswith(wikipatternid) and len(k) == (2+len(wikipatternid)):
             return k[0:2]
     return None

--- a/searx/engines/xpath.py
+++ b/searx/engines/xpath.py
@@ -1,8 +1,17 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import zip
+from builtins import map
+
 from lxml import html
-from urllib import urlencode, unquote
-from urlparse import urlparse, urljoin
+from urllib.parse import urlencode, unquote
+from urllib.parse import urlparse, urljoin
 from lxml.etree import _ElementStringResult, _ElementUnicodeResult
 from searx.utils import html_to_text
+from six.moves import map
+from six.moves import zip
 
 search_url = None
 url_xpath = None
@@ -94,8 +103,8 @@ def response(resp):
         for url, title, content in zip(
             (extract_url(x, search_url) for
              x in dom.xpath(url_xpath)),
-            map(extract_text, dom.xpath(title_xpath)),
-            map(extract_text, dom.xpath(content_xpath))
+            list(map(extract_text, dom.xpath(title_xpath))),
+            list(map(extract_text, dom.xpath(content_xpath)))
         ):
             results.append({'url': url, 'title': title, 'content': content})
 

--- a/searx/engines/yacy.py
+++ b/searx/engines/yacy.py
@@ -12,8 +12,13 @@
 #
 # @todo        parse video, audio and file results
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
 from json import loads
-from urllib import urlencode
+from urllib.parse import urlencode
 from dateutil import parser
 
 # engine dependent config

--- a/searx/engines/yahoo.py
+++ b/searx/engines/yahoo.py
@@ -9,8 +9,13 @@
 # @stable      no (HTML can change)
 # @parse       url, title, content, suggestion
 
-from urllib import urlencode
-from urlparse import unquote
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
+from urllib.parse import urlencode
+from urllib.parse import unquote
 from lxml import html
 from searx.engines.xpath import extract_text, extract_url
 

--- a/searx/engines/yahoo_news.py
+++ b/searx/engines/yahoo_news.py
@@ -9,7 +9,12 @@
 # @stable      no (HTML can change)
 # @parse       url, title, content, publishedDate
 
-from urllib import urlencode
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
+from urllib.parse import urlencode
 from lxml import html
 from searx.engines.xpath import extract_text, extract_url
 from searx.engines.yahoo import parse_url

--- a/searx/engines/youtube.py
+++ b/searx/engines/youtube.py
@@ -8,8 +8,13 @@
 # @stable      yes
 # @parse       url, title, content, publishedDate, thumbnail, embedded
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
 from json import loads
-from urllib import urlencode
+from urllib.parse import urlencode
 from dateutil import parser
 
 # engine dependent config

--- a/searx/https_rewrite.py
+++ b/searx/https_rewrite.py
@@ -14,9 +14,11 @@ along with searx. If not, see < http://www.gnu.org/licenses/ >.
 
 (C) 2013- by Adam Tauber, <asciimoo@gmail.com>
 '''
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
 import re
-from urlparse import urlparse
+from urllib.parse import urlparse
 from lxml import etree
 from os import listdir
 from os.path import isfile, isdir, join

--- a/searx/https_rewrite.py
+++ b/searx/https_rewrite.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import re
-from urllib.parse import urlparse
+from six.moves.urllib.parse import urlparse
 from lxml import etree
 from os import listdir
 from os.path import isfile, isdir, join

--- a/searx/languages.py
+++ b/searx/languages.py
@@ -14,6 +14,7 @@ along with searx. If not, see < http://www.gnu.org/licenses/ >.
 
 (C) 2013- by Adam Tauber, <asciimoo@gmail.com>
 '''
+from __future__ import unicode_literals
 
 # list of language codes
 language_codes = (

--- a/searx/poolrequests.py
+++ b/searx/poolrequests.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import requests
 
 

--- a/searx/query.py
+++ b/searx/query.py
@@ -16,6 +16,10 @@ along with searx. If not, see < http://www.gnu.org/licenses/ >.
 
 (C) 2014 by Thomas Pointhuber, <thomas.pointhuber@gmx.at>
 '''
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import map
+from builtins import object
 
 from searx.languages import language_codes
 from searx.engines import (
@@ -23,6 +27,7 @@ from searx.engines import (
 )
 import string
 import re
+from six.moves import map
 
 
 class Query(object):
@@ -71,7 +76,7 @@ class Query(object):
                 # check if any language-code is equal with
                 # declared language-codes
                 for lc in language_codes:
-                    lang_id, lang_name, country = map(str.lower, lc)
+                    lang_id, lang_name, country = list(map(str.lower, lc))
 
                     # if correct language-code is found
                     # set it as new search-language

--- a/searx/testing.py
+++ b/searx/testing.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 """Shared testing code."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import object
 
 from plone.testing import Layer
 from unittest2 import TestCase
@@ -9,7 +12,7 @@ import os
 import subprocess
 
 
-class SearxTestLayer:
+class SearxTestLayer(object):
     """Base layer for non-robot tests."""
 
     __name__ = u'SearxTestLayer'

--- a/searx/tests/engines/test_dummy.py
+++ b/searx/tests/engines/test_dummy.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from searx.engines import dummy
 from searx.testing import SearxTestCase
 

--- a/searx/tests/engines/test_github.py
+++ b/searx/tests/engines/test_github.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from collections import defaultdict
 import mock
 from searx.engines import github

--- a/searx/tests/test_engines.py
+++ b/searx/tests/test_engines.py
@@ -1,2 +1,4 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
 from searx.tests.engines.test_dummy import *  # noqa
 from searx.tests.engines.test_github import *  # noqa

--- a/searx/tests/test_robot.py
+++ b/searx/tests/test_robot.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
 # -*- coding: utf-8 -*-
 
 import os

--- a/searx/tests/test_utils.py
+++ b/searx/tests/test_utils.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
 import mock
 from searx.testing import SearxTestCase
 from searx import utils

--- a/searx/tests/test_utils.py
+++ b/searx/tests/test_utils.py
@@ -9,7 +9,7 @@ from searx import utils
 class TestUtils(SearxTestCase):
 
     def test_gen_useragent(self):
-        self.assertIsInstance(utils.gen_useragent(), str)
+        self.assertIsInstance(utils.gen_useragent(), unicode)
         self.assertIsNotNone(utils.gen_useragent())
         self.assertTrue(utils.gen_useragent().startswith('Mozilla'))
 

--- a/searx/tests/test_webapp.py
+++ b/searx/tests/test_webapp.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+
 import json
-from urlparse import ParseResult
+from urllib.parse import ParseResult
 from mock import patch
 from searx import webapp
 from searx.testing import SearxTestCase

--- a/searx/tests/test_webapp.py
+++ b/searx/tests/test_webapp.py
@@ -136,21 +136,21 @@ class ViewsTestCase(SearxTestCase):
     def test_about(self):
         result = self.app.get('/about')
         self.assertEqual(result.status_code, 200)
-        self.assertIn('<h1>About <a href="/">searx</a></h1>', result.data)
+        self.assertIn(b'<h1>About <a href="/">searx</a></h1>', result.data)
 
     def test_preferences(self):
         result = self.app.get('/preferences')
         self.assertEqual(result.status_code, 200)
         self.assertIn(
-            '<form method="post" action="/preferences" id="search_form">',
+            b'<form method="post" action="/preferences" id="search_form">',
             result.data
         )
         self.assertIn(
-            '<legend>Default categories</legend>',
+            b'<legend>Default categories</legend>',
             result.data
         )
         self.assertIn(
-            '<legend>Interface language</legend>',
+            b'<legend>Interface language</legend>',
             result.data
         )
 

--- a/searx/utils.py
+++ b/searx/utils.py
@@ -1,18 +1,25 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import chr
+from builtins import object
 # import htmlentitydefs
 import locale
 import dateutil.parser
-import cStringIO
+from six.moves import cStringIO
 import csv
 import os
 import re
 
 from codecs import getincrementalencoder
-from HTMLParser import HTMLParser
+from six.moves.html_parser import HTMLParser
 from random import choice
 
 from searx.version import VERSION_STRING
 from searx import settings
 from searx import logger
+import six
 
 
 logger = logger.getChild('utils')
@@ -105,7 +112,7 @@ class HTMLTextExtractor(HTMLParser):
             codepoint = int(number[1:], 16)
         else:
             codepoint = int(number)
-        self.result.append(unichr(codepoint))
+        self.result.append(chr(codepoint))
 
     def handle_entityref(self, name):
         if not self.is_valid_tag():
@@ -124,7 +131,7 @@ def html_to_text(html):
     return s.get_text()
 
 
-class UnicodeWriter:
+class UnicodeWriter(object):
     """
     A CSV writer which will write rows to CSV file "f",
     which is encoded in the given encoding.
@@ -140,7 +147,7 @@ class UnicodeWriter:
     def writerow(self, row):
         unicode_row = []
         for col in row:
-            if type(col) == str or type(col) == unicode:
+            if type(col) == str or type(col) == six.text_type:
                 unicode_row.append(col.encode('utf-8').strip())
             else:
                 unicode_row.append(col)

--- a/searx/utils.py
+++ b/searx/utils.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from future import standard_library
 standard_library.install_aliases()
+
 from builtins import chr
 from builtins import object
 # import htmlentitydefs
@@ -139,7 +140,7 @@ class UnicodeWriter(object):
 
     def __init__(self, f, dialect=csv.excel, encoding="utf-8", **kwds):
         # Redirect output to a queue
-        self.queue = cStringIO.StringIO()
+        self.queue = cStringIO()
         self.writer = csv.writer(self.queue, dialect=dialect, **kwds)
         self.stream = f
         self.encoder = getincrementalencoder(encoding)()

--- a/searx/version.py
+++ b/searx/version.py
@@ -15,6 +15,7 @@ along with searx. If not, see < http://www.gnu.org/licenses/ >.
 
 (C) 2013- by Adam Tauber, <asciimoo@gmail.com>
 '''
+from __future__ import unicode_literals
 
 # version of searx
 VERSION_MAJOR = 0

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -16,6 +16,12 @@ along with searx. If not, see < http://www.gnu.org/licenses/ >.
 
 (C) 2013- by Adam Tauber, <asciimoo@gmail.com>
 '''
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from past.utils import old_div
 
 if __name__ == '__main__':
     from sys import path
@@ -23,13 +29,13 @@ if __name__ == '__main__':
     path.append(realpath(dirname(realpath(__file__))+'/../'))
 
 import json
-import cStringIO
+from six.moves import cStringIO
 import os
 import hashlib
 
 from datetime import datetime, timedelta
 from itertools import chain
-from urllib import urlencode
+from urllib.parse import urlencode
 from flask import (
     Flask, request, render_template, url_for, Response, make_response,
     redirect, send_from_directory
@@ -96,7 +102,7 @@ cookie_max_age = 60 * 60 * 24 * 365 * 23  # 23 years
 
 @babel.localeselector
 def get_locale():
-    locale = request.accept_languages.best_match(settings['locales'].keys())
+    locale = request.accept_languages.best_match(list(settings['locales'].keys()))
 
     if settings['server'].get('default_locale'):
         locale = settings['server']['default_locale']
@@ -341,7 +347,7 @@ def index():
             result['pubdate'] = result['publishedDate'].strftime('%Y-%m-%d %H:%M:%S%z')
             if result['publishedDate'].replace(tzinfo=None) >= datetime.now() - timedelta(days=1):
                 timedifference = datetime.now() - result['publishedDate'].replace(tzinfo=None)
-                minutes = int((timedifference.seconds / 60) % 60)
+                minutes = int((old_div(timedifference.seconds, 60)) % 60)
                 hours = int(timedifference.seconds / 60 / 60)
                 if hours == 0:
                     result['publishedDate'] = gettext(u'{minutes} minute(s) ago').format(minutes=minutes)  # noqa
@@ -482,7 +488,7 @@ def preferences():
         locale = None
         autocomplete = ''
         method = 'POST'
-        for pd_name, pd in request.form.items():
+        for pd_name, pd in list(request.form.items()):
             if pd_name.startswith('category_'):
                 category = pd_name[9:]
                 if category not in categories:
@@ -554,10 +560,10 @@ def preferences():
                   current_language=lang or 'all',
                   image_proxy=image_proxy,
                   language_codes=language_codes,
-                  categs=categories.items(),
+                  categs=list(categories.items()),
                   blocked_engines=blocked_engines,
                   autocomplete_backends=autocomplete_backends,
-                  shortcuts={y: x for x, y in engine_shortcuts.items()},
+                  shortcuts={y: x for x, y in list(engine_shortcuts.items())},
                   themes=themes,
                   theme=get_current_theme_name())
 

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -361,7 +361,7 @@ def index():
                                     'results': search.results}),
                         mimetype='application/json')
     elif search.request_data.get('format') == 'csv':
-        csv = UnicodeWriter(cStringIO.StringIO())
+        csv = UnicodeWriter(cStringIO())
         keys = ('title', 'url', 'content', 'host', 'engine', 'score')
         if search.results:
             csv.writerow(keys)

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
     install_requires=[
         'flask',
         'flask-babel',
+        'future',
         'requests',
         'lxml',
         'pyyaml',

--- a/versions.cfg
+++ b/versions.cfg
@@ -2,6 +2,7 @@
 Babel = 1.3
 Flask = 0.10.1
 Flask-Babel = 0.9
+Future = 0.14.3
 Jinja2 = 2.7.2
 MarkupSafe = 0.18
 Pygments = 2.0.1


### PR DESCRIPTION
Ok, I tried to add support to Python 3.4, without leaving python 2.7.
**_DO NOT MERGE THAT**_

As you can see, it's mostly automated import adding, using Futurize project.
But there were a few tweaks and tricks here or there.
I tested globally searx on python 2.7 and 3.4, and it worked. I discovered a few bugs I  corrected along the way (subtitleseeker for example), and one on kickass that needs an issue opened.

Travis will fail. I have no idea why.

I started this pull request to show that it was possible, but I need an hand to help me finish, particularly on the testing everything is OK and on the travis side.

EDIT : I forgot to tell, I needed to install `future` in python 2.7 (pip2.7) to make it work.
