### PR TITLE
show engine errors in infobox && add new error alert

### DIFF
--- a/searx/results.py
+++ b/searx/results.py
@@ -135,6 +135,7 @@ class ResultContainer(object):
         self._number_of_results = []
         self._ordered = False
         self.paging = False
+        self.unresponsive_engines = []
 
     def extend(self, engine_name, results):
         for result in list(results):
@@ -304,3 +305,6 @@ class ResultContainer(object):
         if not resultnum_sum or not self._number_of_results:
             return 0
         return resultnum_sum / len(self._number_of_results)
+
+    def add_unresponsive_engine(self, engine_name):
+        self.unresponsive_engines.append(engine_name)

--- a/searx/search.py
+++ b/searx/search.py
@@ -20,6 +20,7 @@ import sys
 import threading
 from time import time
 from uuid import uuid4
+from flask_babel import gettext
 import requests.exceptions
 import searx.poolrequests as requests_lib
 from searx.engines import (
@@ -133,18 +134,21 @@ def search_one_request_safe(engine_name, query, request_params, result_container
         requests_exception = False
 
         if (issubclass(e.__class__, requests.exceptions.Timeout)):
+            result_container.add_unresponsive_engine((engine_name, gettext('timeout')))
             # requests timeout (connect or read)
             logger.error("engine {0} : HTTP requests timeout"
                          "(search duration : {1} s, timeout: {2} s) : {3}"
                          .format(engine_name, search_duration, timeout_limit, e.__class__.__name__))
             requests_exception = True
         elif (issubclass(e.__class__, requests.exceptions.RequestException)):
+            result_container.add_unresponsive_engine((engine_name, gettext('request exception')))
             # other requests exception
             logger.exception("engine {0} : requests exception"
                              "(search duration : {1} s, timeout: {2} s) : {3}"
                              .format(engine_name, search_duration, timeout_limit, e))
             requests_exception = True
         else:
+            result_container.add_unresponsive_engine((engine_name, gettext('unexpected crash')))
             # others errors
             logger.exception('engine {0} : exception : {1}'.format(engine_name, e))
 

--- a/searx/templates/oscar/messages/no_results.html
+++ b/searx/templates/oscar/messages/no_results.html
@@ -2,6 +2,11 @@
 {% if unresponsive_engines %}
 <div class="alert alert-danger fade in" role="alert">
     <p><strong class="lead">{{ icon('remove-sign') }} {{ _('Error!') }}</strong> {{ _('Engines cannot retrieve results.') }}</p>
+    <p>
+        {% for engine_name, error_type in unresponsive_engines %}
+        {{ engine_name }} ({{ error_type }}){% if not loop.last %}, {% endif %}
+        {% endfor %}
+    </p>
     <p><small>{{ _('Please, try again later or find another searx instance.') }}</small></p>
 </div>
 {% else %}

--- a/searx/templates/oscar/messages/no_results.html
+++ b/searx/templates/oscar/messages/no_results.html
@@ -1,9 +1,12 @@
 {% from 'oscar/macros.html' import icon %}
+{% if unresponsive_engines %}
+<div class="alert alert-danger fade in" role="alert">
+    <p><strong class="lead">{{ icon('remove-sign') }} {{ _('Error!') }}</strong> {{ _('Engines cannot retrieve results.') }}</p>
+    <p><small>{{ _('Please, try again later or find another searx instance.') }}</small></p>
+</div>
+{% else %}
 <div class="alert alert-info fade in" role="alert">
-    <button class="close" data-dismiss="alert" type="button">
-        <span aria-hidden="true">×</span>
-        <span class="sr-only">{{ _('Close') }}</span>
-    </button>
     <strong class="lead">{{ icon('info-sign') }} {{ _('Sorry!') }}</strong>
     {{ _('we didn\'t find any results. Please use another query or search in more categories.') }}
 </div>
+{% endif %}

--- a/searx/templates/oscar/results.html
+++ b/searx/templates/oscar/results.html
@@ -94,6 +94,16 @@
             {% if number_of_results != '0' %}
                 <p><small>{{ _('Number of results') }}: {{ number_of_results }}</small></p>
             {% endif %}
+
+            {% if unresponsive_engines and results|length >= 1 %}
+            <div class="alert alert-danger fade in" role="alert">
+                <p>{{ _('Engines cannot retrieve results') }}:</p>
+                {% for engine_name, error_type in unresponsive_engines %}
+                {{ engine_name }} ({{ error_type }}){% if not loop.last %}, {% endif %}
+                {% endfor %}
+            </div>
+            {% endif %}
+
             {% if infoboxes %}
                 {% for infobox in infoboxes %}
                     {% include 'oscar/infobox.html' %}

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -534,7 +534,8 @@ def index():
                                     'answers': list(result_container.answers),
                                     'corrections': list(result_container.corrections),
                                     'infoboxes': result_container.infoboxes,
-                                    'suggestions': list(result_container.suggestions)}),
+                                    'suggestions': list(result_container.suggestions),
+                                    'unresponsive_engines': list(result_container.unresponsive_engines)}),
                         mimetype='application/json')
     elif output_format == 'csv':
         csv = UnicodeWriter(StringIO())
@@ -573,6 +574,7 @@ def index():
         corrections=result_container.corrections,
         infoboxes=result_container.infoboxes,
         paging=result_container.paging,
+        unresponsive_engines=result_container.unresponsive_engines,
         current_language=search_query.lang,
         base_url=get_base_url(),
         theme=get_current_theme_name(),

--- a/tests/unit/test_webapp.py
+++ b/tests/unit/test_webapp.py
@@ -39,6 +39,7 @@ class ViewsTestCase(SearxTestCase):
                                                 corrections=set(),
                                                 suggestions=set(),
                                                 infoboxes=[],
+                                                unresponsive_engines=[],
                                                 results=self.test_results,
                                                 results_number=lambda: 3,
                                                 results_length=lambda: len(self.test_results))


### PR DESCRIPTION
From now on engine errors with type name are visible to users. I also removed the unnecessary close button from the "no result" alert.

![error_wo_results](https://user-images.githubusercontent.com/3876218/28122593-eb7e93a2-671e-11e7-844e-71d6a83cbb76.png)

![error_w_result](https://user-images.githubusercontent.com/3876218/28122599-f007d294-671e-11e7-9bea-a95ab9e0ed95.png)
