### PR TITLE
Quote variables and backticks in manage.sh

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-BASE_DIR=$(dirname `readlink -f $0`)
+BASE_DIR=$(dirname "`readlink -f "$0"`")
 PYTHONPATH=$BASE_DIR
 SEARX_DIR="$BASE_DIR/searx"
 ACTION=$1


### PR DESCRIPTION
Otherwise the script fails with spaces or asterisks in the directory path.
