### PR TITLE
Fixes #271

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -687,6 +687,10 @@ Disallow: /preferences
 @app.route('/opensearch.xml', methods=['GET'])
 def opensearch():
     method = 'post'
+
+    if request.cookies.get('method', 'POST') == 'GET':
+        method = 'get'
+
     # chrome/chromium only supports HTTP GET....
     if request.headers.get('User-Agent', '').lower().find('webkit') >= 0:
         method = 'get'


### PR DESCRIPTION
The opensearch method is now the method set in the preferences.

As before, POST by default and GET for Chrome/Chromium which doesn't
handle POST
