### PR TITLE
Revert of #195 when the search language is not english

### DIFF
--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -76,7 +76,8 @@ def request(query, params):
                                       query=urlencode({'q': query}))
 
     params['headers']['Accept-Language'] = language
-    params['cookies']['PREF'] = get_google_pref_cookie()
+    if language.startswith('en'):
+        params['cookies']['PREF'] = get_google_pref_cookie()
 
     return params
 

--- a/searx/tests/engines/test_google.py
+++ b/searx/tests/engines/test_google.py
@@ -17,12 +17,13 @@ class TestGoogleEngine(SearxTestCase):
         self.assertIn('url', params)
         self.assertIn(query, params['url'])
         self.assertIn('google.com', params['url'])
-        self.assertIn('PREF', params['cookies'])
+        self.assertNotIn('PREF', params['cookies'])
         self.assertIn('fr', params['headers']['Accept-Language'])
 
         dicto['language'] = 'all'
         params = google.request(query, dicto)
         self.assertIn('en', params['headers']['Accept-Language'])
+        self.assertIn('PREF', params['cookies'])
 
     def test_response(self):
         self.assertRaises(AttributeError, google.response, None)


### PR DESCRIPTION
Sometimes there is two requests to google (depending of the source IP) : the first to google.com which redirect to the second : google.fr (for instance).

Going to https://www.google.com/ncr and saving the PREF cookie for future use prevent this (there is no redirection).

But, recently (or not ?), by doing this the search returns English results even if the Accept-Language is specified.

There is still a way to prevent this : going to preference, set the search language. I don't know if this can be done by searx.

For now, a quick fix is to disable the use of the PREF cookie when the search language is not English (google engine will slower but returns excepted results).

Note : sending the Accept-Language header when getting the .../ncr URL doesn't help.
