### PR TITLE
[mod] searx doesn't crash at startup when an engine can't be loaded

### DIFF
--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -218,4 +218,5 @@ def get_engines_stats():
 def initialize_engines(engine_list):
     for engine_data in engine_list:
         engine = load_engine(engine_data)
-        engines[engine.name] = engine
+        if engine is not None:
+            engines[engine.name] = engine


### PR DESCRIPTION
see #884

With this PR, searx ignores engine that can't be loaded (the module), instead of crashing.

A reason to keep the actual behavior : 
* it's up to the administrator to adjust the settings.yml and carefully disable the engines which doesn't work.

A reason to accept this PR : 
* the setup is more easy, there are logs. Administrator can start to use searx and then adjust seeing the logs. 