### PR TITLE
[fix] bing_news

### DIFF
--- a/searx/engines/bing_news.py
+++ b/searx/engines/bing_news.py
@@ -65,7 +65,7 @@ def response(resp):
 
         # parse publishedDate
         publishedDateXPath = result.xpath('.//div[@class="sn_txt"]/div'
-                                          '//span[contains(@class,"sn_ST")]'
+                                          '//div[contains(@class,"sn_ST")]'
                                           '//span[contains(@class,"sn_tm")]')
 
         publishedDate = escape(extract_text(publishedDateXPath))

--- a/searx/tests/engines/test_bing_news.py
+++ b/searx/tests/engines/test_bing_news.py
@@ -52,11 +52,11 @@ class TestBingNewsEngine(SearxTestCase):
             <div class="sn_txt">
                 <div class="sn_oi">
                     <span class="sn_snip">Article Content</span>
-                    <span class="sn_ST">
+                    <div class="sn_ST">
                         <cite class="sn_src">metronews.fr</cite>
                         &nbsp;&#0183;&#32;
                         <span class="sn_tm">44 minutes ago</span>
-                    </span>
+                    </div>
                 </div>
             </div>
         </div>
@@ -84,11 +84,11 @@ class TestBingNewsEngine(SearxTestCase):
             <div class="sn_txt">
                 <div class="sn_oi">
                     <span class="sn_snip">Article Content</span>
-                    <span class="sn_ST">
+                    <div class="sn_ST">
                         <cite class="sn_src">metronews.fr</cite>
                         &nbsp;&#0183;&#32;
                         <span class="sn_tm">44 minutes ago</span>
-                    </span>
+                    </div>
                 </div>
             </div>
         </div>
@@ -106,11 +106,11 @@ class TestBingNewsEngine(SearxTestCase):
             <div class="sn_txt">
                 <div class="sn_oi">
                     <span class="sn_snip">Article Content</span>
-                    <span class="sn_ST">
+                    <div class="sn_ST">
                         <cite class="sn_src">metronews.fr</cite>
                         &nbsp;&#0183;&#32;
                         <span class="sn_tm">3 hours, 44 minutes ago</span>
-                    </span>
+                    </div>
                 </div>
             </div>
         </div>
@@ -128,11 +128,11 @@ class TestBingNewsEngine(SearxTestCase):
             <div class="sn_txt">
                 <div class="sn_oi">
                     <span class="sn_snip">Article Content</span>
-                    <span class="sn_ST">
+                    <div class="sn_ST">
                         <cite class="sn_src">metronews.fr</cite>
                         &nbsp;&#0183;&#32;
                         <span class="sn_tm">44 hours ago</span>
-                    </span>
+                    </div>
                 </div>
             </div>
         </div>
@@ -150,11 +150,11 @@ class TestBingNewsEngine(SearxTestCase):
             <div class="sn_txt">
                 <div class="sn_oi">
                     <span class="sn_snip">Article Content</span>
-                    <span class="sn_ST">
+                    <div class="sn_ST">
                         <cite class="sn_src">metronews.fr</cite>
                         &nbsp;&#0183;&#32;
                         <span class="sn_tm">2 days ago</span>
-                    </span>
+                    </div>
                 </div>
             </div>
         </div>
@@ -172,11 +172,11 @@ class TestBingNewsEngine(SearxTestCase):
             <div class="sn_txt">
                 <div class="sn_oi">
                     <span class="sn_snip">Article Content</span>
-                    <span class="sn_ST">
+                    <div class="sn_ST">
                         <cite class="sn_src">metronews.fr</cite>
                         &nbsp;&#0183;&#32;
                         <span class="sn_tm">27/01/2015</span>
-                    </span>
+                    </div>
                 </div>
             </div>
         </div>
@@ -194,11 +194,11 @@ class TestBingNewsEngine(SearxTestCase):
             <div class="sn_txt">
                 <div class="sn_oi">
                     <span class="sn_snip">Article Content</span>
-                    <span class="sn_ST">
+                    <div class="sn_ST">
                         <cite class="sn_src">metronews.fr</cite>
                         &nbsp;&#0183;&#32;
                         <span class="sn_tm">Il y a 3 heures</span>
-                    </span>
+                    </div>
                 </div>
             </div>
         </div>
@@ -222,11 +222,11 @@ class TestBingNewsEngine(SearxTestCase):
         <div class="sn_txt">
             <div class="sn_oi">
                 <span class="sn_snip">Article Content</span>
-                <span class="sn_ST">
+                <div class="sn_ST">
                     <cite class="sn_src">metronews.fr</cite>
                     &nbsp;&#0183;&#32;
                     <span class="sn_tm">44 minutes ago</span>
-                </span>
+                </div>
             </div>
         </div>
         """


### PR DESCRIPTION
Fix #328

The bing news website has replace a span by a div : 

``` html
<div class="newstitle">
<div class="sn_txt">
<div class="sn_oi">
<span class="sn_snip">...</span>
<div class="sn_ST"> <!-- was a span before -->
<a class="articletopic" h="..." href="...">...</a>
</div>
...
```
