### PR TITLE
[mod] the static and templates directories can be defined in the settings.yml

### DIFF
--- a/searx/__init__.py
+++ b/searx/__init__.py
@@ -18,7 +18,7 @@ along with searx. If not, see < http://www.gnu.org/licenses/ >.
 import certifi
 import logging
 from os import environ
-from os.path import realpath, dirname, join, abspath
+from os.path import realpath, dirname, join, abspath, isfile
 from ssl import OPENSSL_VERSION_INFO, OPENSSL_VERSION
 try:
     from yaml import load
@@ -30,13 +30,24 @@ except:
 searx_dir = abspath(dirname(__file__))
 engine_dir = dirname(realpath(__file__))
 
-# if possible set path to settings using the
-# enviroment variable SEARX_SETTINGS_PATH
+
+def check_settings_yml(file_name):
+    if isfile(file_name):
+        return file_name
+    else:
+        return None
+
+# find location of settings.yml
 if 'SEARX_SETTINGS_PATH' in environ:
-    settings_path = environ['SEARX_SETTINGS_PATH']
-# otherwise using default path
+    # if possible set path to settings using the
+    # enviroment variable SEARX_SETTINGS_PATH
+    settings_path = check_settings_yml(environ['SEARX_SETTINGS_PATH'])
 else:
-    settings_path = join(searx_dir, 'settings.yml')
+    # if not, get it from searx code base or last solution from /etc/searx
+    settings_path = check_settings_yml(join(searx_dir, 'settings.yml')) or check_settings_yml('/etc/searx/settings.yml')
+
+if not settings_path:
+    raise Exception('settings.yml not found')
 
 # load settings
 with open(settings_path) as settings_yaml:
@@ -67,7 +78,7 @@ else:
     logging.basicConfig(level=logging.WARNING)
 
 logger = logging.getLogger('searx')
-
+logger.debug('read configuration from %s', settings_path)
 # Workaround for openssl versions <1.0.2
 # https://github.com/certifi/python-certifi/issues/26
 if OPENSSL_VERSION_INFO[0:3] < (1, 0, 2):

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -16,7 +16,8 @@ server:
     http_protocol_version : "1.0"  # 1.0 and 1.1 are supported
 
 ui:
-    themes_path : "" # Custom ui themes path - leave it blank if you didn't change
+    static_path : "" # Custom static path - leave it blank if you didn't change
+    templates_path : "" # Custom templates path - leave it blank if you didn't change
     default_theme : oscar # ui theme
     default_locale : "" # Default interface locale - leave blank to detect from browser information or use codes from the 'locales' config section
 

--- a/searx/settings_robot.yml
+++ b/searx/settings_robot.yml
@@ -16,7 +16,8 @@ server:
     http_protocol_version : "1.0"
 
 ui:
-    themes_path : ""
+    static_path : ""
+    templates_path : ""
     default_theme : oscar
     default_locale : ""
 

--- a/searx/utils.py
+++ b/searx/utils.py
@@ -186,9 +186,9 @@ def get_resources_directory(searx_directory, subdirectory, resources_directory):
     return resources_directory
 
 
-def get_themes(static_path):
+def get_themes(templates_path):
     """Returns available themes list."""
-    themes = os.listdir(os.path.join(static_path, 'themes'))
+    themes = os.listdir(templates_path)
     if '__common__' in themes:
         themes.remove('__common__')
     return themes

--- a/searx/utils.py
+++ b/searx/utils.py
@@ -178,37 +178,39 @@ class UnicodeWriter:
             self.writerow(row)
 
 
-def get_themes(root):
+def get_resources_directory(searx_directory, subdirectory, resources_directory):
+    if not resources_directory:
+        resources_directory = os.path.join(searx_directory, subdirectory)
+    if not os.path.isdir(resources_directory):
+        raise Exception(directory + " is not a directory")
+    return resources_directory
+
+
+def get_themes(static_path):
     """Returns available themes list."""
-
-    static_path = os.path.join(root, 'static')
-    templates_path = os.path.join(root, 'templates')
-
     themes = os.listdir(os.path.join(static_path, 'themes'))
     if '__common__' in themes:
         themes.remove('__common__')
-    return static_path, templates_path, themes
+    return themes
 
 
-def get_static_files(base_path):
-    base_path = os.path.join(base_path, 'static')
+def get_static_files(static_path):
     static_files = set()
-    base_path_length = len(base_path) + 1
-    for directory, _, files in os.walk(base_path):
+    static_path_length = len(static_path) + 1
+    for directory, _, files in os.walk(static_path):
         for filename in files:
-            f = os.path.join(directory[base_path_length:], filename)
+            f = os.path.join(directory[static_path_length:], filename)
             static_files.add(f)
     return static_files
 
 
-def get_result_templates(base_path):
-    base_path = os.path.join(base_path, 'templates')
+def get_result_templates(templates_path):
     result_templates = set()
-    base_path_length = len(base_path) + 1
-    for directory, _, files in os.walk(base_path):
+    templates_path_length = len(templates_path) + 1
+    for directory, _, files in os.walk(templates_path):
         if directory.endswith('result_templates'):
             for filename in files:
-                f = os.path.join(directory[base_path_length:], filename)
+                f = os.path.join(directory[templates_path_length:], filename)
                 result_templates.add(f)
     return result_templates
 

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -100,7 +100,7 @@ static_files = get_static_files(static_path)
 default_theme = settings['ui']['default_theme']
 templates_path = get_resources_directory(searx_dir, 'templates', settings['ui']['templates_path'])
 logger.debug('templates directory is %s', templates_path)
-themes = get_themes(static_path)
+themes = get_themes(templates_path)
 result_templates = get_result_templates(templates_path)
 global_favicons = []
 for indice, theme in enumerate(themes):


### PR DESCRIPTION
Add ```static_path``` and ```templates_path``` settings as asked by #815

The ```themes_path``` setting is removed.

Note about previous implementation : the ```themes_path``` was not used for ```global_favicons``` according [this line](https://github.com/asciimoo/searx/blob/master/searx/webapp.py#L118) : 
```python
 theme_img_path = searx_dir + "/static/themes/" + theme + "/img/icons/"
```

Moreover, there is a second commit which allow settings.yml to be loaded from /etc/searx/settings.yml

Searx looks for settings.yml in this order:
* from SEARX_SETTINGS_PATH if defined (if the environment variable reference an file that doesn't exist an exception is raised)
* if not found then from searx code base,
* if not found then from /etc/searx/settings.yml
* if not found an exception stops searx loading