### PR TITLE
Stop running twice the tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - "make"
   - pip install coveralls
 script:
-  - "make tests"
+  - "make flake8"
   - "make robot"
   - "make styles"
   - "make grunt"


### PR DESCRIPTION
Tests are run twice. Once on make tests, and second in make coverage.
If we don't run make tests, we still need the make flake8. Hence the change.
