### PR TITLE
fix little bug inside settings, improve oscar template

### DIFF
--- a/searx/templates/courgette/preferences.html
+++ b/searx/templates/courgette/preferences.html
@@ -101,7 +101,7 @@
                 <th>{{ _('Category') }}</th>
                 <th>{{ _('Allow') }} / {{ _('Block') }}</th>
             </tr>
-        {% for categ in categories %}
+        {% for categ in all_categories %}
             {% for search_engine in engines_by_category[categ] %}
 
                 {% if not search_engine.private %}

--- a/searx/templates/default/preferences.html
+++ b/searx/templates/default/preferences.html
@@ -89,7 +89,7 @@
             <th>{{ _('Category') }}</th>
             <th>{{ _('Allow') }} / {{ _('Block') }}</th>
         </tr>
-    {% for categ in categories %}
+    {% for categ in all_categories %}
         {% for search_engine in engines_by_category[categ] %}
 
             {% if not search_engine.private %}

--- a/searx/templates/oscar/messages/no_cookies.html
+++ b/searx/templates/oscar/messages/no_cookies.html
@@ -1,0 +1,5 @@
+{% from 'oscar/macros.html' import icon %}
+<div class="alert alert-info fade in" role="alert">
+    <strong class="lead">{{ icon('info-sign') }} {{ _('Information!') }}</strong>
+    {{ _('currently, there are no cookies defined.') }}
+</div>

--- a/searx/templates/oscar/preferences.html
+++ b/searx/templates/oscar/preferences.html
@@ -213,21 +213,23 @@
                     {{ _('This is the list of cookies and their values searx is storing on your computer.') }}<br />
                     {{ _('With that list, you can assess searx transparency.') }}<br />
                 </p>
-                <div class="container-fluid">
-                    <fieldset>
-                        <div class="row">
-                            <div class="col-xs-6 col-sm-4 col-md-4 text-muted"><label>{{ _('Cookie name') }}</label></div>
-                            <div class="col-xs-6 col-sm-4 col-md-4 text-muted"><label>{{ _('Value') }}</label></div>
-                        </div>
+                {% if cookies %}
+                <table class="table table-striped">
+                    <tr>
+                        <th class="text-muted" style="padding-right:40px;">{{ _('Cookie name') }}</th>
+                        <th class="text-muted">{{ _('Value') }}</th>
+                    </tr>
 
                     {% for cookie in cookies %}
-                        <div class="row">
-                            <div class="col-xs-6 col-sm-4 col-md-4 text-muted">{{ cookie }}</div>
-                            <div class="col-xs-6 col-sm-4 col-md-4 text-muted">{{ cookies[cookie] }}</div>
-                        </div>
+                    <tr>
+                        <td class="text-muted" style="padding-right:40px;">{{ cookie }}</td>
+                        <td class="text-muted">{{ cookies[cookie] }}</td>
+                    </tr>
                     {% endfor %}
-                    </fieldset>
-                </div>
+                </table>
+                {% else %}
+                    {% include 'oscar/messages/no_cookies.html' %}
+                {% endif %}
             </div>
         </div>
         <p class="text-muted" style="margin:20px 0;">{{ _('These settings are stored in your cookies, this allows us not to store this data about you.') }}

--- a/searx/templates/oscar/preferences.html
+++ b/searx/templates/oscar/preferences.html
@@ -117,7 +117,7 @@
 
                 <!-- Nav tabs -->
                 <ul class="nav nav-tabs nav-justified hide_if_nojs" role="tablist" style="margin-bottom:20px;">
-                    {% for categ in categories %}
+                    {% for categ in all_categories %}
                     <li{% if loop.first %} class="active"{% endif %}><a href="#tab_engine_{{ categ|replace(' ', '_') }}" role="tab" data-toggle="tab">{{ _(categ) }}</a></li>
                     {% endfor %}
                 </ul>
@@ -128,7 +128,7 @@
 
                 <!-- Tab panes -->
                 <div class="tab-content">
-                    {% for categ in categories %}
+                    {% for categ in all_categories %}
                     <noscript><label>{{ _(categ) }}</label>
                     </noscript>
                     <div class="tab-pane{% if loop.first %} active{% endif %} active_if_nojs" id="tab_engine_{{ categ|replace(' ', '_') }}">

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -279,6 +279,12 @@ def render(template_name, override_theme=None, **kwargs):
                                     if x != 'general'
                                     and x in nonblocked_categories)
 
+    if 'all_categories' not in kwargs:
+        kwargs['all_categories'] = ['general']
+        kwargs['all_categories'].extend(x for x in
+                                        sorted(categories.keys())
+                                        if x != 'general')
+
     if 'selected_categories' not in kwargs:
         kwargs['selected_categories'] = []
         for arg in request.args:
@@ -286,11 +292,13 @@ def render(template_name, override_theme=None, **kwargs):
                 c = arg.split('_', 1)[1]
                 if c in categories:
                     kwargs['selected_categories'].append(c)
+
     if not kwargs['selected_categories']:
         cookie_categories = request.cookies.get('categories', '').split(',')
         for ccateg in cookie_categories:
             if ccateg in categories:
                 kwargs['selected_categories'].append(ccateg)
+
     if not kwargs['selected_categories']:
         kwargs['selected_categories'] = ['general']
 


### PR DESCRIPTION
**fix**: When someone deactivated all engines from a defined categorie, the categorie wasn't displayed anymore inside the settings.

**enh**: use of table instead of container-fluid in the cookie tab, to provide a continuous design and to show more contrast between the single rows.
