### PR TITLE
Add a plugin to remove trackers from results URLs

### DIFF
--- a/searx/plugins/__init__.py
+++ b/searx/plugins/__init__.py
@@ -21,7 +21,8 @@ logger = logger.getChild('plugins')
 
 from searx.plugins import (https_rewrite,
                            self_ip,
-                           search_on_category_select)
+                           search_on_category_select,
+                           tracker_url_remover)
 
 required_attrs = (('name', str),
                   ('description', str),
@@ -73,3 +74,4 @@ plugins = PluginStore()
 plugins.register(https_rewrite)
 plugins.register(self_ip)
 plugins.register(search_on_category_select)
+plugins.register(tracker_url_remover)

--- a/searx/plugins/tracker_url_remover.py
+++ b/searx/plugins/tracker_url_remover.py
@@ -1,0 +1,40 @@
+'''
+searx is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+searx is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with searx. If not, see < http://www.gnu.org/licenses/ >.
+
+(C) 2015 by Adam Tauber, <asciimoo@gmail.com>
+'''
+
+from flask.ext.babel import gettext
+import re
+
+re1 = re.compile(r'utm_[^&]+&?')
+re2 = re.compile(r'(wkey|wemail)[^&]+&?')
+re3 = re.compile(r'&$')
+re4 = re.compile(r'^\?$')
+
+name = gettext('Tracker URL remover')
+description = gettext('Remove trackers arguments from the returned URL')
+default_on = True
+
+
+def on_result(request, ctx):
+    url = ctx['result']['url']
+
+    url = re1.sub('', url)
+    url = re2.sub('', url)
+    url = re3.sub('', url)
+    url = re4.sub('', url)
+
+    ctx['result']['url'] = url
+    return True

--- a/searx/plugins/tracker_url_remover.py
+++ b/searx/plugins/tracker_url_remover.py
@@ -18,10 +18,9 @@ along with searx. If not, see < http://www.gnu.org/licenses/ >.
 from flask.ext.babel import gettext
 import re
 
-re1 = re.compile(r'utm_[^&]+&?')
-re2 = re.compile(r'(wkey|wemail)[^&]+&?')
-re3 = re.compile(r'&$')
-re4 = re.compile(r'^\?$')
+regexes = {re.compile(r'utm_[^&]+&?'),
+           re.compile(r'(wkey|wemail)[^&]+&?'),
+           re.compile(r'&$')}
 
 name = gettext('Tracker URL remover')
 description = gettext('Remove trackers arguments from the returned URL')
@@ -29,12 +28,17 @@ default_on = True
 
 
 def on_result(request, ctx):
-    url = ctx['result']['url']
+    splited_url = ctx['result']['url'].split('?')
 
-    url = re1.sub('', url)
-    url = re2.sub('', url)
-    url = re3.sub('', url)
-    url = re4.sub('', url)
+    if len(splited_url) is not 2:
+        return True
 
-    ctx['result']['url'] = url
+    for reg in regexes:
+        splited_url[1] = reg.sub('', splited_url[1])
+
+    if splited_url[1] == "":
+        ctx['result']['url'] = splited_url[0]
+    else:
+        ctx['result']['url'] = splited_url[0] + '?' + splited_url[1]
+
     return True

--- a/searx/plugins/tracker_url_remover.py
+++ b/searx/plugins/tracker_url_remover.py
@@ -17,6 +17,7 @@ along with searx. If not, see < http://www.gnu.org/licenses/ >.
 
 from flask.ext.babel import gettext
 import re
+from urlparse import urlunparse
 
 regexes = {re.compile(r'utm_[^&]+&?'),
            re.compile(r'(wkey|wemail)[^&]+&?'),
@@ -28,17 +29,16 @@ default_on = True
 
 
 def on_result(request, ctx):
-    splited_url = ctx['result']['url'].split('?')
+    query = ctx['result']['parsed_url'].query
 
-    if len(splited_url) is not 2:
+    if query == "":
         return True
 
     for reg in regexes:
-        splited_url[1] = reg.sub('', splited_url[1])
+        query = reg.sub('', query)
 
-    if splited_url[1] == "":
-        ctx['result']['url'] = splited_url[0]
-    else:
-        ctx['result']['url'] = splited_url[0] + '?' + splited_url[1]
+    if query != ctx['result']['parsed_url'].query:
+        ctx['result']['parsed_url'] = ctx['result']['parsed_url']._replace(query=query)
+        ctx['result']['url'] = urlunparse(ctx['result']['parsed_url'])
 
     return True


### PR DESCRIPTION
Add a tiny plugin that remove the trackers arguments (like 'utm_*') in URLs returned after a search.

I was not able to test it with a real life test, because I couldn't find an example where a search engine would return such URLs.

First draft of #316 
