### PR TITLE
[fix] SSL : SNI support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,8 @@ lxml
 pyyaml
 pygments
 python-dateutil
+ndg-httpsclient
+pyopenssl
+pyasn1
+pyasn1-modules
+certifi

--- a/searx/engines/btdigg.py
+++ b/searx/engines/btdigg.py
@@ -29,10 +29,6 @@ def request(query, params):
     params['url'] = search_url.format(search_term=quote(query),
                                       pageno=params['pageno']-1)
 
-    # FIX: SSLError: hostname 'btdigg.org'
-    # doesn't match either of 'ssl2000.cloudflare.com', 'cloudflare.com', '*.cloudflare.com'
-    params['verify'] = False
-
     return params
 
 

--- a/searx/engines/kickass.py
+++ b/searx/engines/kickass.py
@@ -34,10 +34,6 @@ def request(query, params):
     params['url'] = search_url.format(search_term=quote(query),
                                       pageno=params['pageno'])
 
-    # FIX: SSLError: hostname 'kickass.so'
-    # doesn't match either of '*.kickass.to', 'kickass.to'
-    params['verify'] = False
-
     return params
 
 

--- a/searx/engines/photon.py
+++ b/searx/engines/photon.py
@@ -41,9 +41,6 @@ def request(query, params):
     # using searx User-Agent
     params['headers']['User-Agent'] = searx_useragent()
 
-    # FIX: SSLError: SSL3_GET_SERVER_CERTIFICATE:certificate verify failed
-    params['verify'] = False
-
     return params
 
 

--- a/searx/tests/engines/test_kickass.py
+++ b/searx/tests/engines/test_kickass.py
@@ -15,7 +15,6 @@ class TestKickassEngine(SearxTestCase):
         self.assertIn('url', params)
         self.assertIn(query, params['url'])
         self.assertIn('kickass.to', params['url'])
-        self.assertIn('verify', params)
         self.assertFalse(params['verify'])
 
     def test_response(self):

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -61,6 +61,16 @@ except:
     from sys import exit
     exit(1)
 
+# check if the pyopenssl, ndg-httpsclient, pyasn1 packages are installed.
+# They are needed for SSL connection without trouble, see #298
+try:
+    import OpenSSL.SSL  # NOQA
+    import ndg.httpsclient  # NOQA
+    import pyasn1  # NOQA
+except ImportError:
+    logger.critical("The pyopenssl, ndg-httpsclient, pyasn1 packages have to be installed.\n"
+                    "Some HTTPS connections will failed")
+
 
 logger = logger.getChild('webapp')
 

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,11 @@ setup(
         'pygments',
         'setuptools',
         'python-dateutil',
+        'pyopenssl',
+        'ndg-httpsclient',
+        'pyasn1',
+        'pyasn1-modules',
+        'certifi'
     ],
     extras_require={
         'test': [

--- a/versions.cfg
+++ b/versions.cfg
@@ -32,6 +32,11 @@ speaklater = 1.3
 unittest2 = 0.5.1
 waitress = 0.8.8
 zc.recipe.testrunner = 2.0.0
+pyopenssl = 0.15.1
+ndg-httpsclient = 0.3.3
+pyasn1 = 0.1.7
+pyasn1-modules = 0.0.5
+certifi = 14.05.14
 
 # Required by:
 # WebTest==2.0.11


### PR DESCRIPTION
In some engines (kickass, btdigg, photon), SSL check is disabled because without it, there is a SSLError.

This pull request fixes this, and improves SSL security using `pyopenssl` package, see below.

To what I understood, the searx error is the lack of [SNI](http://en.wikipedia.org/wiki/Server_Name_Indication) support. 

The package `pyopenssl` can bring that with others things  : https://urllib3.readthedocs.org/en/latest/security.html#openssl-pyopenssl

> By default, we use the standard library’s ssl module. Unfortunately, there are several limitations which are addressed by PyOpenSSL:  (Python 2.x) SNI support, (Python 2.x-3.2) Disabling compression to mitigate CRIME attack.

`requests` supports this fix if `ndg-httpsclient` and `pyopenssl` are available : https://github.com/kennethreitz/requests/commit/18857a0eedcebbfc40bb1ae431daed935cd51d56

So this pull request : 
- adds the required packages
- includes the [certifi](http://certifi.io/en/latest/) package
- removes `params['verify'] = False`

Note : 
- SNI seems supported in [python 2.7.7](https://www.python.org/dev/peps/pep-0466/#new-security-related-features-in-python-2-7-maintenance-releases) and python 3
- pyopenssl can be slow to start : https://github.com/pyca/pyopenssl/issues/137
