### PR TITLE
Fix #872. Google search works again with docker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,6 @@ RUN echo "@commuedge http://nl.alpinelinux.org/alpine/edge/community" >> /etc/ap
  && apk del \
     build-base \
     python-dev \
-    py-pip\
     libffi-dev \
     openssl-dev \
     libxslt-dev \


### PR DESCRIPTION
All the credit goes to Wonderfall. Thanks for that!
See: https://github.com/Wonderfall/dockerfiles/issues/110