### PR TITLE
[fix] fix duckduckgo's offset

### DIFF
--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -79,16 +79,15 @@ def request(query, params):
     if params['time_range'] and params['time_range'] not in time_range_dict:
         return params
 
-    offset = 30 + (params['pageno'] - 1) * 50
-    dc_param = offset + 1
+    offset = (params['pageno'] - 1) * 30
 
     region_code = get_region_code(params['language'])
     if region_code:
         params['url'] = url.format(
-            query=urlencode({'q': query, 'kl': region_code}), offset=offset, dc_param=dc_param)
+            query=urlencode({'q': query, 'kl': region_code}), offset=offset, dc_param=offset)
     else:
         params['url'] = url.format(
-            query=urlencode({'q': query}), offset=offset, dc_param=dc_param)
+            query=urlencode({'q': query}), offset=offset, dc_param=offset)
 
     if params['time_range'] in time_range_dict:
         params['url'] += time_range_url.format(range=time_range_dict[params['time_range']])

--- a/tests/unit/engines/test_duckduckgo.py
+++ b/tests/unit/engines/test_duckduckgo.py
@@ -18,6 +18,7 @@ class TestDuckduckgoEngine(SearxTestCase):
         self.assertIn(query, params['url'])
         self.assertIn('duckduckgo.com', params['url'])
         self.assertIn('ch-de', params['url'])
+        self.assertIn('s=0', params['url'])
 
         # when ddg uses non standard code
         dicto['language'] = 'en-GB'


### PR DESCRIPTION
First page now starts with 0 offset, rather than starting on the 30th result.

DuckDuckGo returns 30 results on each page.