### PR TITLE
Fix a typo in the French translation.

### DIFF
--- a/searx/translations/fr/LC_MESSAGES/messages.po
+++ b/searx/translations/fr/LC_MESSAGES/messages.po
@@ -525,7 +525,7 @@ msgstr "Voir l'image"
 
 #: searx/templates/oscar/result_templates/images.html:24
 msgid "View source"
-msgstr "Voir le source"
+msgstr "Voir la source"
 
 #: searx/templates/oscar/result_templates/map.html:7
 msgid "show map"


### PR DESCRIPTION
Replaces the phrase "Voir le source" by "Voir la source".
