### PR TITLE
ddg encoding of URLs to UTF-8

### DIFF
--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -72,7 +72,7 @@ def response(resp):
         # append result
         results.append({'title': title,
                         'content': content,
-                        'url': res_url})
+                        'url': res_url.encode('utf8')})
 
     # return results
     return results


### PR DESCRIPTION
Revealed when trying to pickle search results to disk.
