### PR TITLE
[fix] Piratebay engine

### DIFF
--- a/searx/engines/piratebay.py
+++ b/searx/engines/piratebay.py
@@ -20,7 +20,7 @@ categories = ['videos', 'music', 'files']
 paging = True
 
 # search-url
-url = 'https://thepiratebay.se/'
+url = 'https://thepiratebay.am/'
 search_url = url + 'search/{search_term}/{pageno}/99/{search_type}'
 
 # piratebay specific type-definitions
@@ -41,10 +41,6 @@ def request(query, params):
     params['url'] = search_url.format(search_term=quote(query),
                                       search_type=search_type,
                                       pageno=params['pageno'] - 1)
-
-    # FIX: SSLError: hostname 'kthepiratebay.se'
-    # doesn't match either of 'ssl2000.cloudflare.com', 'cloudflare.com', '*.cloudflare.com'
-    params['verify'] = False
 
     return params
 

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -167,6 +167,7 @@ engines:
   - name : piratebay
     engine : piratebay
     shortcut : tpb
+    disabled : True
 
   - name : kickass
     engine : kickass

--- a/searx/tests/engines/test_piratebay.py
+++ b/searx/tests/engines/test_piratebay.py
@@ -15,7 +15,7 @@ class TestPiratebayEngine(SearxTestCase):
         params = piratebay.request(query, dicto)
         self.assertIn('url', params)
         self.assertIn(query, params['url'])
-        self.assertIn('piratebay.se', params['url'])
+        self.assertIn('piratebay.am', params['url'])
         self.assertIn('0', params['url'])
 
         dicto['category'] = 'music'
@@ -99,7 +99,7 @@ class TestPiratebayEngine(SearxTestCase):
         self.assertEqual(type(results), list)
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0]['title'], 'This is the title')
-        self.assertEqual(results[0]['url'], 'https://thepiratebay.se/this.is.the.link')
+        self.assertEqual(results[0]['url'], 'https://thepiratebay.am/this.is.the.link')
         self.assertEqual(results[0]['content'], 'This is the content and should be OK')
         self.assertEqual(results[0]['seed'], 13)
         self.assertEqual(results[0]['leech'], 334)
@@ -149,7 +149,7 @@ class TestPiratebayEngine(SearxTestCase):
         self.assertEqual(type(results), list)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['title'], 'This is the title')
-        self.assertEqual(results[0]['url'], 'https://thepiratebay.se/this.is.the.link')
+        self.assertEqual(results[0]['url'], 'https://thepiratebay.am/this.is.the.link')
         self.assertEqual(results[0]['content'], 'This is the content and should be OK')
         self.assertEqual(results[0]['seed'], 0)
         self.assertEqual(results[0]['leech'], 0)


### PR DESCRIPTION
Fix #330

Fix the URL, and disable the engine by default by the history of this website seems "strange" now.
May be it should be completely deleted.
