### PR TITLE
fix hmac python3 compatibility

### DIFF
--- a/searx/utils.py
+++ b/searx/utils.py
@@ -1,4 +1,6 @@
 import csv
+import hashlib
+import hmac
 import os
 import re
 
@@ -321,3 +323,10 @@ def load_module(filename, module_dir):
     module = load_source(modname, filepath)
     module.name = modname
     return module
+
+
+def new_hmac(secret_key, url):
+    if sys.version_info[0] == 2:
+        return hmac.new(bytes(secret_key), url, hashlib.sha256).hexdigest()
+    else:
+        return hmac.new(bytes(secret_key, 'utf-8'), url, hashlib.sha256).hexdigest()

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -69,6 +69,7 @@ from searx.plugins import plugins
 from searx.preferences import Preferences, ValidationException
 from searx.answerers import answerers
 from searx.url_utils import urlencode, urlparse, urljoin
+from searx.utils import new_hmac
 
 # check if the pyopenssl package is installed.
 # It is needed for SSL connection without trouble, see #298
@@ -290,7 +291,7 @@ def image_proxify(url):
     if settings.get('result_proxy'):
         return proxify(url)
 
-    h = hmac.new(settings['server']['secret_key'], url.encode('utf-8'), hashlib.sha256).hexdigest()
+    h = new_hmac(settings['server']['secret_key'], url.encode('utf-8'))
 
     return '{0}?{1}'.format(url_for('image_proxy'),
                             urlencode(dict(url=url.encode('utf-8'), h=h)))
@@ -704,7 +705,7 @@ def image_proxy():
     if not url:
         return '', 400
 
-    h = hmac.new(settings['server']['secret_key'], url, hashlib.sha256).hexdigest()
+    h = new_hmac(settings['server']['secret_key'], url)
 
     if h != request.args.get('h'):
         return '', 400
@@ -731,7 +732,7 @@ def image_proxy():
         logger.debug('image-proxy: wrong content-type: {0}'.format(resp.headers.get('content-type')))
         return '', 400
 
-    img = ''
+    img = b''
     chunk_counter = 0
 
     for chunk in resp.iter_content(1024 * 1024):


### PR DESCRIPTION
A new compatibility layer was introduced to select the proper functions based on Python version. It is similar to the `url_utils` solution, but I created a new module for general compatibility functions. If you don't like this approach, I am open to different solutions. :)

Fixes #968 