### PR TITLE
[fix] set the title on the opensearch link tag

### DIFF
--- a/searx/templates/courgette/base.html
+++ b/searx/templates/courgette/base.html
@@ -22,7 +22,7 @@
         {% endblock %}
         {% block meta %}{% endblock %}
         {% block head %}
-        <link title="searx" type="application/opensearchdescription+xml" rel="search" href="{{ url_for('opensearch') }}"/>
+        <link title="{{ instance_name }}" type="application/opensearchdescription+xml" rel="search" href="{{ url_for('opensearch') }}"/>
         {% endblock %}
         <script type="text/javascript">
             searx = {};

--- a/searx/templates/legacy/base.html
+++ b/searx/templates/legacy/base.html
@@ -17,7 +17,7 @@
         {% endblock %}
         {% block meta %}{% endblock %}
         {% block head %}
-        <link title="searx" type="application/opensearchdescription+xml" rel="search" href="{{ url_for('opensearch') }}"/>
+        <link title="{{ instance_name }}" type="application/opensearchdescription+xml" rel="search" href="{{ url_for('opensearch') }}"/>
         {% endblock %}
     </head>
     <body>


### PR DESCRIPTION
Firefox uses the title attributes instead of the ShortName from the xml file
as set in 0fbd7052 which closed #405 

Note I didn't add opensearch to the pix-art template.
