### PR TITLE
[fix] btdigg: disable ssl check

### DIFF
--- a/searx/engines/btdigg.py
+++ b/searx/engines/btdigg.py
@@ -29,6 +29,10 @@ def request(query, params):
     params['url'] = search_url.format(search_term=quote(query),
                                       pageno=params['pageno']-1)
 
+    # FIX: SSLError: hostname 'btdigg.org'
+    # doesn't match either of 'ssl2000.cloudflare.com', 'cloudflare.com', '*.cloudflare.com'
+    params['verify'] = False
+
     return params
 
 


### PR DESCRIPTION
On my laptop, there is this error :
SSLError: hostname 'btdigg.org' doesn't match either of 'ssl2000.cloudflare.com', 'cloudflare.com', '*.cloudflare.com'

On http://searx.me there is no issue, but on some others instances there is no result, I guess it's depend on the geolocation of the IP
