### PR TITLE
Migrating Travis CI from legacy to container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 cache:
   - pip
   - npm
-  directories:
+  - directories:
     - $HOME/.cache/pip
 language: python
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+sudo: false
+cache:
+  - pip
+  - npm
 language: python
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false
 cache:
   - pip
   - npm
+  directories:
+    - $HOME/.cache/pip
 language: python
 python:
   - "2.7"


### PR DESCRIPTION
Documentation about this changes:
- http://docs.travis-ci.com/user/migrating-from-legacy/
- http://docs.travis-ci.com/user/caching/

If all is working correctly, searx should be build faster on the container-based infrastructure. Probably we also fixed the partial build errors while installing the packages, because they are now cached (and not downloaded every time)
