### PR TITLE
Dockerfile nitpicks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,6 @@ RUN echo "@commuedge http://nl.alpinelinux.org/alpine/edge/community" >> /etc/ap
  && apk del \
     build-base \
     python-dev \
-    py-pip\
     libffi-dev \
     openssl-dev \
     libxslt-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,6 @@ RUN echo "@commuedge http://nl.alpinelinux.org/alpine/edge/community" >> /etc/ap
     build-base \
     python-dev \
     libffi-dev \
-    openssl-dev \
     libxslt-dev \
     libxml2-dev \
     openssl-dev \


### PR DESCRIPTION
removing removal of py-pip fixes this terrifying message at start of searx in docker environment:

```
CRITICAL:searx.webapp:The pyopenssl, ndg-httpsclient, pyasn1 packages have to be installed.
Some HTTPS connections will fail
```

(searx works with or without this fix)