### PR TITLE
Add Image on opensearch

### DIFF
--- a/searx/templates/courgette/opensearch.xml
+++ b/searx/templates/courgette/opensearch.xml
@@ -3,6 +3,7 @@
   <ShortName>searx</ShortName>
   <Description>Search searx</Description>
   <InputEncoding>UTF-8</InputEncoding>
+  <Image>{{ host }}{{ url_for('static', filename='img/favicon.png') | replace("/", "", 1) }}</Image>
   <LongName>searx metasearch</LongName>
   {% if opensearch_method == 'get' %}
     <Url type="text/html" method="get" template="{{ host }}search?q={searchTerms}"/>

--- a/searx/templates/default/opensearch.xml
+++ b/searx/templates/default/opensearch.xml
@@ -3,6 +3,7 @@
   <ShortName>searx</ShortName>
   <Description>Search searx</Description>
   <InputEncoding>UTF-8</InputEncoding>
+  <Image>{{ host }}{{ url_for('static', filename='img/favicon.png') | replace("/", "", 1) }}</Image>
   <LongName>searx metasearch</LongName>
   {% if opensearch_method == 'get' %}
     <Url type="text/html" method="get" template="{{ host }}search?q={searchTerms}"/>

--- a/searx/templates/oscar/opensearch.xml
+++ b/searx/templates/oscar/opensearch.xml
@@ -3,6 +3,7 @@
   <ShortName>searx</ShortName>
   <Description>Search searx</Description>
   <InputEncoding>UTF-8</InputEncoding>
+  <Image>{{ host }}{{ url_for('static', filename='img/favicon.png') | replace("/", "", 1) }}</Image>
   <LongName>searx metasearch</LongName>
   {% if opensearch_method == 'get' %}
     <Url type="text/html" method="get" template="{{ host }}search?q={searchTerms}"/>


### PR DESCRIPTION
When you add Searx as search engine in your browser, you don't have the favicon in your search engines list.

This fixes this behavior by specifying Image in `opensearch.xml` (http://www.opensearch.org/Specifications/OpenSearch/1.1#The_.22Image.22_element).

I had to fix the URL with a `replace` filter, otherwise the URL looks like `http://example.org//static/themes/oscar/img/favicon.png` which is not correct. If someone has a better idea…
