### PR TITLE
Engine can be offline and has a full access to the search_query object.

### DIFF
--- a/searx/engines/__base__.py
+++ b/searx/engines/__base__.py
@@ -1,0 +1,94 @@
+import threading
+import requests.exceptions
+import searx.poolrequests as requests_lib
+from time import time
+from searx import logger
+
+logger = logger.getChild('engine')
+
+
+def send_http_request(engine, request_params, timeout_limit):
+    # for page_load_time stats
+    time_before_request = time()
+
+    # create dictionary which contain all
+    # informations about the request
+    request_args = dict(
+        headers=request_params['headers'],
+        cookies=request_params['cookies'],
+        timeout=timeout_limit,
+        verify=request_params['verify']
+    )
+
+    # specific type of request (GET or POST)
+    if request_params['method'] == 'GET':
+        req = requests_lib.get
+    else:
+        req = requests_lib.post
+        request_args['data'] = request_params['data']
+
+    # send the request
+    response = req(request_params['url'], **request_args)
+
+    # is there a timeout (no parsing in this case)
+    timeout_overhead = 0.2  # seconds
+    search_duration = time() - request_params['started']
+    if search_duration > timeout_limit + timeout_overhead:
+        raise requests.exceptions.Timeout(response=response)
+
+    with threading.RLock():
+        # no error : reset the suspend variables
+        engine.continuous_errors = 0
+        engine.suspend_end_time = 0
+        # update stats with current page-load-time
+        # only the HTTP request
+        engine.stats['page_load_time'] += time() - time_before_request
+        engine.stats['page_load_count'] += 1
+
+    # everything is ok : return the response
+    return response
+
+
+def get_default_search(engine):
+
+    def search(query, request_params, timeout_limit):
+        # update request parameters dependent on
+        # search-engine (contained in engines folder)
+        engine.request(query, request_params)
+
+        # check if there is a HTTP request
+        if request_params['url'] is None:
+            return []
+
+        if not request_params['url']:
+            return []
+
+        # send request
+        response = send_http_request(engine, request_params, timeout_limit)
+
+        # parse the response
+        response.search_params = request_params
+        return engine.response(response)
+
+    return search
+
+
+def get_default_can_accept_search_query(engine):
+
+    def can_accept_search_query(search_query):
+        # if paging is not supported, skip
+        if search_query.pageno > 1 and not engine.paging:
+            return False
+
+        # if search-language is set and engine does not
+        # provide language-support, skip
+        if search_query.lang != 'all' and not engine.language_support:
+            return False
+
+        # if time_range is not supported, skip
+        if search_query.time_range and not engine.time_range_support:
+            return False
+
+        return True
+
+    return can_accept_search_query

--- a/searx/engines/__base__.py
+++ b/searx/engines/__base__.py
@@ -2,12 +2,13 @@ import threading
 import requests.exceptions
 import searx.poolrequests as requests_lib
 from time import time
+from searx.utils import gen_useragent
 from searx import logger
 
 logger = logger.getChild('engine')
 
 
-def send_http_request(engine, request_params, timeout_limit):
+def send_http_request(engine, request_params, start_time, timeout_limit):
     # for page_load_time stats
     time_before_request = time()
 
@@ -32,7 +33,7 @@ def send_http_request(engine, request_params, timeout_limit):
 
     # is there a timeout (no parsing in this case)
     timeout_overhead = 0.2  # seconds
-    search_duration = time() - request_params['started']
+    search_duration = time() - start_time
     if search_duration > timeout_limit + timeout_overhead:
         raise requests.exceptions.Timeout(response=response)
 
@@ -49,9 +50,38 @@ def send_http_request(engine, request_params, timeout_limit):
     return response
 
 
+# get default reqest parameter
+def default_request_params():
+    return {
+        'method': 'GET',
+        'headers': {},
+        'data': {},
+        'url': '',
+        'cookies': {},
+        'verify': True
+    }
+
+
 def get_default_search(engine):
 
-    def search(query, request_params, timeout_limit):
+    def search(search_query, selected_categories, start_time, timeout_limit):
+        # set default request parameters
+        request_params = default_request_params()
+        request_params['headers']['User-Agent'] = gen_useragent()
+        request_params['category'] = selected_categories
+        request_params['pageno'] = search_query.pageno
+
+        if hasattr(engine, 'language') and engine.language:
+            request_params['language'] = engine.language
+        else:
+            request_params['language'] = search_query.lang
+
+        # 0 = None, 1 = Moderate, 2 = Strict
+        request_params['safesearch'] = search_query.safesearch
+        request_params['time_range'] = search_query.time_range
+
+        query = search_query.query.encode('utf-8')
+
         # update request parameters dependent on
         # search-engine (contained in engines folder)
         engine.request(query, request_params)
@@ -64,7 +94,7 @@ def get_default_search(engine):
             return []
 
         # send request
-        response = send_http_request(engine, request_params, timeout_limit)
+        response = send_http_request(engine, request_params, start_time, timeout_limit)
 
         # parse the response
         response.search_params = request_params
@@ -73,9 +103,9 @@ def get_default_search(engine):
     return search
 
 
-def get_default_can_accept_search_query(engine):
+def get_default_can_accept(engine):
 
-    def can_accept_search_query(search_query):
+    def can_accept(search_query):
         # if paging is not supported, skip
         if search_query.pageno > 1 and not engine.paging:
             return False
@@ -91,4 +121,4 @@ def get_default_can_accept_search_query(engine):
 
         return True
 
-    return can_accept_search_query
+    return can_accept

--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -129,11 +129,11 @@ def load_engine(engine_data):
         sys.exit(1)
 
     # check the "can_accept_search_query" function (create one if needed)
-    if not hasattr(engine, 'can_accept_search_query'):
-        setattr(engine, 'can_accept_search_query', searx.engines.__base__.get_default_can_accept_search_query(engine))
+    if not hasattr(engine, 'can_accept'):
+        setattr(engine, 'can_accept', searx.engines.__base__.get_default_can_accept(engine))
 
-    if not callable(getattr(engine, 'can_accept_search_query')):
-        logger.error('Engine error: can_accept_search_query is not callable: {0}'.format(engine.shortcut))
+    if not callable(getattr(engine, 'can_accept')):
+        logger.error('Engine error: can_accept is not callable: {0}'.format(engine.shortcut))
         sys.exit(1)
 
     return engine

--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -26,6 +26,7 @@ from searx import settings
 from searx import logger
 from searx.utils import load_module
 
+import searx.engines.__base__
 
 logger = logger.getChild('engines')
 
@@ -118,6 +119,22 @@ def load_engine(engine_data):
         sys.exit(1)
 
     engine_shortcuts[engine.shortcut] = engine.name
+
+    # check the "search" function (create one if needed)
+    if not hasattr(engine, 'search'):
+        setattr(engine, 'search', searx.engines.__base__.get_default_search(engine))
+
+    if not callable(getattr(engine, 'search')):
+        logger.error('Engine error: search is not callable: {0}'.format(engine.shortcut))
+        sys.exit(1)
+
+    # check the "can_accept_search_query" function (create one if needed)
+    if not hasattr(engine, 'can_accept_search_query'):
+        setattr(engine, 'can_accept_search_query', searx.engines.__base__.get_default_can_accept_search_query(engine))
+
+    if not callable(getattr(engine, 'can_accept_search_query')):
+        logger.error('Engine error: can_accept_search_query is not callable: {0}'.format(engine.shortcut))
+        sys.exit(1)
 
     return engine
 

--- a/searx/search.py
+++ b/searx/search.py
@@ -20,6 +20,7 @@ import threading
 from thread import start_new_thread
 from time import time
 from uuid import uuid4
+import requests.exceptions
 import searx.poolrequests as requests_lib
 from searx.engines import (
     categories, engines
@@ -37,109 +38,118 @@ number_of_searches = 0
 
 
 def send_http_request(engine, request_params, timeout_limit):
-    response = None
-    try:
-        # create dictionary which contain all
-        # informations about the request
-        request_args = dict(
-            headers=request_params['headers'],
-            cookies=request_params['cookies'],
-            timeout=timeout_limit,
-            verify=request_params['verify']
-        )
-        # specific type of request (GET or POST)
-        if request_params['method'] == 'GET':
-            req = requests_lib.get
-        else:
-            req = requests_lib.post
-            request_args['data'] = request_params['data']
+    # for page_load_time stats
+    time_before_request = time()
 
-        # for page_load_time stats
-        time_before_request = time()
+    # create dictionary which contain all
+    # informations about the request
+    request_args = dict(
+        headers=request_params['headers'],
+        cookies=request_params['cookies'],
+        timeout=timeout_limit,
+        verify=request_params['verify']
+    )
 
-        # send the request
-        response = req(request_params['url'], **request_args)
+    # specific type of request (GET or POST)
+    if request_params['method'] == 'GET':
+        req = requests_lib.get
+    else:
+        req = requests_lib.post
+        request_args['data'] = request_params['data']
 
-        with threading.RLock():
-            # no error : reset the suspend variables
-            engine.continuous_errors = 0
-            engine.suspend_end_time = 0
-            # update stats with current page-load-time
-            # only the HTTP request
-            engine.stats['page_load_time'] += time() - time_before_request
-            engine.stats['page_load_count'] += 1
+    # send the request
+    response = req(request_params['url'], **request_args)
 
-        # is there a timeout (no parsing in this case)
-        timeout_overhead = 0.2  # seconds
-        search_duration = time() - request_params['started']
-        if search_duration > timeout_limit + timeout_overhead:
-            logger.exception('engine timeout on HTTP request:'
-                             '{0} (search duration : {1} ms, time-out: {2} )'
-                             .format(engine.name, search_duration, timeout_limit))
-            with threading.RLock():
-                engine.stats['errors'] += 1
-            return False
+    # is there a timeout (no parsing in this case)
+    timeout_overhead = 0.2  # seconds
+    search_duration = time() - request_params['started']
+    if search_duration > timeout_limit + timeout_overhead:
+        raise Timeout(response=response)
 
-        # everything is ok : return the response
-        return response
+    with threading.RLock():
+        # no error : reset the suspend variables
+        engine.continuous_errors = 0
+        engine.suspend_end_time = 0
+        # update stats with current page-load-time
+        # only the HTTP request
+        engine.stats['page_load_time'] += time() - time_before_request
+        engine.stats['page_load_count'] += 1
 
-    except:
-        # increase errors stats
-        with threading.RLock():
-            engine.stats['errors'] += 1
-            engine.continuous_errors += 1
-            engine.suspend_end_time = time() + min(60, engine.continuous_errors)
-
-        # print engine name and specific error message
-        logger.exception('engine crash: {0}'.format(engine.name))
-        return False
+    # everything is ok : return the response
+    return response
 
 
-def search_one_request(engine_name, query, request_params, result_container, timeout_limit):
-    engine = engines[engine_name]
-
+def search_one_request(engine, query, request_params, timeout_limit):
     # update request parameters dependent on
     # search-engine (contained in engines folder)
     engine.request(query, request_params)
 
     # TODO add support of offline engines
     if request_params['url'] is None:
-        return False
+        return []
 
     # ignoring empty urls
     if not request_params['url']:
-        return False
+        return []
 
     # send request
     response = send_http_request(engine, request_params, timeout_limit)
 
-    # parse response
-    success = None
-    if response:
-        # parse the response
-        response.search_params = request_params
-        try:
-            search_results = engine.response(response)
-        except:
-            logger.exception('engine crash: {0}'.format(engine.name))
-            search_results = []
+    # parse the response
+    response.search_params = request_params
+    return engine.response(response)
+
+
+def search_one_request_safe(engine_name, query, request_params, result_container, timeout_limit):
+    start_time = time()
+    engine = engines[engine_name]
+
+    try:
+        # send requests and parse the results
+        search_results = search_one_request(engine, query, request_params, timeout_limit)
 
         # add results
         for result in search_results:
-            result['engine'] = engine.name
+            result['engine'] = engine_name
+        result_container.extend(engine_name, search_results)
 
-        result_container.extend(engine.name, search_results)
+        # update engine time when there is no exception
+        with threading.RLock():
+            engine.stats['engine_time'] += time() - start_time
+            engine.stats['engine_time_count'] += 1
 
-        success = True
-    else:
-        success = False
+        return True
 
-    with threading.RLock():
-        # update stats : total time
-        engine.stats['engine_time'] += time() - request_params['started']
-        engine.stats['engine_time_count'] += 1
+    except Exception as e:
+        engine.stats['errors'] += 1
 
-    return success
+        search_duration = time() - start_time
+        requests_exception = False
+
+        if (issubclass(e.__class__, requests.exceptions.Timeout)):
+            # requests timeout (connect or read)
+            logger.error("engine {0} : HTTP requests timeout"
+                         "(search duration : {1} s, timeout: {2} s) : {3}"
+                         .format(engine_name, search_duration, timeout_limit, e.__class__.__name__))
+            requests_exception = True
+        if (issubclass(e.__class__, requests.exceptions.RequestException)):
+            # other requests exception
+            logger.exception("engine {0} : requests exception"
+                             "(search duration : {1} s, timeout: {2} s) : {3}"
+                             .format(engine_name, search_duration, timeout_limit, e))
+            requests_exception = True
+        else:
+            # others errors
+            logger.exception('engine {0} : exception : {1}'.format(engine_name, e))
+
+        # update continuous_errors / suspend_end_time
+        if requests_exception:
+            with threading.RLock():
+                engine.continuous_errors += 1
+                engine.suspend_end_time = time() + min(60, engine.continuous_errors)
+
+        #
+        return False
 
 
 def search_multiple_requests(requests, result_container, timeout_limit):
@@ -148,7 +158,7 @@ def search_multiple_requests(requests, result_container, timeout_limit):
 
     for engine_name, query, request_params in requests:
         th = threading.Thread(
-            target=search_one_request,
+            target=search_one_request_safe,
             args=(engine_name, query, request_params, result_container, timeout_limit),
             name=search_id,
         )


### PR DESCRIPTION
It would allow sympy to be an engine instead of a plugin. Since it would be thread, it would be more easier to deal with timeout.

The full access to the search_query object would allow translation by specifying two languages in the request for example. 

Changes : 
* an engine can define the ```search(search_query, selected_categories, start_time, timeout_limit)``` function. If not the default behavior doesn't change, see ```get_default_search function``` in  ```searx/engines/__base__.py```   
* an engine can define the ```can_accept(search_query)``` function. It would allow the sympy engine to accept or not the request. The default behavior doesn't change, see ```get_default_can_accept``` function.

Side effects : 
* For one user request, multiple HTTP were done using the same user agent. It's no more the case with this PR.
* About the global timeout in the ```send_http_request``` function ( ```if search_duration > timeout_limit + timeout_overhead``` ) : before, the ```engine.continuous_errors``` was reseted, it's not the case anymore. It can be reverted.

Notes : 
* there are three commits, to show the incremental changes.
* the engine.continuous_errors is set inside ```searx/search.py``` and ```searx/engines/__base__py``` not very nice. They can be squashed.
