### PR TITLE
Feature/horriblesubs engine integration

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -58,3 +58,4 @@ generally made searx better:
 - marc @a01200356
 - Harry Wood @harry-wood
 - Thomas Renard @threnard
+- `@Yuyu0 <https://github.com/Yuyu0>`_

--- a/searx/engines/horriblesubs.py
+++ b/searx/engines/horriblesubs.py
@@ -95,11 +95,9 @@ def request(query, params):
 def response(resp):
     results = []
 
-    try:
-        query = unquote_plus(re.search(r'value=(.*?)&', resp.url).groups()[0])
-    except TypeError:
-        pass
-    else:
+    query_match = re.search(r'value=(.*?)&', resp.url)
+    if query_match and resp.search_params['pageno'] == 1:
+        query = unquote_plus(query_match.groups()[0])
         shows = search_schedule(query)
 
         for show in shows:

--- a/searx/engines/horriblesubs.py
+++ b/searx/engines/horriblesubs.py
@@ -70,19 +70,16 @@ schedules = index_schedules()
 # search for a schedule entry
 def search_schedule(search):
     search = search.lower()
-    result = None
+    results = []
 
     for weekday in schedules:
-        if result: break
-
         for show in weekday['shows']:
-            if result: break
-
             if search in show['title'].lower():
                 result = show
                 result['weekday'] = weekday['weekday']
+                results.append(result)
 
-    return result
+    return results
 
 # do search-request
 def request(query, params):
@@ -95,14 +92,15 @@ def request(query, params):
 def response(resp):
     results = []
     query = unquote_plus(re.search(r'value=(.*?)&', resp.url).groups()[0])
-    show = search_schedule(query)
+    shows = search_schedule(query)
 
-    if show:
-        content = 'Releases at {weekday} {time} PST'
-        content = content.format(weekday=show['weekday'], time=show['time'])
-        results.append({'url': show['url'],
-                        'title': show['title'],
-                        'content': content})
+    if shows:
+        for show in shows:
+            content = 'Releases at {weekday} {time} PST'
+            content = content.format(weekday=show['weekday'], time=show['time'])
+            results.append({'url': show['url'],
+                            'title': show['title'],
+                            'content': content})
 
     try:
         dom = html.fromstring(resp.text)

--- a/searx/engines/horriblesubs.py
+++ b/searx/engines/horriblesubs.py
@@ -91,15 +91,20 @@ def request(query, params):
 # get response from search-request
 def response(resp):
     results = []
-    query = unquote_plus(re.search(r'value=(.*?)&', resp.url).groups()[0])
-    shows = search_schedule(query)
 
-    for show in shows:
-        content = 'Releases at {weekday} {time} PST'
-        content = content.format(weekday=show['weekday'], time=show['time'])
-        results.append({'url': show['url'],
-                        'title': show['title'],
-                        'content': content})
+    try:
+        query = unquote_plus(re.search(r'value=(.*?)&', resp.url).groups()[0])
+    except TypeError:
+        pass
+    else:
+        shows = search_schedule(query)
+
+        for show in shows:
+            content = 'Releases at {weekday} {time} PST'
+            content = content.format(weekday=show['weekday'], time=show['time'])
+            results.append({'url': show['url'],
+                            'title': show['title'],
+                            'content': content})
 
     try:
         dom = html.fromstring(resp.text)

--- a/searx/engines/horriblesubs.py
+++ b/searx/engines/horriblesubs.py
@@ -10,10 +10,13 @@
 """
 
 from cgi import escape
-from urllib import urlencode
+from urllib import urlencode, unquote_plus
+from urlparse import urljoin
 from lxml import html
 from lxml.etree import XMLSyntaxError
+import re
 from searx.engines.xpath import extract_text
+from searx.poolrequests import get as http_get
 
 # engine dependent config
 categories = ['files', 'videos']
@@ -21,6 +24,7 @@ paging = True
 
 # search-url
 base_url = 'http://horriblesubs.info/'
+schedules_url = 'http://horriblesubs.info/release-schedule/'
 search_url = base_url + 'lib/search.php?{query}&nextid={offset}'
 
 # xpath queries
@@ -30,6 +34,55 @@ xpath_magnetlink = './/td[contains(@class, "hs-magnet-link")]/span/a'
 xpath_torrentfile = './/td[contains(@class, "hs-torrent-link")]/span/a'
 xpath_ddls = './/td[contains(@class, "hs-ddl-link")]/span/a'
 
+xpath_schedule_weekdays = '//h2[contains(@class, "weekday")]'
+xpath_schedule_shows = './/tr[contains(@class, "schedule-page-item")]'
+xpath_schedule_show_title = './/td[contains(@class, "schedule-page-show")]/a'
+xpath_schedule_show_time = './/td[contains(@class, "schedule-time")]'
+
+def index_schedules():
+    schedules = []
+
+    resp = http_get(schedules_url)
+    dom = html.fromstring(resp.text)
+
+    for weekday in dom.xpath(xpath_schedule_weekdays):
+        day = weekday.text_content()
+
+        weekday_table = weekday.getnext()
+        shows = []
+
+        for show in weekday_table.xpath(xpath_schedule_shows):
+            title = show.xpath(xpath_schedule_show_title)[0]
+            href = urljoin(base_url, title.attrib.get('href'))
+            title = title.text_content()
+            time = show.xpath(xpath_schedule_show_time)[0].text_content()
+            shows.append({'title': title,
+                          'url': href,
+                          'time': time})
+
+        schedules.append({'weekday': day,
+                          'shows': shows})
+
+    return schedules
+
+schedules = index_schedules()
+
+# search for a schedule entry
+def search_schedule(search):
+    search = search.lower()
+    result = None
+
+    for weekday in schedules:
+        if result: break
+
+        for show in weekday['shows']:
+            if result: break
+
+            if search in show['title'].lower():
+                result = show
+                result['weekday'] = weekday['weekday']
+
+    return result
 
 # do search-request
 def request(query, params):
@@ -41,6 +94,15 @@ def request(query, params):
 # get response from search-request
 def response(resp):
     results = []
+    query = unquote_plus(re.search(r'value=(.*?)&', resp.url).groups()[0])
+    show = search_schedule(query)
+
+    if show:
+        content = 'Releases at {weekday} {time} PST'
+        content = content.format(weekday=show['weekday'], time=show['time'])
+        results.append({'url': show['url'],
+                        'title': show['title'],
+                        'content': content})
 
     try:
         dom = html.fromstring(resp.text)
@@ -49,7 +111,7 @@ def response(resp):
 
     for result in dom.xpath(xpath_results):
         title = result.xpath(xpath_title)[0].text_content()
-        content = "Resolution: " + title[title.index('[')+1:title.index(']')]
+        content = 'Resolution: ' + title[title.index('[')+1:title.index(']')]
 
         magnetlink = result.xpath(xpath_magnetlink)[0].attrib.get('href')
 

--- a/searx/engines/horriblesubs.py
+++ b/searx/engines/horriblesubs.py
@@ -1,0 +1,73 @@
+"""
+ horriblesubs.info (Anime rips)
+
+ @website      http://horriblesubs.info/
+ @provide-api  no
+ @using-api    no
+ @results      HTML
+ @stable       no (HTML can change)
+ @parse        title, content, torrentfile, magnetlink, ddls
+"""
+
+from cgi import escape
+from urllib import urlencode
+from lxml import html
+from lxml.etree import XMLSyntaxError
+from searx.engines.xpath import extract_text
+
+# engine dependent config
+categories = ['files', 'videos']
+paging = True
+
+# search-url
+base_url = 'http://horriblesubs.info/'
+search_url = base_url + 'lib/search.php?{query}&nextid={offset}'
+
+# xpath queries
+xpath_results = '//div[contains(@class, "release-links")]'
+xpath_title = './/td[contains(@class, "dl-label")]/i'
+xpath_magnetlink = './/td[contains(@class, "hs-magnet-link")]/span/a'
+xpath_torrentfile = './/td[contains(@class, "hs-torrent-link")]/span/a'
+xpath_ddls = './/td[contains(@class, "hs-ddl-link")]/span/a'
+
+
+# do search-request
+def request(query, params):
+    query = urlencode({'value': query})
+    params['url'] = search_url.format(query=query, offset=params['pageno']-1)
+    return params
+
+
+# get response from search-request
+def response(resp):
+    results = []
+
+    try:
+        dom = html.fromstring(resp.text)
+    except XMLSyntaxError:
+        return results
+
+    for result in dom.xpath(xpath_results):
+        title = result.xpath(xpath_title)[0].text_content()
+        content = "Resolution: " + title[title.index('[')+1:title.index(']')]
+
+        magnetlink = result.xpath(xpath_magnetlink)[0].attrib.get('href')
+
+        torrentfile = result.xpath(xpath_torrentfile)[0].attrib.get('href')
+        href = torrentfile.replace('page=download', 'page=view')
+
+        ddls = []
+        for ddl in result.xpath(xpath_ddls):
+            ddl_href = ddl.attrib.get('href')
+            ddl_title = ddl.text_content()
+            ddls.append({'url': ddl_href,
+                         'title': ddl_title})
+
+        results.append({'url': href,
+                        'title': title,
+                        'content': content,
+                        'magnetlink': magnetlink,
+                        'torrentfile': torrentfile,
+                        'ddls': ddls})
+
+    return results

--- a/searx/engines/horriblesubs.py
+++ b/searx/engines/horriblesubs.py
@@ -39,6 +39,7 @@ xpath_schedule_shows = './/tr[contains(@class, "schedule-page-item")]'
 xpath_schedule_show_title = './/td[contains(@class, "schedule-page-show")]/a'
 xpath_schedule_show_time = './/td[contains(@class, "schedule-time")]'
 
+
 def index_schedules():
     schedules = []
 
@@ -67,6 +68,7 @@ def index_schedules():
 
 schedules = index_schedules()
 
+
 # search for a schedule entry
 def search_schedule(search):
     search = search.lower()
@@ -81,10 +83,11 @@ def search_schedule(search):
 
     return results
 
+
 # do search-request
 def request(query, params):
     query = urlencode({'value': query})
-    params['url'] = search_url.format(query=query, offset=params['pageno']-1)
+    params['url'] = search_url.format(query=query, offset=params['pageno'] - 1)
     return params
 
 
@@ -113,7 +116,7 @@ def response(resp):
 
     for result in dom.xpath(xpath_results):
         title = result.xpath(xpath_title)[0].text_content()
-        content = 'Resolution: ' + title[title.index('[')+1:title.index(']')]
+        content = 'Resolution: ' + title[title.index('[') + 1:title.index(']')]
 
         magnetlink = result.xpath(xpath_magnetlink)[0].attrib.get('href')
 

--- a/searx/engines/horriblesubs.py
+++ b/searx/engines/horriblesubs.py
@@ -94,13 +94,12 @@ def response(resp):
     query = unquote_plus(re.search(r'value=(.*?)&', resp.url).groups()[0])
     shows = search_schedule(query)
 
-    if shows:
-        for show in shows:
-            content = 'Releases at {weekday} {time} PST'
-            content = content.format(weekday=show['weekday'], time=show['time'])
-            results.append({'url': show['url'],
-                            'title': show['title'],
-                            'content': content})
+    for show in shows:
+        content = 'Releases at {weekday} {time} PST'
+        content = content.format(weekday=show['weekday'], time=show['time'])
+        results.append({'url': show['url'],
+                        'title': show['title'],
+                        'content': content})
 
     try:
         dom = html.fromstring(resp.text)

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -295,6 +295,11 @@ engines:
     categories : it
     shortcut : ho
 
+  - name : horriblesubs
+    engine : horriblesubs
+    shortcut : hs
+    disabled : True
+
   - name : ina
     engine : ina
     shortcut : in

--- a/searx/templates/oscar/macros.html
+++ b/searx/templates/oscar/macros.html
@@ -23,6 +23,7 @@
     {% if result.publishedDate %}<time class="text-muted" datetime="{{ result.pubdate }}" >{{ result.publishedDate }}</time>{% endif %}
     {% if result.magnetlink %}<small> &bull; {{ result_link(result.magnetlink, icon('magnet') + _('magnet link'), "magnetlink") }}</small>{% endif %}
     {% if result.torrentfile %}<small> &bull; {{ result_link(result.torrentfile, icon('download-alt') + _('torrent file'), "torrentfile") }}</small>{% endif %}
+    {% if result.ddls %}{% for ddl in result.ddls %}<small> &bull; {{ result_link(ddl.url, ddl.title, "ddl") }}</small>{% endfor %}{% endif %}
 {%- endmacro %}
 
 <!-- Draw result footer -->

--- a/tests/unit/engines/test_horriblesubs.py
+++ b/tests/unit/engines/test_horriblesubs.py
@@ -16,7 +16,7 @@ class TestHorribleSubsEngine(SearxTestCase):
         self.assertTrue('horriblesubs.info' in params['url'])
 
     def test_response(self):
-        resp = mock.Mock(text='<html></html>')
+        resp = mock.Mock(text='<html></html>', url='http://horriblesubs.info/lib/search.php?value=test&offset=0', search_params={'pageno': 1})
         self.assertEqual(horriblesubs.response(resp), [])
 
         html = """
@@ -47,7 +47,7 @@ class TestHorribleSubsEngine(SearxTestCase):
         </div>
         """
 
-        resp = mock.Mock(text=html)
+        resp = mock.Mock(text=html, url='http://horriblesubs.info/lib/search.php?value=test&offset=0', search_params={'pageno': 1})
         results = horriblesubs.response(resp)
 
         self.assertEqual(type(results), list)

--- a/tests/unit/engines/test_horriblesubs.py
+++ b/tests/unit/engines/test_horriblesubs.py
@@ -1,0 +1,63 @@
+from collections import defaultdict
+import mock
+from searx.engines import horriblesubs
+from searx.testing import SearxTestCase
+
+
+class TestHorribleSubsEngine(SearxTestCase):
+
+    def test_request(self):
+        query = 'test_query'
+        dic = defaultdict(dict)
+        dic['pageno'] = 0
+        params = horriblesubs.request(query, dic)
+        self.assertTrue('url' in params)
+        self.assertTrue(query in params['url'])
+        self.assertTrue('horriblesubs.info' in params['url'])
+
+    def test_response(self):
+        resp = mock.Mock(text='<html></html>')
+        self.assertEqual(horriblesubs.response(resp), [])
+
+        html = """
+        <div class="release-links some-kind-of-title-480p">
+            <table class="release-table" cellpadding="0" border="0" cellspacing="0">
+                <tr>
+                    <td class="dl-label"><i>Some kind of title [480p]</i>
+                    </td>
+                    <td class="dl-type hs-magnet-link">
+                        <span class="dl-link"><a title="Magnet Link" href="magnet.link">Magnet</a></span>
+                    </td>
+                    <td class="dl-type hs-torrent-link">
+                        <span class="dl-link"><a title="Torrent Link"
+                            href="http://www.nyaa.se/?page=download&tid=sometestid">Torrent</a></span>
+                    </td>
+                    <td class="dl-type hs-ddl-link">
+                        <span class="dl-link"><a title="Download from FileFactory" href="ffddl.link">FF</a></span>
+                    </td>
+                    <td class="dl-type hs-ddl-link">
+                        <span class="dl-link"><a title="Download from Uploaded.net" href="ulddl.link">UL</a></span>
+                    </td>
+                    <td class="linkless dl-type hs-ddl-link">MXS</td>
+                    <td class="dl-type hs-ddl-link">
+                        <span class="dl-link"><a title="Download from UploadRocket.net" href="urddl.link">UR</a></span>
+                    </td>
+                </tr>
+            </table>
+        </div>
+        """
+
+        resp = mock.Mock(text=html)
+        results = horriblesubs.response(resp)
+
+        self.assertEqual(type(results), list)
+        self.assertEqual(len(results), 1)
+
+        r = results[0]
+        self.assertEqual(r['url'], 'http://www.nyaa.se/?page=view&tid=sometestid')
+        self.assertEqual(r['title'], 'Some kind of title [480p]')
+        self.assertEqual(r['content'], 'Resolution: 480p')
+        self.assertEqual(r['magnetlink'], 'magnet.link')
+        self.assertEqual(r['torrentfile'], 'http://www.nyaa.se/?page=download&tid=sometestid')
+        self.assertEqual(r['ddls'][0]['url'], 'ffddl.link')
+        self.assertEqual(r['ddls'][0]['title'], 'FF')

--- a/tests/unit/engines/test_horriblesubs.py
+++ b/tests/unit/engines/test_horriblesubs.py
@@ -16,7 +16,8 @@ class TestHorribleSubsEngine(SearxTestCase):
         self.assertTrue('horriblesubs.info' in params['url'])
 
     def test_response(self):
-        resp = mock.Mock(text='<html></html>', url='http://horriblesubs.info/lib/search.php?value=test&offset=0', search_params={'pageno': 1})
+        resp = mock.Mock(text='<html></html>', url='http://horriblesubs.info/lib/search.php?value=test&offset=0',
+                         search_params={'pageno': 1})
         self.assertEqual(horriblesubs.response(resp), [])
 
         html = """
@@ -47,7 +48,8 @@ class TestHorribleSubsEngine(SearxTestCase):
         </div>
         """
 
-        resp = mock.Mock(text=html, url='http://horriblesubs.info/lib/search.php?value=test&offset=0', search_params={'pageno': 1})
+        resp = mock.Mock(text=html, url='http://horriblesubs.info/lib/search.php?value=test&offset=0',
+                         search_params={'pageno': 1})
         results = horriblesubs.response(resp)
 
         self.assertEqual(type(results), list)


### PR DESCRIPTION
Includes horriblesubs.info as a searchable engine.
I've made it include airing/release times from shows if there's any matches in there too. If your instance runs for >3 months it's likely the "index" will be obsolete, but I'm not sure how to work around this yet.
