### PR TITLE
ignore double-quotes when highlighting query parts

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -63,3 +63,4 @@ generally made searx better:
 - @firebovine
 - Lorenzo J. Lucchini @luccoj
 - @eig8phei
+- Daniel Hones

--- a/searx/utils.py
+++ b/searx/utils.py
@@ -66,7 +66,10 @@ def highlight_content(content, query):
     else:
         regex_parts = []
         for chunk in query.split():
-            if len(chunk) == 1:
+            chunk = chunk.replace('"', '')
+            if len(chunk) == 0:
+                continue
+            elif len(chunk) == 1:
                 regex_parts.append(u'\\W+{0}\\W+'.format(re.escape(chunk)))
             else:
                 regex_parts.append(u'{0}'.format(re.escape(chunk)))

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -34,6 +34,21 @@ class TestUtils(SearxTestCase):
         self.assertEqual(utils.highlight_content(content, query), content)
         query = 'a test'
         self.assertEqual(utils.highlight_content(content, query), content)
+        content = 'this is a test string that matches entire query'
+        highlighted = 'this is <span class="highlight">a test</span> string that matches entire query'
+        self.assertEqual(utils.highlight_content(content, query), highlighted)
+
+        query = 'this a test'
+        content = 'this is a string to test.'
+        highlighted = '<span class="highlight">this</span> is<span class="highlight"> a </span>' + \
+                      'string to <span class="highlight">test</span>.'
+        self.assertEqual(utils.highlight_content(content, query), highlighted)
+
+        query = 'match this "exact phrase"'
+        content = 'this string contains the exact phrase we want to match'
+        highlighted = '<span class="highlight">this</span> string contains the <span class="highlight">exact</span>' + \
+                      ' <span class="highlight">phrase</span> we want to <span class="highlight">match</span>'
+        self.assertEqual(utils.highlight_content(content, query), highlighted)
 
     def test_html_to_text(self):
         html = """


### PR DESCRIPTION
This is to fix a minor UI bug where using a search with an exact phrase in quotes wouldn't highlight the matching phrase in the search results.  For example:

search: `master of none`
result: **master of none**

search: `"master of none"`
result: master **of** none