### PR TITLE
Add ccctv engine to settings.yml

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -60,3 +60,4 @@ generally made searx better:
 - Thomas Renard @threnard
 - Pydo `<https://github.com/pydo>`_
 - Athemis `<https://github.com/Athemis>`_
+- Stefan Antoni `<http://stefan.antoni.io>`

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -99,6 +99,7 @@ engines:
     title_xpath : //div[@class="caption"]/h3/a/text()
     content_xpath : //div[@class="caption"]/h4/@title
     categories : videos
+    disabled : True
     shortcut : c3tv
 
   - name : crossref

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -91,6 +91,16 @@ engines:
     disabled : True
     shortcut : bb
 
+  - name : ccc-tv
+    engine : xpath
+    paging : False
+    search_url : https://media.ccc.de/search/?q={query}
+    url_xpath : //div[@class="caption"]/h3/a/@href
+    title_xpath : //div[@class="caption"]/h3/a/text()
+    content_xpath : //div[@class="caption"]/h4/@title
+    categories : videos
+    shortcut : c3tv
+
   - name : crossref
     engine : json_engine
     paging : True


### PR DESCRIPTION
This adds https://media.ccc.de to searx.

Tested in docker container. Content extraction works and deeplinks work, too.
Sadly paging is not provided by ccc-tv itself (yet?).

This supersedes pull request #786 which had unnecessary commits.