### PR TITLE
Result storage with access from the API in order to retrieve past results without calls to the underlying search engines

### DIFF
--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -72,7 +72,7 @@ def response(resp):
         # append result
         results.append({'title': title,
                         'content': content,
-                        'url': res_url})
+                        'url': res_url.encode('utf8')})
 
     # return results
     return results

--- a/searx/search.py
+++ b/searx/search.py
@@ -359,7 +359,8 @@ class Search(object):
 
         # set caching
         if self.request_data.get('c'):
-            self.cached = True
+            if self.request_data.get('c') == '1':
+                self.cached = True
         
         # set pagenumber
         pageno_param = self.request_data.get('pageno', '1')

--- a/searx/search.py
+++ b/searx/search.py
@@ -383,7 +383,7 @@ class Search(object):
             self.lang = query_obj.languages[-1]
 
         self.engines = query_obj.engines
-
+                
         self.categories = []
 
         # if engines are calculated from query,
@@ -487,7 +487,7 @@ class Search(object):
                 self.results = self.get_cached_results(self.query.encode('utf8'))
         if self.results:
             return self        
-            
+
         for selected_engine in self.engines:
             if selected_engine['name'] not in engines:
                 continue

--- a/searx/search.py
+++ b/searx/search.py
@@ -605,7 +605,12 @@ class Search(object):
                     .stats['score_count'] += result['score']
 
         # persist the results
-        self.store_results(self.query.encode('utf8'), self.results)
+        try:
+            sresults = int(request.cookies.get('store_results'))
+        except Exception:
+            sresults = settings['search']['store_results']
+        if sresults == 1:
+            self.store_results(self.query.encode('utf8'), self.results)
                 
         # return results, suggestions, answers and infoboxes
         return self

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -4,6 +4,7 @@ general:
 search:
     safe_search : 0 # Filter results. 0: None, 1: Moderate, 2: Strict
     autocomplete : "" # Existing autocomplete backends: "dbpedia", "duckduckgo", "google", "startpage", "wikipedia" - leave blank to turn it off by default
+    store_results: 1 # Stores queries and search results into local db
 
 server:
     port : 8888

--- a/searx/settings_robot.yml
+++ b/searx/settings_robot.yml
@@ -4,6 +4,7 @@ general:
 search:
     safe_search : 0
     autocomplete : 0
+    store_results: 1
 
 server:
     port : 11111

--- a/searx/templates/courgette/preferences.html
+++ b/searx/templates/courgette/preferences.html
@@ -70,6 +70,15 @@
         </p>
     </fieldset>
     <fieldset>
+        <legend>{{ _('Store Results') }}</legend>
+        <p>
+            <select name='store_results'>
+              <option value="1" {% if store_results == '1' %}selected="selected"{% endif %}>{{ _('Yes') }}</option>
+                <option value="0" {% if store_results == '0' %}selected="selected"{% endif %}>{{ _('No') }}</option>
+            </select>
+        </p>
+    </fieldset>
+    <fieldset>
         <legend>{{ _('Themes') }}</legend>
         <p>
             <select name="theme">

--- a/searx/templates/default/preferences.html
+++ b/searx/templates/default/preferences.html
@@ -71,6 +71,15 @@
         </p>
     </fieldset>
     <fieldset>
+        <legend>{{ _('Store Results') }}</legend>
+        <p>
+            <select name='store_results'>
+              <option value="1" {% if store_results == '1' %}selected="selected"{% endif %}>{{ _('Yes') }}</option>
+                <option value="0" {% if store_results == '0' %}selected="selected"{% endif %}>{{ _('No') }}</option>
+            </select>
+        </p>
+    </fieldset>
+    <fieldset>
         <legend>{{ _('Themes') }}</legend>
         <p>
         <select name="theme">

--- a/searx/templates/oscar/preferences.html
+++ b/searx/templates/oscar/preferences.html
@@ -101,6 +101,15 @@
                         </select>
                     {{ preferences_item_footer(safesearch_info, safesearch_label, rtl) }}
 
+                    {% set store_results_label = _('Store Results') %}
+                    {% set store_results_info = _('Filter content') %}
+                    {{ preferences_item_header(store_results_info, store_results_label, rtl) }}
+                        <select class="form-control" name='store_results'>
+                          <option value="1" {% if store_results == '1' %}selected="selected"{% endif %}>{{ _('Yes') }}</option>
+                          <option value="0" {% if store_results == '0' %}selected="selected"{% endif %}>{{ _('No') }}</option>
+                        </select>
+                    {{ preferences_item_footer(store_results_info, store_results_label, rtl) }}
+			
                     {% set theme_label = _('Themes') %}
                     {% set theme_info = _('Change searx layout') %}
                     {{ preferences_item_header(theme_info, theme_label, rtl) }}
@@ -142,12 +151,14 @@
 				    <th>{{ _("Engine name") }}</th>
 				    <th>{{ _("Shortcut") }}</th>
 				    <th>{{ _("SafeSearch") }}</th>
+				    <th>{{ _("Store results") }}</th>
 				    <th>{{ _("Avg. time") }}</th>
 				    <th>{{ _("Max time") }}</th>
                                     {% else %}
 				    <th>{{ _("Max time") }}</th>
 				    <th>{{ _("Avg. time") }}</th>
 				    <th>{{ _("SafeSearch") }}</th>
+				    <th>{{ _("Store results") }}</th>
 				    <th>{{ _("Shortcut") }}</th>
 				    <th>{{ _("Engine name") }}</th>
 				    <th>{{ _("Allow") }}</th>


### PR DESCRIPTION
This PR adds:
- Storage of search results when 'Storage Results in preferences tab is set and/or storage_results is 1 in settings.yml
- Retrieval of stored results when they exist, via the `c=1` parameter in URL from the command line

Technicals:
- storage uses Python [shelve](https://docs.python.org/2/library/shelve.html)
- when storage is activated, all queries and results are stored, without filter
- storage key is the query, so issuing query with different search engines will overwrite existing results in storage (i.e. results from different engines via multiple queries will _not_ be merged)

Usage:
- query 'test' from Web interface
- get stored results:

```
curl -XGET "http://localhost:8888/search?q=test&c=1&format=json"
```

Result should appear instantaneously.

Considerations
- This PR is primarily for my own use, aiming at sharing search results in a p2p net, there'll be no hard sentiment if it is rejected :)
- The storage of results obviously must be considered as a privacy leak (i.e. unless you're willing to share, which is not the issue here). In case this PR is of interest to some, there are some ways to mitigate the privacy issue, and they can be discussed here or elsewhere in subsequent additions.

Thanks for searx, this is a tremendously well executed piece of software, simple and easy to hack, which is why I doubly enjoy it :)
