### PR TITLE
Add Docker support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM debian:stable
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+            python-dev python2.7-minimal python-virtualenv \
+            python-pybabel python-pip zlib1g-dev \
+            libxml2-dev libxslt1-dev build-essential \
+            openssl
+
+RUN useradd searx
+
+WORKDIR /app
+RUN pip install uwsgi
+COPY requirements.txt /app/requirements.txt
+RUN pip install -r requirements.txt
+
+COPY . /app
+RUN sed -i -e "s/ultrasecretkey/`openssl rand -hex 16`/g" searx/settings.yml
+
+EXPOSE 5000
+CMD ["/usr/local/bin/uwsgi", "--uid", "searx", "--gid", "searx", "--http", ":5000", "-w",  "searx.webapp"]


### PR DESCRIPTION
This is a simple dockerfile that creates a docker image with the current checked out files, installs packages needed and makes basic configuration to run searx. By default it runs a uwsgi server on port 5000.

I've used this successfully on [deis](deis.io/) and [dokku-alt](https://github.com/dokku-alt/dokku-alt) servers.
