### PR TITLE
eliminate pagination bug in search forms

### DIFF
--- a/searx/templates/oscar/results.html
+++ b/searx/templates/oscar/results.html
@@ -1,8 +1,8 @@
 {% extends "oscar/base.html" %}
-{% macro search_form_attrs() -%}
+{% macro search_form_attrs(pageno) -%}
     {% for category in selected_categories %}<input type="hidden" name="category_{{ category }}" value="1"/>{% endfor %}
     <input type="hidden" name="q" value="{{ q|e }}" />
-    <input type="hidden" name="pageno" value="{{ pageno+1 }}" />
+    <input type="hidden" name="pageno" value="{{ pageno }}" />
     <input type="hidden" name="time_range" value="{{ time_range }}" />
     <input type="hidden" name="language" value="{{ current_language }}" />
 {%- endmacro %}
@@ -58,13 +58,13 @@
             <div id="pagination">
                 <div class="pull-left">
                   <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}" class="pull-left">
-                        {{ search_form_attrs() }}
+                        {{ search_form_attrs(pageno+1) }}
                         <button type="submit" class="btn btn-default"><span class="glyphicon glyphicon-backward"></span> {{ _('next page') }}</button>
                     </form>
                 </div>
                 <div class="pull-right">
                     <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}"  class="pull-left">
-                        {{ search_form_attrs() }}
+                        {{ search_form_attrs(pageno-1) }}
                         <button type="submit" class="btn btn-default" {% if pageno == 1 %}disabled{% endif %}><span class="glyphicon glyphicon-forward"></span> {{ _('previous page') }}</button>
                     </form>
                 </div>
@@ -74,13 +74,13 @@
             <div id="pagination">
                 <div class="pull-left">
                     <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}" class="pull-left">
-                        {{ search_form_attrs() }}
+                        {{ search_form_attrs(pageno-1) }}
                         <button type="submit" class="btn btn-default" {% if pageno == 1 %}disabled{% endif %}><span class="glyphicon glyphicon-backward"></span> {{ _('previous page') }}</button>
                     </form>
                 </div>
                 <div class="pull-right">
                     <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}"  class="pull-left">
-                        {{ search_form_attrs() }}
+                        {{ search_form_attrs(pageno+1) }}
                         <button type="submit" class="btn btn-default"><span class="glyphicon glyphicon-forward"></span> {{ _('next page') }}</button>
                     </form>
                 </div>
@@ -132,7 +132,7 @@
                     <div class="clearfix"></div>
                     {% for output_type in ('csv', 'json', 'rss') %}
                     <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}" class="form-inline pull-{% if rtl %}right{% else %}left{% endif %} result_download">
-                        {{ search_form_attrs() }}
+                        {{ search_form_attrs(pageno) }}
                         <input type="hidden" name="format" value="{{ output_type }}">
                         <button type="submit" class="btn btn-default">{{ output_type }}</button>
                     </form>


### PR DESCRIPTION
Bugs fixed:
 - broken backward pagination on web UI
 - inability to retrieve the first page of results in JSON, CSV, RSS via the buttons in the search forms
