### PR TITLE
deusu.de support via xpath

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -103,6 +103,18 @@ engines:
     engine : deezer
     shortcut : dz
 
+  - name : deusu
+    engine : xpath
+    paging : True
+    first_page_num : 1
+    page_size : 10
+    search_url : https://deusu.de/query?q={query}&startwith={pageno}1
+    url_xpath : //div[@class="result"]/a/@href
+    title_xpath : //div[@class="result"]/a
+    content_xpath : //div[@class="result"]/span[@class="result_snippet"]
+    categories : general
+    shortcut : ds
+
   - name : deviantart
     engine : deviantart
     shortcut : da


### PR DESCRIPTION
https://deusu.de is a free search engine. Found it from here: 

http://www.heise.de/forum/heise-online/News-Kommentare/Meta-Suchmaschine-MetaGer-setzt-auf-Open-Source/DeuSu-de-macht-das-schon-seit-Jahren/posting-29054518/show/

Source:

https://github.com/MichaelSchoebel/DeuSu

Done via xpath though there may be more elegant ways to bind.
