### PR TITLE
[fix] results with digbit don't truncate anymore

### DIFF
--- a/searx/engines/digbt.py
+++ b/searx/engines/digbt.py
@@ -40,7 +40,7 @@ def response(resp):
     results = list()
     for result in search_res:
         url = urljoin(URL, result.xpath('.//a[@title]/@href')[0])
-        title = result.xpath('.//a[@title]/text()')[0]
+        title = extract_text(result.xpath('.//a[@title]'))
         content = extract_text(result.xpath('.//div[@class="files"]'))
         files_data = extract_text(result.xpath('.//div[@class="tail"]')).split()
         filesize = get_torrent_size(files_data[FILESIZE], files_data[FILESIZE_MULTIPLIER])

--- a/tests/unit/engines/test_digbt.py
+++ b/tests/unit/engines/test_digbt.py
@@ -28,7 +28,9 @@ class TestDigBTEngine(SearxTestCase):
         <table class="table">
             <tr><td class="x-item">
             <div>
-                <a title="The Big Bang Theory" class="title" href="/The-Big-Bang-Theory-d2.html">The Big Bang Theory</a>
+                <a title="The Big Bang Theory" class="title" href="/The-Big-Bang-Theory-d2.html">
+                    The Big <span class="highlight">Bang</span> Theory
+                </a>
                 <span class="ctime"><span style="color:red;">4 hours ago</span></span>
             </div>
             <div class="files">


### PR DESCRIPTION
For example: [!digbt a tribe called quest](https://searx.me/?q=%21digbt%20a%20tribe%20called%20quest&categories=none) currently truncates the results' titles to "A Tribe C".
