### PR TITLE
Meta keywords are obsolete = removal

### DIFF
--- a/searx/templates/courgette/base.html
+++ b/searx/templates/courgette/base.html
@@ -3,7 +3,6 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="description" content="Searx - a privacy-respecting, hackable metasearch engine" />
-        <meta name="keywords" content="searx, search, search engine, metasearch, meta search" />
         <meta name="generator" content="searx/{{ searx_version }}">
         <meta name="referrer" content="no-referrer">
         <meta name="viewport" content="width=device-width, maximum-scale=1.0, user-scalable=1" />

--- a/searx/templates/default/base.html
+++ b/searx/templates/default/base.html
@@ -3,7 +3,6 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="description" content="Searx - a privacy-respecting, hackable metasearch engine" />
-        <meta name="keywords" content="searx, search, search engine, metasearch, meta search" />
         <meta name="generator" content="searx/{{ searx_version }}">
         <meta name="referrer" content="no-referrer">
         <meta name="viewport" content="width=device-width, maximum-scale=1.0, user-scalable=1" />

--- a/searx/templates/oscar/base.html
+++ b/searx/templates/oscar/base.html
@@ -3,7 +3,6 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="description" content="Searx - a privacy-respecting, hackable metasearch engine" />
-    <meta name="keywords" content="searx, search, search engine, metasearch, meta search" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="generator" content="searx/{{ searx_version }}">
     <meta name="referrer" content="no-referrer">

--- a/searx/templates/pix-art/base.html
+++ b/searx/templates/pix-art/base.html
@@ -3,7 +3,6 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="description" content="Searx - a privacy-respecting, hackable metasearch engine" />
-        <meta name="keywords" content="searx, search, search engine, metasearch, meta search" />
         <meta name="generator" content="searx/{{ searx_version }}">
         <meta name="referrer" content="no-referrer">
         <meta name="viewport" content="width=device-width, maximum-scale=1.0, user-scalable=1" />


### PR DESCRIPTION
Hi,

Meta keywords are obsolete since 2009 according to [Google](http://googlewebmastercentral.blogspot.fr/2009/09/google-does-not-use-keywords-meta-tag.html) and the [Moz Marketing Scientist](http://moz.com/community/q/are-meta-keywords-coming-back#reply_136215), so I removed them.

Thanks in advance,
