### PR TITLE
Self information on later pages

### DIFF
--- a/searx/plugins/self_info.py
+++ b/searx/plugins/self_info.py
@@ -29,6 +29,8 @@ p = re.compile('.*user[ -]agent.*', re.IGNORECASE)
 #  request: flask request object
 #  ctx: the whole local context of the pre search hook
 def post_search(request, ctx):
+    if ctx['search'].pageno > 1:
+        return True
     if ctx['search'].query == 'ip':
         x_forwarded_for = request.headers.getlist("X-Forwarded-For")
         if x_forwarded_for:

--- a/tests/unit/test_plugins.py
+++ b/tests/unit/test_plugins.py
@@ -52,23 +52,39 @@ class SelfIPTest(SearxTestCase):
         request = Mock(user_plugins=store.plugins,
                        remote_addr='127.0.0.1')
         request.headers.getlist.return_value = []
-        ctx = get_search_mock(query='ip')
+        ctx = get_search_mock(query='ip', pageno=1)
         store.call('post_search', request, ctx)
         self.assertTrue('127.0.0.1' in ctx['search'].result_container.answers)
+
+        ctx = get_search_mock(query='ip', pageno=2)
+        store.call('post_search', request, ctx)
+        self.assertFalse('127.0.0.1' in ctx['search'].result_container.answers)
 
         # User agent test
         request = Mock(user_plugins=store.plugins,
                        user_agent='Mock')
         request.headers.getlist.return_value = []
 
-        ctx = get_search_mock(query='user-agent')
+        ctx = get_search_mock(query='user-agent', pageno=1)
         store.call('post_search', request, ctx)
         self.assertTrue('Mock' in ctx['search'].result_container.answers)
 
-        ctx = get_search_mock(query='user-agent')
+        ctx = get_search_mock(query='user-agent', pageno=2)
+        store.call('post_search', request, ctx)
+        self.assertFalse('Mock' in ctx['search'].result_container.answers)
+
+        ctx = get_search_mock(query='user-agent', pageno=1)
         store.call('post_search', request, ctx)
         self.assertTrue('Mock' in ctx['search'].result_container.answers)
 
-        ctx = get_search_mock(query='What is my User-Agent?')
+        ctx = get_search_mock(query='user-agent', pageno=2)
+        store.call('post_search', request, ctx)
+        self.assertFalse('Mock' in ctx['search'].result_container.answers)
+
+        ctx = get_search_mock(query='What is my User-Agent?', pageno=1)
         store.call('post_search', request, ctx)
         self.assertTrue('Mock' in ctx['search'].result_container.answers)
+
+        ctx = get_search_mock(query='What is my User-Agent?', pageno=2)
+        store.call('post_search', request, ctx)
+        self.assertFalse('Mock' in ctx['search'].result_container.answers)


### PR DESCRIPTION
This patch fixes #668. So answers from self information plugin do not show in the pages of results from the second page.
