### PR TITLE
Chiefr integration - distributed contribution model for searx

### DIFF
--- a/.maintainers.ini
+++ b/.maintainers.ini
@@ -1,0 +1,56 @@
+[engines]
+Repository = https://github.com/asciimoo/searx
+IssueTracker = https://github.com/asciimoo/searx/issues
+Chiefs = asciimoo, kvch
+FilePatterns = searx/engines/.*
+Topics = engine
+Priority = 1
+
+[http backend]
+Repository = https://github.com/dalf/searx
+IssueTracker = https://github.com/dalf/searx/issues
+Chiefs = dalf
+FilePatterns = searx/poolrequests\.py
+Topics = http
+Priority = 1
+
+[plugins]
+Repository = https://github.com/asciimoo/searx
+IssueTracker = https://github.com/asciimoo/searx/issues
+Chiefs = asciimoo
+FilePatterns = searx/plugins/.*
+Topics = engine
+Priority = 1
+
+[simple theme]
+Repository = https://github.com/dalf/searx
+IssueTracker = https://github.com/dalf/searx/issues
+Chiefs = dalf
+FilePatterns = searx/static/themes/simple/.*, searx/templates/simple/.*
+Topics = theme
+Priority = 2
+
+[preferences]
+Repository = https://github.com/kvch/searx
+IssueTracker = https://github.com/kvch/searx/issues
+Chiefs = kvch
+FilePatterns = searx/preferences\.py, templates/.+preferences.+
+Topics = preferences
+Priority = 1
+
+[translations]
+Repository = https://github.com/kvch/searx
+IssueTracker = https://github.com/kvch/searx/issues
+Chiefs = kvch
+FilePatterns = searx/translations/.*
+Topics = translation
+Priority = 1
+
+[tests]
+Repository = https://github.com/asciimoo/searx
+IssueTracker = https://github.com/asciimoo/searx/issues
+Chiefs = asciimoo
+FilePatterns = tests/.*
+Topics = test
+Priority = 1
+

--- a/.maintainers.ini
+++ b/.maintainers.ini
@@ -54,3 +54,10 @@ FilePatterns = tests/.*
 Topics = test
 Priority = 1
 
+[any]
+Repository = https://github.com/asciimoo/searx
+IssueTracker = https://github.com/asciimoo/searx/issues
+Chiefs = asciimoo
+FilePatterns = .*
+Priority = 0
+


### PR DESCRIPTION
Hello,

I'd like to try to decentralize the contribution model of searx because of the following reasons:
 - Reduces the load of maintainers
 - Increases the responsiveness if a contribution arrives
 - Explicitly defines ownership of project parts (segments)
 - Experimenting is always good =)

I've created a tool (https://github.com/asciimoo/chiefr) to support the above idea.
Chiefr requires to define a maintainers file which contains all information about the maintainers and resources of project segments. I already created a minimal `.maintainers.ini` file and added some segments, but it is far from complete.

Please comment, if you have any thoughts about the idea or you want to be a maintainer of a segment of searx, and I'll update the maintainers file. Segment can be any set of files (except empty set) in the repo, even a single engine or just a function.