### PR TITLE
use https instead of ssh with git-clone

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Installation
 ~~~~~~~~~~~~
 
 -  clone source:
-   ``git clone git@github.com:asciimoo/searx.git && cd searx``
+   ``git clone https://github.com/asciimoo/searx.git && cd searx``
 -  install dependencies: ``./manage.sh update_packages``
 -  edit your
    `settings.yml <https://github.com/asciimoo/searx/blob/master/searx/settings.yml>`__


### PR DESCRIPTION
I tried to follow the installation instructions on an anonymous machine, and noticed that it uses ssh to clone the repository:

``` bash
git clone git@github.com:asciimoo/searx.git
```

This gave me the following error:

``` bash
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

That's why I think that using `https` instead of `ssh` is better as a general clone instruction.
