### PR TITLE
Add free software directory engine

### DIFF
--- a/searx/engines/mediawiki.py
+++ b/searx/engines/mediawiki.py
@@ -31,7 +31,7 @@ search_postfix = 'w/api.php?action=query'\
     '&format=json'\
     '&sroffset={offset}'\
     '&srlimit={limit}'\
-    '&srwhat={searchtype}'  # search for a near match in the title
+    '&srwhat={searchtype}'
 
 
 # do search-request

--- a/searx/engines/mediawiki.py
+++ b/searx/engines/mediawiki.py
@@ -21,6 +21,7 @@ categories = ['general']
 language_support = True
 paging = True
 number_of_results = 1
+search_type = 'nearmatch' # possible values: title, text, nearmatch
 
 # search-url
 base_url = 'https://{language}.wikipedia.org/'
@@ -30,7 +31,7 @@ search_postfix = 'w/api.php?action=query'\
     '&format=json'\
     '&sroffset={offset}'\
     '&srlimit={limit}'\
-    '&srwhat=nearmatch'  # search for a near match in the title
+    '&srwhat={searchtype}'  # search for a near match in the title
 
 
 # do search-request
@@ -39,7 +40,8 @@ def request(query, params):
 
     string_args = dict(query=urlencode({'srsearch': query}),
                        offset=offset,
-                       limit=number_of_results)
+                       limit=number_of_results,
+                       searchtype=search_type)
 
     format_strings = list(Formatter().parse(base_url))
 

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -215,6 +215,8 @@ engines:
     categories : it
     base_url : https://directory.fsf.org/
     number_of_results : 5
+# what part of a page matches the query string: title, text, nearmatch
+# title - query matches title, text - query matches the text of page, nearmatch - nearmatch in title
     search_type : title
     timeout : 5.0
     disabled : True

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -209,6 +209,16 @@ engines:
 # Or you can use the html non-stable engine, activated by default
     engine : flickr_noapi
 
+  - name : free software directory
+    engine : mediawiki
+    shortcut : fsd
+    categories : it
+    base_url : https://directory.fsf.org/
+    number_of_results : 5
+    search_type : title
+    timeout : 5.0
+    disabled : True
+
   - name : frinkiac
     engine : frinkiac
     shortcut : frk


### PR DESCRIPTION
The engine was added in IT category. I haven't added software category, because I think it fits perfectly in IT category. However, if someone wants to change the category, it is possible to change `it` to `software` in `settings.yml`.

Closes #909