### PR TITLE
Don't throw away the request if pageno is wrong

### DIFF
--- a/searx/search.py
+++ b/searx/search.py
@@ -358,7 +358,7 @@ class Search(object):
         # set pagenumber
         pageno_param = self.request_data.get('pageno', '1')
         if not pageno_param.isdigit() or int(pageno_param) < 1:
-            raise Exception('wrong pagenumber')
+            pageno_param = 1
 
         self.pageno = int(pageno_param)
 


### PR DESCRIPTION
Fix #424 but only partially.

When there is an error in the pageno arg, previously, we throwed away the request, and sended the user to index. Now, it'll only send the user to the first page of the result.
It will still send the user to the index.html page when there is no request. It's a stop gap since the real solution would be in the next paragraph :

An error manager should be implemented sometimes, to allow us to display error messages to the user, in all the formats that he could use (json, xml, html...), to solve completly #424.
