### PR TITLE
[enh] Implement http proxies for outgoing requests. (see #236)

### DIFF
--- a/searx/poolrequests.py
+++ b/searx/poolrequests.py
@@ -66,8 +66,10 @@ class SessionSinglePool(requests.Session):
 
 
 def request(method, url, **kwargs):
-    """same as requests/requests/api.py request(...) except it use SessionSinglePool"""
+    """same as requests/requests/api.py request(...) except it use SessionSinglePool and force proxies"""
+    global settings
     session = SessionSinglePool()
+    kwargs['proxies'] = settings.get('outgoing_proxies', None)
     response = session.request(method=method, url=url, **kwargs)
     session.close()
     return response

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -10,6 +10,13 @@ server:
     image_proxy : False # Proxying image results through searx
     default_locale : "" # Default interface locale - leave blank to detect from browser information or use codes from the 'locales' config section
 
+# uncomment below section if you want to use a proxy
+# see http://docs.python-requests.org/en/latest/user/advanced/#proxies
+# SOCKS proxies are not supported : see https://github.com/kennethreitz/requests/pull/478
+#outgoing_proxies :
+#    http : http://127.0.0.1:8080
+#    https: http://127.0.0.1:8080
+
 # uncomment below section only if you have more than one network interface
 # which can be the source of outgoing search requests
 #source_ips:

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -110,6 +110,7 @@ _category_names = (gettext('files'),
                    gettext('news'),
                    gettext('map'))
 
+outgoing_proxies = settings.get('outgoing_proxies', None)
 
 @babel.localeselector
 def get_locale():
@@ -638,7 +639,8 @@ def image_proxy():
     resp = requests.get(url,
                         stream=True,
                         timeout=settings['server'].get('request_timeout', 2),
-                        headers=headers)
+                        headers=headers,
+                        proxies=outgoing_proxies)
 
     if resp.status_code == 304:
         return '', resp.status_code

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -112,6 +112,7 @@ _category_names = (gettext('files'),
 
 outgoing_proxies = settings.get('outgoing_proxies', None)
 
+
 @babel.localeselector
 def get_locale():
     locale = request.accept_languages.best_match(settings['locales'].keys())


### PR DESCRIPTION
`requests` package is used at different places : search.py, webapp.py, and in engines (see wikidata and google engines). Two solutions : either we are very vigilant are using the proxy everywhere, either 
the package `poolrequests` uses the defined proxies even it is not defined in the parameters.

This pull requests implements the second solution (exception : the image proxy which uses directly `requests` package)

The new setting `outgoing_proxies` can be set. It is directly pass are a parameter to request : http://docs.python-requests.org/en/latest/user/advanced/#proxies

SOCKS proxies are not supported : see https://github.com/kennethreitz/requests/pull/478
