### PR TITLE
Fix 'set' object does not support indexing

### DIFF
--- a/searx/preferences.py
+++ b/searx/preferences.py
@@ -181,7 +181,7 @@ class EnginesSetting(SwitchableSetting):
         return [item[len('engine_'):].replace('_', ' ').replace('  ', '__') for item in items]
 
     def transform_values(self, values):
-        if len(values) == 1 and values[0] == '':
+        if len(values) == 1 and next(iter(values)) == '':
             return list()
         transformed_values = []
         for value in values:


### PR DESCRIPTION
This PR is for fixing `'set' object does not support indexing`

And this error could be reproduced by following command:

``` sh
$ ~/ curl 'http://localhost:8888/' -H 'Pragma: no-cache' -H 'DNT: 1' -H 'Accept-Encoding: gzip, deflate, sdch' -H 'Accept-Language: zh-TW,zh;q=0.8,en-US;q=0.6,en;q=0.4' -H 'Upgrade-Insecure-Requests: 1' -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.94 Safari/537.36' -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8' -H 'Cache-Control: no-cache' -H 'Cookie: autocomplete=google; safesearch=0; theme=pix-art; language=zh_TW; locale=en; image_proxy=; categories=; method=POST; disabled_engines=google__general; enabled_engines="reddit__social media\054google play apps__files\054piratebay__videos\054reddit__news\054fdroid__files\054google play music__music\054yandex__general\054reddit__general\054geektimes__it\054google play movies__videos\0541x__images\054piratebay__files\054piratebay__music\054reddit__images\054erowid__general\054nyaa__images\054habrahabr__it\054bitbucket__it\054frinkiac__images\054tokyotoshokan__music\054nyaa__videos\054nyaa__music\054ixquick__general\054qwant__general\054nyaa__files\054tokyotoshokan__videos\054tokyotoshokan__files\054swisscows__images\054gigablast__general\054searchcode code__it\054swisscows__general\054gitlab__it\054startpage__general\054ddg definitions__general"; disabled_plugins=; enabled_plugins="Vim-like_hotkeys\054Open_result_links_on_new_browser_tabs"' -H 'Connection: keep-alive' --compressed
```

You will get:

```
ERROR:__main__:Exception on / [GET]
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/lib/python2.7/site-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/lib/python2.7/site-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/lib/python2.7/site-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/lib/python2.7/site-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "searx/webapp.py", line 367, in index
    'index.html',
  File "searx/webapp.py", line 260, in render
    disabled_engines = request.preferences.engines.get_disabled()
  File "/usr/local/searx/searx/preferences.py", line 158, in get_disabled
    return self.transform_values(disabled)
  File "/usr/local/searx/searx/preferences.py", line 184, in transform_values
    if len(values) == 1 and values[0] == '':
TypeError: 'set' object does not support indexing
```
