### PR TITLE
[enh] make number of results less prominent

### DIFF
--- a/searx/templates/oscar/results.html
+++ b/searx/templates/oscar/results.html
@@ -92,14 +92,7 @@
 
         <div class="col-sm-4" id="sidebar_results">
             {% if number_of_results != '0' %}
-            <div class="panel panel-default">
-                <div class="panel-heading">
-                    <h4 class="panel-title">{{ _('Number of results') }}</h4>
-                </div>
-                <div class="panel-body">
-                    {{ number_of_results }}
-                </div>
-            </div>
+                <p><small>{{ _('Number of results') }}: {{ number_of_results }}</small></p>
             {% endif %}
             {% if infoboxes %}
                 {% for infobox in infoboxes %}


### PR DESCRIPTION
Move number of results out of its infobox to mimic other search engines.

Based on #226 