### PR TITLE
Add XML parser to fix encoding error

### DIFF
--- a/searx/engines/base.py
+++ b/searx/engines/base.py
@@ -74,7 +74,7 @@ def response(resp):
     results = []
 
     parser = etree.XMLParser()
-    search_results = etree.XML(resp.text), parser)
+    search_results = etree.XML(resp.text, parser)
 
     for entry in search_results.xpath('./result/doc'):
         content = "No description available"

--- a/searx/engines/base.py
+++ b/searx/engines/base.py
@@ -73,7 +73,8 @@ def request(query, params):
 def response(resp):
     results = []
 
-    search_results = etree.XML(resp.text)
+    parser = etree.XMLParser()
+    search_results = etree.XML(resp.text), parser)
 
     for entry in search_results.xpath('./result/doc'):
         content = "No description available"


### PR DESCRIPTION
BASE engine (in Science category) has an encoding error.

Traceback of the corresponding error:

>ERROR:searx.search:engine base : exception : Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.
Traceback (most recent call last):
  File "/home/u/abc/searx/searx/search.py", line 117, in search_one_request_safe
    search_results = search_one_request(engine, query, request_params, start_time, timeout_limit)
  File "/home/u/abc/searx/searx/search.py", line 109, in search_one_request
    return engine.response(response)
  File "/home/u/abc/searx/searx/engines/base.py", line 76, in response
    search_results = etree.XML(resp.text)
  File "src/lxml/lxml.etree.pyx", line 3192, in lxml.etree.XML (src/lxml/lxml.etree.c:77490)
  File "src/lxml/parser.pxi", line 1825, in lxml.etree._parseMemoryDocument (src/lxml/lxml.etree.c:116615)
ValueError: Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.

Addition of an xml parser solves this.