### PR TITLE
settings.yml clean up : remove locale

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -25,17 +25,14 @@ engines:
 
   - name : bing
     engine : bing
-    locale : en-US
     shortcut : bi
 
   - name : bing images
     engine : bing_images
-    locale : en-US
     shortcut : bii
 
   - name : bing news
     engine : bing_news
-    locale : en-US
     shortcut : bin
 
   - name : btdigg
@@ -244,7 +241,6 @@ engines:
 
   - name : vimeo
     engine : vimeo
-    locale : en-US
     shortcut : vm
 
 #The blekko technology and team have joined IBM Watson! -> https://blekko.com/


### PR DESCRIPTION
locale was declared for bing\* engines and vimeo.
- bing\* engines use the language settings.
- vimeo uses neither locale nor language settings.

This avoid confusion
