### PR TITLE
add noopener noreferrer to target=_blank

### DIFF
--- a/searx/static/plugins/js/open_results_on_new_tab.js
+++ b/searx/static/plugins/js/open_results_on_new_tab.js
@@ -1,3 +1,4 @@
 $(document).ready(function() {
     $('.result_header > a').attr('target', '_blank');
+    $('.result_header > a').attr('rel', 'noopener noreferrer');
 });


### PR DESCRIPTION
Set `noopener` and `noreferrer` for opening new tab. This issue and fix is based on [this blogpost](https://dev.to/ben/the-targetblank-vulnerability-by-example) and [this blogpost](https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/).
