### PR TITLE
[enh] measure response time with more details.

### DIFF
--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -19,8 +19,6 @@ along with searx. If not, see < http://www.gnu.org/licenses/ >.
 from os.path import realpath, dirname, splitext, join
 import sys
 from imp import load_source
-from flask.ext.babel import gettext
-from operator import itemgetter
 from searx import settings
 from searx import logger
 
@@ -92,14 +90,6 @@ def load_engine(engine_data):
                          .format(engine.name, engine_attr))
             sys.exit(1)
 
-    engine.stats = {
-        'result_count': 0,
-        'search_count': 0,
-        'page_load_time': 0,
-        'score_count': 0,
-        'errors': 0
-    }
-
     if hasattr(engine, 'categories'):
         for category_name in engine.categories:
             categories.setdefault(category_name, []).append(engine)
@@ -113,95 +103,6 @@ def load_engine(engine_data):
             sys.exit(1)
         engine_shortcuts[engine.shortcut] = engine.name
     return engine
-
-
-def get_engines_stats():
-    # TODO refactor
-    pageloads = []
-    results = []
-    scores = []
-    errors = []
-    scores_per_result = []
-
-    max_pageload = max_results = max_score = max_errors = max_score_per_result = 0  # noqa
-    for engine in engines.values():
-        if engine.stats['search_count'] == 0:
-            continue
-        results_num = \
-            engine.stats['result_count'] / float(engine.stats['search_count'])
-        load_times = engine.stats['page_load_time'] / float(engine.stats['search_count'])  # noqa
-        if results_num:
-            score = engine.stats['score_count'] / float(engine.stats['search_count'])  # noqa
-            score_per_result = score / results_num
-        else:
-            score = score_per_result = 0.0
-        max_results = max(results_num, max_results)
-        max_pageload = max(load_times, max_pageload)
-        max_score = max(score, max_score)
-        max_score_per_result = max(score_per_result, max_score_per_result)
-        max_errors = max(max_errors, engine.stats['errors'])
-        pageloads.append({'avg': load_times, 'name': engine.name})
-        results.append({'avg': results_num, 'name': engine.name})
-        scores.append({'avg': score, 'name': engine.name})
-        errors.append({'avg': engine.stats['errors'], 'name': engine.name})
-        scores_per_result.append({
-            'avg': score_per_result,
-            'name': engine.name
-        })
-
-    for engine in pageloads:
-        if max_pageload:
-            engine['percentage'] = int(engine['avg'] / max_pageload * 100)
-        else:
-            engine['percentage'] = 0
-
-    for engine in results:
-        if max_results:
-            engine['percentage'] = int(engine['avg'] / max_results * 100)
-        else:
-            engine['percentage'] = 0
-
-    for engine in scores:
-        if max_score:
-            engine['percentage'] = int(engine['avg'] / max_score * 100)
-        else:
-            engine['percentage'] = 0
-
-    for engine in scores_per_result:
-        if max_score_per_result:
-            engine['percentage'] = int(engine['avg']
-                                       / max_score_per_result * 100)
-        else:
-            engine['percentage'] = 0
-
-    for engine in errors:
-        if max_errors:
-            engine['percentage'] = int(float(engine['avg']) / max_errors * 100)
-        else:
-            engine['percentage'] = 0
-
-    return [
-        (
-            gettext('Page loads (sec)'),
-            sorted(pageloads, key=itemgetter('avg'))
-        ),
-        (
-            gettext('Number of results'),
-            sorted(results, key=itemgetter('avg'), reverse=True)
-        ),
-        (
-            gettext('Scores'),
-            sorted(scores, key=itemgetter('avg'), reverse=True)
-        ),
-        (
-            gettext('Scores per result'),
-            sorted(scores_per_result, key=itemgetter('avg'), reverse=True)
-        ),
-        (
-            gettext('Errors'),
-            sorted(errors, key=itemgetter('avg'), reverse=True)
-        ),
-    ]
 
 
 if 'engines' not in settings or not settings['engines']:

--- a/searx/metrology/__init__.py
+++ b/searx/metrology/__init__.py
@@ -1,0 +1,81 @@
+'''
+searx is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+searx is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with searx. If not, see < http://www.gnu.org/licenses/ >.
+
+(C) 2015- by Alexandre Flament, <alex@al-f.net>
+'''
+import threading
+import implementation
+from time import time
+
+__all__ = ["implementation",
+           "initialize",
+           "measure_storage", "record", "measure", "start_timer", "end_timer", "configure_measure",
+           "counter_storage", "counter", "counter_inc", "counter_add", "reset_counter"]
+
+measure_storage = implementation.MeasureStorage()
+counter_storage = implementation.CounterStorage()
+
+threadlocal_dict = threading.local()
+threadlocal_dict.timers = {}
+timers = threadlocal_dict.timers
+
+
+def record(value, *args):
+    global measure_storage
+    measure_storage.get(*args).record(value)
+
+
+def counter_inc(*args):
+    global counter_storage
+    counter_storage.add(1, *args)
+
+
+def counter_add(value, *args):
+    global counter_storage
+    counter_storage.add(value, *args)
+
+
+def start_timer(*args):
+    global timers
+    timers[args] = time()
+
+
+def end_timer(*args):
+    global timers
+    if args in timers:
+        previous_time = timers[args]
+        if previous_time is not None:
+            timers[args] = None
+            duration = time() - previous_time
+            record(duration, *args)
+
+
+def measure(*args):
+    global measure_storage
+    return measure_storage.get(*args)
+
+
+def counter(*args):
+    global counter_storage
+    return counter_storage.get(*args)
+
+
+def configure_measure(width, size, *args):
+    global measure_storage
+    return measure_storage.configure(width, size, *args)
+
+
+def reset_counter(*args):
+    global counter_storage
+    return counter_storage.reset(*args)

--- a/searx/metrology/implementation.py
+++ b/searx/metrology/implementation.py
@@ -1,0 +1,127 @@
+from __future__ import division, with_statement
+from searx import logger
+import threading
+
+__all__ = ["Measure", "MeasureStorage", "CounterStorage"]
+
+logger = logger.getChild('metrology')
+
+
+class Measure(object):
+
+    def __init__(self, width=10, size=200):
+        self.lock = threading.RLock()
+        self.quartiles = [0] * size
+        self.count = 0
+        self.width = width
+        self.size = size
+        self.sum = long(0)
+
+    def record(self, value):
+        with self.lock:
+            q = int(value / self.width)
+            if q < 0:
+                '''FIXME ? Ignore value below zero'''
+                return
+            if q >= self.size:
+                q = self.size - 1
+            self.quartiles[q] += 1
+            self.count += 1
+            self.sum += value
+
+    def get_count(self):
+        return self.count
+
+    def get_sum(self):
+        return self.sum
+
+    def get_average(self):
+        with self.lock:
+            if self.count != 0:
+                return self.sum / self.count
+            else:
+                return 0
+
+    def get_quartile(self):
+        return self.quartiles
+
+    def get_qp(self):
+        ''' Quartile in percentage '''
+        with self.lock:
+            if self.count > 0:
+                return [int(q*100/self.count) for q in self.quartiles]
+            else:
+                return self.quartiles
+
+    def get_qpmap(self):
+        result = {}
+        x = 0
+        with self.lock:
+            if self.count > 0:
+                for y in self.quartiles:
+                    yp = int(y*100/self.count)
+                    if yp != 0:
+                        result[x] = yp
+                    x += self.width
+        return result
+
+    def __repr__(self):
+        return "Measure<avg: " + str(self.get_average()) + ", count: " + str(self.get_count()) + ">"
+
+
+class MeasureStorage(object):
+
+    def __init__(self):
+        self.measures = {}
+        self.lock = threading.RLock()
+
+    def configure(self, width, size, *args):
+        with self.lock:
+            measure = Measure(width, size)
+            self.measures[args] = measure
+        return measure
+
+    def get(self, *args):
+        measure = self.measures.get(args, None)
+        if measure is None:
+            with self.lock:
+                measure = self.measures.get(args, None)
+                if measure is None:
+                    measure = Measure()
+                    self.measures[args] = measure
+        return measure
+
+    def dump(self):
+        ks = None
+        with self.lock:
+            ks = sorted(self.measures.keys(), key=lambda k: '/'.join(k))
+        logger.debug("Measures:")
+        for k in ks:
+            logger.debug("- %-60s %s", '|'.join(k), self.measures[k])
+
+
+class CounterStorage(object):
+
+    def __init__(self):
+        self.counters = {}
+        self.lock = threading.RLock()
+
+    def reset(self, *args):
+        with self.lock:
+            self.counters[args] = 0
+
+    def get(self, *args):
+        # logger.debug("Counter for {0} : {1}".format(args, self.counters.get(args, 0)))
+        return self.counters.get(args, 0)
+
+    def add(self, value, *args):
+        with self.lock:
+            self.counters[args] = value + self.counters.get(args, long(0))
+            # logger.debug("Counter for {0} : {1}".format(args, self.counters[args]))
+
+    def dump(self):
+        with self.lock:
+            ks = sorted(self.counters.keys(), key=lambda k: '/'.join(k))
+        logger.debug("Counters:")
+        for k in ks:
+            logger.debug("- %-60s %s", '|'.join(k), self.counters[k])

--- a/searx/metrology/specific.py
+++ b/searx/metrology/specific.py
@@ -37,15 +37,15 @@ def initialize():
         # time for the HTTP(S) request
         metrology.configure_measure(0.1, 30, engine, 'time', 'search')
         # time for calling the callback function "response"
-        # call everytime, even if the callback hasn't really call 
+        # call everytime, even if the callback hasn't really call
         # to keep the call count synchronize with <engine>, time, search
         metrology.configure_measure(0.1, 30, engine, 'time', 'callback')
         # time to append the results
-        # call everytime, even if the callback hasn't really call 
+        # call everytime, even if the callback hasn't really call
         # to keep the call count synchronize with <engine>, time, search
         metrology.configure_measure(0.1, 30, engine, 'time', 'append')
         # global time (request, search, callback, append)
-        # call everytime, even if the callback hasn't really call 
+        # call everytime, even if the callback hasn't really call
         # to keep the call count synchronize with <engine>, time, search
         metrology.configure_measure(0.1, 30, engine, 'time', 'total')
         # bandwidth usage (from searx to outside), update for each HTTP request

--- a/searx/metrology/specific.py
+++ b/searx/metrology/specific.py
@@ -1,0 +1,165 @@
+'''
+searx is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+searx is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with searx. If not, see < http://www.gnu.org/licenses/ >.
+
+(C) 2015- by Alexandre Flament, <alex@al-f.net>
+'''
+
+from operator import itemgetter
+from flask.ext.babel import gettext
+from searx.engines import engines
+import searx.metrology as metrology
+
+
+def initialize():
+    # initialize metrology
+    # response time of a search (everything)
+    metrology.configure_measure(0.1, 30, 'search', 'time')
+    # response time of a search, without rendering
+    metrology.configure_measure(0.1, 30, 'search', 'time', 'search')
+    # response time of a search, only rendering
+    metrology.configure_measure(0.1, 30, 'search', 'time', 'render')
+    for engine in engines:
+        # result count per requests
+        metrology.configure_measure(1, 100, engine, 'result', 'count')
+        # time for calling the "request" function
+        metrology.configure_measure(0.1, 30, engine, 'time', 'request')
+        # time for the HTTP(S) request
+        metrology.configure_measure(0.1, 30, engine, 'time', 'search')
+        # time for calling the callback function "response"
+        # call everytime, even if the callback hasn't really call 
+        # to keep the call count synchronize with <engine>, time, search
+        metrology.configure_measure(0.1, 30, engine, 'time', 'callback')
+        # time to append the results
+        # call everytime, even if the callback hasn't really call 
+        # to keep the call count synchronize with <engine>, time, search
+        metrology.configure_measure(0.1, 30, engine, 'time', 'append')
+        # global time (request, search, callback, append)
+        # call everytime, even if the callback hasn't really call 
+        # to keep the call count synchronize with <engine>, time, search
+        metrology.configure_measure(0.1, 30, engine, 'time', 'total')
+        # bandwidth usage (from searx to outside), update for each HTTP request
+        # warning : not used
+        metrology.configure_measure(1024, 300, engine, 'bandwidth', 'up')
+        # bandwidth usage (from outside to searx), uddate for each HTTP request
+        # warning : only the bytes from the main requests,
+        # an engine can make several HTTP requests per user request
+        metrology.configure_measure(1024, 300, engine, 'bandwidth', 'down')
+        # score of the engine
+        metrology.reset_counter(engine, 'score')
+        # count the number of timeout
+        metrology.reset_counter(engine, 'error', 'timeout')
+        # count the number of requests lib errors
+        metrology.reset_counter(engine, 'error', 'requests')
+        # count the other errors
+        metrology.reset_counter(engine, 'error', 'other')
+        # global counter of errors
+        metrology.reset_counter(engine, 'error')
+
+
+def get_engines_stats():
+    # TODO refactor
+    pageloads = []
+    results = []
+    scores = []
+    errors = []
+    scores_per_result = []
+
+    max_pageload = max_results = max_score = max_errors = max_score_per_result = 0  # noqa
+
+    for engine in engines.values():
+        error_count = metrology.counter(engine.name, 'error')
+        if error_count > 0:
+            max_errors = max(max_errors, error_count)
+            errors.append({'avg': error_count, 'name': engine.name})
+
+    for engine in engines.values():
+        m_result_count = metrology.measure(engine.name, 'result', 'count')
+        if m_result_count.get_count() == 0:
+            continue
+        m_time_total = metrology.measure(engine.name, 'time', 'total')
+        score_count = metrology.counter(engine.name, 'score')
+
+        result_count_avg = m_result_count.get_average()
+        search_count = m_result_count.get_count()
+        time_total_avg = m_time_total.get_average()  # noqa
+        if search_count > 0 and result_count_avg > 0:
+            score = score_count / float(search_count)  # noqa
+            score_per_result = score / result_count_avg
+        else:
+            score = score_per_result = 0.0
+        max_results = max(result_count_avg, max_results)
+        max_pageload = max(time_total_avg, max_pageload)
+        max_score = max(score, max_score)
+        max_score_per_result = max(score_per_result, max_score_per_result)
+        pageloads.append({'avg': time_total_avg, 'name': engine.name})
+        results.append({'avg': result_count_avg, 'name': engine.name})
+        scores.append({'avg': score, 'name': engine.name})
+        scores_per_result.append({
+            'avg': score_per_result,
+            'name': engine.name
+        })
+
+    for engine in pageloads:
+        if max_pageload:
+            engine['percentage'] = int(engine['avg'] / max_pageload * 100)
+        else:
+            engine['percentage'] = 0
+
+    for engine in results:
+        if max_results:
+            engine['percentage'] = int(engine['avg'] / max_results * 100)
+        else:
+            engine['percentage'] = 0
+
+    for engine in scores:
+        if max_score:
+            engine['percentage'] = int(engine['avg'] / max_score * 100)
+        else:
+            engine['percentage'] = 0
+
+    for engine in scores_per_result:
+        if max_score_per_result:
+            engine['percentage'] = int(engine['avg']
+                                       / max_score_per_result * 100)
+        else:
+            engine['percentage'] = 0
+
+    for engine in errors:
+        if max_errors:
+            engine['percentage'] = int(float(engine['avg']) / max_errors * 100)
+        else:
+            engine['percentage'] = 0
+
+    return [
+        (
+            gettext('Page loads (sec)'),
+            sorted(pageloads, key=itemgetter('avg'))
+        ),
+        (
+            gettext('Number of results'),
+            sorted(results, key=itemgetter('avg'), reverse=True)
+        ),
+        (
+            gettext('Scores'),
+            sorted(scores, key=itemgetter('avg'), reverse=True)
+        ),
+        (
+            gettext('Scores per result'),
+            sorted(scores_per_result, key=itemgetter('avg'), reverse=True)
+        ),
+        (
+            gettext('Errors'),
+            sorted(errors, key=itemgetter('avg'), reverse=True)
+        ),
+    ]

--- a/searx/results.py
+++ b/searx/results.py
@@ -1,4 +1,5 @@
 import re
+import searx.metrology as metrology
 from collections import defaultdict
 from operator import itemgetter
 from threading import RLock
@@ -106,9 +107,7 @@ class ResultContainer(object):
                 self._merge_infobox(result)
                 results.remove(result)
 
-        with RLock():
-            engines[engine_name].stats['search_count'] += 1
-            engines[engine_name].stats['result_count'] += len(results)
+        metrology.record(len(results), engine_name, 'result', 'count')
 
         if not results:
             return
@@ -186,9 +185,8 @@ class ResultContainer(object):
         for result in self._merged_results:
             score = result_score(result)
             result['score'] = score
-            with RLock():
-                for result_engine in result['engines']:
-                    engines[result_engine].stats['score_count'] += score
+            for result_engine in result['engines']:
+                metrology.counter_add(result['score'], result['engine'], 'score')
 
         results = sorted(self._merged_results, key=itemgetter('score'), reverse=True)
 


### PR DESCRIPTION
First step to fix #162
The shown statistics are the same, except in memory there is a lot more information.
The second steps would be to re-implements UI. See https://github.com/dalf/searx/tree/metrology

Notes : 
- there is no tests
- the stats  are per unix process, so if there more than one as uwsgi does, it won't be accurate ( #199 ). The current implementation has already this issue.
- the idea of implementation.py is to add a redis / sql / whatever backend later. This would fix the previous note, except we have to take into account the speed. One idea : recording a measure only records an action to do later. A dedicate thread reads all these actions and executes them. Note : two unix processes equals two dedicated threads to record measures.  
