### PR TITLE
uncapitalize searx in templates

### DIFF
--- a/searx/templates/courgette/about.html
+++ b/searx/templates/courgette/about.html
@@ -6,20 +6,20 @@
 
     <p>Searx is a <a href="https://en.wikipedia.org/wiki/Metasearch_engine">metasearch engine</a>, aggregating the results of other <a href="{{ url_for('preferences') }}">search engines</a> while not storing information about its users.
     </p>
-    <h2>Why use Searx?</h2>
+    <h2>Why use searx?</h2>
     <ul>
-        <li>Searx may not offer you as personalised results as Google, but it doesn't generate a profile about you</li>
-        <li>Searx doesn't care about what you search for, never shares anything with a third party, and it can't be used to compromise you</li>
-        <li>Searx is free software, the code is 100% open and you can help to make it better. See more on <a href="https://github.com/asciimoo/searx">github</a></li>
+        <li>searx may not offer you as personalised results as Google, but it doesn't generate a profile about you</li>
+        <li>searx doesn't care about what you search for, never shares anything with a third party, and it can't be used to compromise you</li>
+        <li>searx is free software, the code is 100% open and you can help to make it better. See more on <a href="https://github.com/asciimoo/searx">github</a></li>
     </ul>
     <p>If you do care about privacy, want to be a conscious user, or otherwise believe
-    in digital freedom, make Searx your default search engine or run it on your own server</p>
+    in digital freedom, make searx your default search engine or run it on your own server</p>
 
 <h2>Technical details - How does it work?</h2>
 
 <p>Searx is a <a href="https://en.wikipedia.org/wiki/Metasearch_engine">metasearch engine</a>,
 inspired by the <a href="http://seeks-project.info/">seeks project</a>.<br />
-It provides basic privacy by mixing your queries with searches on other platforms without storing search data. Queries are made using a POST request on every browser (except chrome*). Therefore they show up in neither our logs, nor your url history. In case of Chrome* users there is an exception, Searx uses the search bar to perform GET requests.<br />
+It provides basic privacy by mixing your queries with searches on other platforms without storing search data. Queries are made using a POST request on every browser (except chrome*). Therefore they show up in neither our logs, nor your url history. In case of Chrome* users there is an exception, searx uses the search bar to perform GET requests.<br />
 Searx can be added to your browser's search bar; moreover, it can be set as the default search engine.
 </p>
 

--- a/searx/templates/courgette/base.html
+++ b/searx/templates/courgette/base.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"{% if rtl %} dir="rtl"{% endif %}>
     <head>
         <meta charset="UTF-8" />
-        <meta name="description" content="Searx - a privacy-respecting, hackable metasearch engine" />
+        <meta name="description" content="searx - a privacy-respecting, hackable metasearch engine" />
         <meta name="keywords" content="searx, search, search engine, metasearch, meta search" />
         <meta name="generator" content="searx/{{ searx_version }}">
         <meta name="referrer" content="no-referrer">

--- a/searx/templates/default/about.html
+++ b/searx/templates/default/about.html
@@ -6,20 +6,20 @@
 
     <p>Searx is a <a href="https://en.wikipedia.org/wiki/Metasearch_engine">metasearch engine</a>, aggregating the results of other <a href="{{ url_for('preferences') }}">search engines</a> while not storing information about its users.
     </p>
-    <h2>Why use Searx?</h2>
+    <h2>Why use searx?</h2>
     <ul>
-        <li>Searx may not offer you as personalised results as Google, but it doesn't generate a profile about you</li>
-        <li>Searx doesn't care about what you search for, never shares anything with a third party, and it can't be used to compromise you</li>
-        <li>Searx is free software, the code is 100% open and you can help to make it better. See more on <a href="https://github.com/asciimoo/searx">github</a></li>
+        <li>searx may not offer you as personalised results as Google, but it doesn't generate a profile about you</li>
+        <li>searx doesn't care about what you search for, never shares anything with a third party, and it can't be used to compromise you</li>
+        <li>searx is free software, the code is 100% open and you can help to make it better. See more on <a href="https://github.com/asciimoo/searx">github</a></li>
     </ul>
     <p>If you do care about privacy, want to be a conscious user, or otherwise believe
-    in digital freedom, make Searx your default search engine or run it on your own server</p>
+    in digital freedom, make searx your default search engine or run it on your own server</p>
 
 <h2>Technical details - How does it work?</h2>
 
 <p>Searx is a <a href="https://en.wikipedia.org/wiki/Metasearch_engine">metasearch engine</a>,
 inspired by the <a href="http://seeks-project.info/">seeks project</a>.<br />
-It provides basic privacy by mixing your queries with searches on other platforms without storing search data. Queries are made using a POST request on every browser (except chrome*). Therefore they show up in neither our logs, nor your url history. In case of Chrome* users there is an exception, if Searx used from the search bar it performs GET requests.<br />
+It provides basic privacy by mixing your queries with searches on other platforms without storing search data. Queries are made using a POST request on every browser (except chrome*). Therefore they show up in neither our logs, nor your url history. In case of Chrome* users there is an exception, if searx used from the search bar it performs GET requests.<br />
 Searx can be added to your browser's search bar; moreover, it can be set as the default search engine.
 </p>
 

--- a/searx/templates/default/base.html
+++ b/searx/templates/default/base.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"{% if rtl %} dir="rtl"{% endif %}>
     <head>
         <meta charset="UTF-8" />
-        <meta name="description" content="Searx - a privacy-respecting, hackable metasearch engine" />
+        <meta name="description" content="searx - a privacy-respecting, hackable metasearch engine" />
         <meta name="keywords" content="searx, search, search engine, metasearch, meta search" />
         <meta name="generator" content="searx/{{ searx_version }}">
         <meta name="referrer" content="no-referrer">

--- a/searx/templates/oscar/about.html
+++ b/searx/templates/oscar/about.html
@@ -7,20 +7,20 @@
 
     <p>Searx is a <a href="https://en.wikipedia.org/wiki/Metasearch_engine">metasearch engine</a>, aggregating the results of other <a href="{{ url_for('preferences') }}">search engines</a> while not storing information about its users.
     </p>
-    <h2>Why use Searx?</h2>
+    <h2>Why use searx?</h2>
     <ul>
-        <li>Searx may not offer you as personalised results as Google, but it doesn't generate a profile about you</li>
-        <li>Searx doesn't care about what you search for, never shares anything with a third party, and it can't be used to compromise you</li>
-        <li>Searx is free software, the code is 100% open and you can help to make it better. See more on <a href="https://github.com/asciimoo/searx">github</a></li>
+        <li>searx may not offer you as personalised results as Google, but it doesn't generate a profile about you</li>
+        <li>searx doesn't care about what you search for, never shares anything with a third party, and it can't be used to compromise you</li>
+        <li>searx is free software, the code is 100% open and you can help to make it better. See more on <a href="https://github.com/asciimoo/searx">github</a></li>
     </ul>
     <p>If you do care about privacy, want to be a conscious user, or otherwise believe
-    in digital freedom, make Searx your default search engine or run it on your own server</p>
+    in digital freedom, make searx your default search engine or run it on your own server</p>
 
 <h2>Technical details - How does it work?</h2>
 
 <p>Searx is a <a href="https://en.wikipedia.org/wiki/Metasearch_engine">metasearch engine</a>,
 inspired by the <a href="http://seeks-project.info/">seeks project</a>.<br />
-It provides basic privacy by mixing your queries with searches on other platforms without storing search data. Queries are made using a POST request on every browser (except chrome*). Therefore they show up in neither our logs, nor your url history. In case of Chrome* users there is an exception, Searx uses the search bar to perform GET requests.<br />
+It provides basic privacy by mixing your queries with searches on other platforms without storing search data. Queries are made using a POST request on every browser (except chrome*). Therefore they show up in neither our logs, nor your url history. In case of Chrome* users there is an exception, searx uses the search bar to perform GET requests.<br />
 Searx can be added to your browser's search bar; moreover, it can be set as the default search engine.
 </p>
 

--- a/searx/templates/oscar/base.html
+++ b/searx/templates/oscar/base.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"{% if rtl %} dir="rtl"{% endif %}>
 <head>
     <meta charset="UTF-8" />
-    <meta name="description" content="Searx - a privacy-respecting, hackable metasearch engine" />
+    <meta name="description" content="searx - a privacy-respecting, hackable metasearch engine" />
     <meta name="keywords" content="searx, search, search engine, metasearch, meta search" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="generator" content="searx/{{ searx_version }}">

--- a/searx/templates/pix-art/about.html
+++ b/searx/templates/pix-art/about.html
@@ -5,20 +5,20 @@
 
     <p>Searx is a <a href="https://en.wikipedia.org/wiki/Metasearch_engine">metasearch engine</a>, aggregating the results of other <a href="{{ url_for('preferences') }}">search engines</a> while not storing information about its users.
     </p>
-    <h2>Why use Searx?</h2>
+    <h2>Why use searx?</h2>
     <ul>
-        <li>Searx may not offer you as personalised results as Google, but it doesn't generate a profile about you</li>
-        <li>Searx doesn't care about what you search for, never shares anything with a third party, and it can't be used to compromise you</li>
-        <li>Searx is free software, the code is 100% open and you can help to make it better. See more on <a href="https://github.com/asciimoo/searx">github</a></li>
+        <li>searx may not offer you as personalised results as Google, but it doesn't generate a profile about you</li>
+        <li>searx doesn't care about what you search for, never shares anything with a third party, and it can't be used to compromise you</li>
+        <li>searx is free software, the code is 100% open and you can help to make it better. See more on <a href="https://github.com/asciimoo/searx">github</a></li>
     </ul>
     <p>If you do care about privacy, want to be a conscious user, or otherwise believe
-    in digital freedom, make Searx your default search engine or run it on your own server</p>
+    in digital freedom, make searx your default search engine or run it on your own server</p>
 
 <h2>Technical details - How does it work?</h2>
 
 <p>Searx is a <a href="https://en.wikipedia.org/wiki/Metasearch_engine">metasearch engine</a>,
 inspired by the <a href="http://seeks-project.info/">seeks project</a>.<br />
-It provides basic privacy by mixing your queries with searches on other platforms without storing search data. Queries are made using a POST request on every browser (except chrome*). Therefore they show up in neither our logs, nor your url history. In case of Chrome* users there is an exception, if Searx used from the search bar it performs GET requests.<br />
+It provides basic privacy by mixing your queries with searches on other platforms without storing search data. Queries are made using a POST request on every browser (except chrome*). Therefore they show up in neither our logs, nor your url history. In case of Chrome* users there is an exception, if searx used from the search bar it performs GET requests.<br />
 Searx can be added to your browser's search bar; moreover, it can be set as the default search engine.
 </p>
 

--- a/searx/templates/pix-art/base.html
+++ b/searx/templates/pix-art/base.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"{% if rtl %} dir="rtl"{% endif %}>
     <head>
         <meta charset="UTF-8" />
-        <meta name="description" content="Searx - a privacy-respecting, hackable metasearch engine" />
+        <meta name="description" content="searx - a privacy-respecting, hackable metasearch engine" />
         <meta name="keywords" content="searx, search, search engine, metasearch, meta search" />
         <meta name="generator" content="searx/{{ searx_version }}">
         <meta name="referrer" content="no-referrer">

--- a/searx/templates/pix-art/index.html
+++ b/searx/templates/pix-art/index.html
@@ -1,7 +1,7 @@
 {% extends "pix-art/base.html" %}
 {% block content %}
 <div class="center">
-    <div class="title"><h1><img src="{{ url_for('static', filename='img/searx-pixel.png') }}" alt="Searx Logo"/></h1></div>
+    <div class="title"><h1><img src="{{ url_for('static', filename='img/searx-pixel.png') }}" alt="searx Logo"/></h1></div>
     {% include 'pix-art/search.html' %}
     <p class="top_margin">
         <a href="{{ url_for('about') }}" class="hmarg">{{ _('about') }}</a>

--- a/searx/templates/pix-art/results.html
+++ b/searx/templates/pix-art/results.html
@@ -8,7 +8,7 @@
 {% block title %}{{ q }} - {% endblock %}
 {% block meta %}{% endblock %}
 {% block content %}
-<div id="logo"><a href="./"><img src="{{ url_for('static', filename='img/searx-pixel-small.png') }}" alt="Searx Logo"/></a></div>
+<div id="logo"><a href="./"><img src="{{ url_for('static', filename='img/searx-pixel-small.png') }}" alt="searx Logo"/></a></div>
 <div class="preferences_container right"><a href="{{ url_for('preferences') }}" id="preferences"><span>preferences</span></a></div>
 <div class="small search center">
     {% include 'pix-art/search.html' %}

--- a/tests/robot/test_basic.robot
+++ b/tests/robot/test_basic.robot
@@ -11,7 +11,7 @@ Front page
 
 About page
     Click Element  link=about
-    Page Should Contain  Why use Searx?
+    Page Should Contain  Why use searx?
     Page Should Contain Element  link=search engines
 
 Preferences page


### PR DESCRIPTION
The name of this searx engine is uncapitalized **searx**. However, it is not consistent in the templates. So it can be confusing. I replaced the occurences of "Searx" to "searx" in sentences for the sake of consistency.
