### PR TITLE
Add missing timeouts

### DIFF
--- a/searx/results.py
+++ b/searx/results.py
@@ -135,7 +135,7 @@ class ResultContainer(object):
         self._number_of_results = []
         self._ordered = False
         self.paging = False
-        self.unresponsive_engines = []
+        self.unresponsive_engines = set()
 
     def extend(self, engine_name, results):
         for result in list(results):
@@ -306,5 +306,5 @@ class ResultContainer(object):
             return 0
         return resultnum_sum / len(self._number_of_results)
 
-    def add_unresponsive_engine(self, engine_name):
-        self.unresponsive_engines.append(engine_name)
+    def add_unresponsive_engine(self, engine_error):
+        self.unresponsive_engines.add(engine_error)

--- a/searx/search.py
+++ b/searx/search.py
@@ -179,6 +179,7 @@ def search_multiple_requests(requests, result_container, start_time, timeout_lim
             remaining_time = max(0.0, timeout_limit - (time() - start_time))
             th.join(remaining_time)
             if th.isAlive():
+                result_container.add_unresponsive_engine((th._engine_name, gettext('timeout')))
                 logger.warning('engine timeout: {0}'.format(th._engine_name))
 
 

--- a/tests/unit/test_webapp.py
+++ b/tests/unit/test_webapp.py
@@ -39,7 +39,7 @@ class ViewsTestCase(SearxTestCase):
                                                 corrections=set(),
                                                 suggestions=set(),
                                                 infoboxes=[],
-                                                unresponsive_engines=[],
+                                                unresponsive_engines=set(),
                                                 results=self.test_results,
                                                 results_number=lambda: 3,
                                                 results_length=lambda: len(self.test_results))


### PR DESCRIPTION
As pointed out by @dalf in https://github.com/asciimoo/searx/pull/961#issuecomment-315597756, a timeout error was missing. I added this to the existing errors.

Furthermore, to eliminate duplication of errors `unresponsive_engines` is changed to `set` from `list`.