### PR TITLE
Remove secret key

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,8 +18,7 @@ Installation
    ``git clone https://github.com/asciimoo/searx.git && cd searx``
 -  install dependencies: ``./manage.sh update_packages``
 -  edit your
-   `settings.yml <https://github.com/asciimoo/searx/blob/master/searx/settings.yml>`__
-   (set your ``secret_key``!)
+   `settings.yml <https://github.com/asciimoo/searx/blob/master/searx/settings.yml>`
 -  run ``python searx/webapp.py`` to start the application
 
 For all the details, follow this `step by step

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pyopenssl==16.2.0
 python-dateutil==2.5.3
 pyyaml==3.11
 requests[socks]==2.12.4
+pyxdg==0.25

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -10,7 +10,6 @@ search:
 server:
     port : 8888
     bind_address : "127.0.0.1" # address to listen on
-    secret_key : "ultrasecretkey" # change this!
     base_url : False # Set custom base_url. Possible values: False or "https://your.custom.host/location/"
     image_proxy : False # Proxying image results through searx
     http_protocol_version : "1.0"  # 1.0 and 1.1 are supported

--- a/searx/settings_robot.yml
+++ b/searx/settings_robot.yml
@@ -10,7 +10,6 @@ search:
 server:
     port : 11111
     bind_address : 127.0.0.1
-    secret_key : "ultrasecretkey" # change this!
     base_url : False
     image_proxy : False
     http_protocol_version : "1.0"

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -28,6 +28,7 @@ import hmac
 import json
 import os
 import requests
+import xdg
 
 from searx import logger
 logger = logger.getChild('webapp')
@@ -59,7 +60,7 @@ from searx.engines import (
 from searx.utils import (
     UnicodeWriter, highlight_content, html_to_text, get_themes,
     get_static_files, get_result_templates, gen_useragent, dict_subset,
-    prettify_url
+    prettify_url, get_secret_app_key
 )
 from searx.version import VERSION_STRING
 from searx.languages import language_codes
@@ -103,7 +104,7 @@ app = Flask(
 
 app.jinja_env.trim_blocks = True
 app.jinja_env.lstrip_blocks = True
-app.secret_key = settings['server']['secret_key']
+app.secret_key = get_secret_app_key()
 
 if not searx_debug or os.environ.get("WERKZEUG_RUN_MAIN") == "true":
     initialize_engines(settings['engines'])
@@ -280,7 +281,7 @@ def image_proxify(url):
     if settings.get('result_proxy'):
         return proxify(url)
 
-    h = hmac.new(settings['server']['secret_key'], url.encode('utf-8'), hashlib.sha256).hexdigest()
+    h = hmac.new(app.secret_key, url.encode('utf-8'), hashlib.sha256).hexdigest()
 
     return '{0}?{1}'.format(url_for('image_proxy'),
                             urlencode(dict(url=url.encode('utf-8'), h=h)))
@@ -684,7 +685,7 @@ def image_proxy():
     if not url:
         return '', 400
 
-    h = hmac.new(settings['server']['secret_key'], url, hashlib.sha256).hexdigest()
+    h = hmac.new(app.secret_key, url, hashlib.sha256).hexdigest()
 
     if h != request.args.get('h'):
         return '', 400

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -104,6 +104,10 @@ app = Flask(
 
 app.jinja_env.trim_blocks = True
 app.jinja_env.lstrip_blocks = True
+
+# notify the user that the secret_key is no longer used
+if 'secret_key' in settings['server']:
+    logger.warning(' The "secret_key" config key is no longer used.')
 app.secret_key = get_secret_app_key()
 
 if not searx_debug or os.environ.get("WERKZEUG_RUN_MAIN") == "true":


### PR DESCRIPTION
Instead of having to “spoil” the config with a secret key (which hinders
uploading to a public repo), we can generate it on application start and put it
into the user cache directory (which should only be readable by the searx user).

Adds `utils.get_secret_app_key` which generates a key if none exists and returns
the existing one otherwise (declarative style).
Also test every codepath of that function.

- [x] Tests run w/o errors
- [x] proxying works with the new generated key

fixes https://github.com/asciimoo/searx/issues/834