### PR TITLE
[mod] ./manage.sh can download geckodriver

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -14,6 +14,36 @@ update_dev_packages() {
     pip install --upgrade -r "$BASE_DIR/requirements-dev.txt"
 }
 
+check_geckodriver() {
+    echo '[!] Checking geckodriver'
+    set -e
+    geckodriver -V 2>1 > /dev/null || NOTFOUND=1
+    set +e
+    if [ -z $NOTFOUND ]; then
+	return
+    fi
+    GECKODRIVER_VERSION="v0.11.1"
+    PLATFORM=`python -c "import platform; print platform.system().lower(), platform.architecture()[0]"`
+    case $PLATFORM in
+	"linux 32bit" | "linux2 32bit") ARCH="linux32";;
+	"linux 64bit" | "linux2 64bit") ARCH="linux64";;
+	"windows 32 bit") ARCH="win32";;
+	"windows 64 bit") ARCH="win64";;
+	"mac 64bit") ARCH="macos";;
+    esac
+    GECKODRIVER_URL="https://github.com/mozilla/geckodriver/releases/download/$GECKODRIVER_VERSION/geckodriver-$GECKODRIVER_VERSION-$ARCH.tar.gz";
+    if [ -z "$VIRTUAL_ENV" ]; then
+	echo "geckodriver can't be installed because VIRTUAL_ENV is not set, you should download it from\n  $GECKODRIVER_URL"
+	exit
+    else
+	echo "Installing $VIRTUAL_ENV from\n  $GECKODRIVER_URL"
+	FILE=`mktemp`
+	wget "$GECKODRIVER_URL" -qO $FILE && tar xz -C $VIRTUAL_ENV/bin/ -f $FILE geckodriver
+	rm $FILE
+	chmod 777 $VIRTUAL_ENV/bin/geckodriver
+    fi
+}
+
 pep8_check() {
     echo '[!] Running pep8 check'
     # ignored rules:
@@ -43,6 +73,7 @@ tests() {
     set -e
     pep8_check
     unit_tests
+    check_geckodriver
     robot_tests
     set +e
 }
@@ -88,6 +119,7 @@ Commands
     unit_tests           - Run unit tests
     update_dev_packages  - Check & update development and production dependency changes
     update_packages      - Check & update dependency changes
+    check_geckodriver    - Check & download geckodriver (required for robot_tests)
 "
 }
 


### PR DESCRIPTION
```./manage.sh check_geckodriver``` : 
* checks if geckdriver is installed anywhere in the PATH.
* if not, get the URL for the right arch from github
* download it and install the binary into the virtual environment OR just give the URL to download if there is no virtual envionment

```./manage.sh tests``` calls check_geckodriver to make sure that the geckodriver is installed.