### PR TITLE
Source ip select

### DIFF
--- a/searx/engines/1337x.py
+++ b/searx/engines/1337x.py
@@ -7,6 +7,7 @@ url = 'https://1337x.to/'
 search_url = url + 'search/{search_term}/{pageno}/'
 categories = ['videos']
 paging = True
+meta = {'ipv6_support': True}
 
 
 def request(query, params):

--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -49,7 +49,9 @@ engine_default_args = {'paging': False,
                        'disabled': False,
                        'suspend_end_time': 0,
                        'continuous_errors': 0,
-                       'time_range_support': False}
+                       'time_range_support': False,
+                       'meta': {
+                           'ipv6_support': False}}
 
 
 def load_engine(engine_data):
@@ -78,6 +80,11 @@ def load_engine(engine_data):
         setattr(engine, param_name, engine_data[param_name])
 
     for arg_name, arg_value in engine_default_args.items():
+        # set meta default values if attribute exists in engine
+        if arg_name == 'meta' and hasattr(engine, arg_name):
+            for meta_name, meta_value in arg_value.items():
+                if meta_name not in engine.meta:
+                    engine.meta[meta_name] = meta_value
         if not hasattr(engine, arg_name):
             setattr(engine, arg_name, arg_value)
 

--- a/searx/engines/archlinux.py
+++ b/searx/engines/archlinux.py
@@ -20,6 +20,7 @@ categories = ['it']
 language_support = True
 paging = True
 base_url = 'https://wiki.archlinux.org'
+meta = {'ipv6_support': True}
 
 # xpath queries
 xpath_results = '//ul[@class="mw-search-results"]/li'

--- a/searx/engines/currency_convert.py
+++ b/searx/engines/currency_convert.py
@@ -12,6 +12,7 @@ if sys.version_info[0] == 3:
 categories = []
 url = 'https://download.finance.yahoo.com/d/quotes.csv?e=.csv&f=sl1d1t1&s={query}=X'
 weight = 100
+meta = {'ipv6_support': True}
 
 parser_re = re.compile(b'.*?(\\d+(?:\\.\\d+)?) ([^.0-9]+) (?:in|to) ([^.0-9]+)', re.I)
 

--- a/searx/engines/dictzone.py
+++ b/searx/engines/dictzone.py
@@ -17,6 +17,7 @@ from searx.url_utils import urljoin
 categories = ['general']
 url = u'http://dictzone.com/{from_lang}-{to_lang}-dictionary/{query}'
 weight = 100
+meta = {'ipv6_support': True}
 
 parser_re = re.compile(b'.*?([a-z]+)-([a-z]+) ([^ ]+)$', re.I)
 results_xpath = './/table[@id="r"]/tr'

--- a/searx/engines/flickr_noapi.py
+++ b/searx/engines/flickr_noapi.py
@@ -36,6 +36,7 @@ time_range_dict = {'day': 60 * 60 * 24,
                    'week': 60 * 60 * 24 * 7,
                    'month': 60 * 60 * 24 * 7 * 4,
                    'year': 60 * 60 * 24 * 7 * 52}
+meta = {'ipv6_support': True}
 
 
 def build_flickr_url(user_id, photo_id):

--- a/searx/engines/framalibre.py
+++ b/searx/engines/framalibre.py
@@ -18,6 +18,7 @@ from searx.url_utils import urljoin, urlencode
 # engine dependent config
 categories = ['it']
 paging = True
+meta = {'ipv6_support': True}
 
 # search-url
 base_url = 'https://framalibre.org/'

--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -23,6 +23,7 @@ paging = True
 language_support = True
 use_locale_domain = True
 time_range_support = True
+meta = {'ipv6_support': True}
 
 # based on https://en.wikipedia.org/wiki/List_of_Google_domains and tests
 default_hostname = 'www.google.com'

--- a/searx/engines/google_images.py
+++ b/searx/engines/google_images.py
@@ -35,6 +35,7 @@ time_range_custom_attr = "cdr:1,cd_min:{start},cd_max{end}"
 time_range_dict = {'day': 'd',
                    'week': 'w',
                    'month': 'm'}
+meta = {'ipv6_support': True}
 
 
 # do search-request

--- a/searx/engines/google_news.py
+++ b/searx/engines/google_news.py
@@ -32,6 +32,7 @@ time_range_dict = {'day': 'd',
                    'week': 'w',
                    'month': 'm',
                    'year': 'y'}
+meta = {'ipv6_support': True}
 
 
 # do search-request

--- a/searx/engines/google_videos.py
+++ b/searx/engines/google_videos.py
@@ -33,7 +33,7 @@ time_range_custom_attr = "cdr:1,cd_min:{start},cd_max{end}"
 time_range_dict = {'day': 'd',
                    'week': 'w',
                    'month': 'm'}
-
+meta = {'ipv6_support': True}
 
 # do search-request
 def request(query, params):

--- a/searx/engines/google_videos.py
+++ b/searx/engines/google_videos.py
@@ -35,6 +35,7 @@ time_range_dict = {'day': 'd',
                    'month': 'm'}
 meta = {'ipv6_support': True}
 
+
 # do search-request
 def request(query, params):
     search_options = {

--- a/searx/engines/kickass.py
+++ b/searx/engines/kickass.py
@@ -19,6 +19,7 @@ from searx.url_utils import quote, urljoin
 # engine dependent config
 categories = ['videos', 'music', 'files']
 paging = True
+meta = {'ipv6_support': True}
 
 # search-url
 url = 'https://kickass.cd/'

--- a/searx/engines/openstreetmap.py
+++ b/searx/engines/openstreetmap.py
@@ -15,6 +15,7 @@ from json import loads
 # engine dependent config
 categories = ['map']
 paging = False
+meta = {'ipv6_support': True}
 
 # search-url
 base_url = 'https://nominatim.openstreetmap.org/'

--- a/searx/engines/piratebay.py
+++ b/searx/engines/piratebay.py
@@ -16,6 +16,7 @@ from searx.url_utils import quote, urljoin
 # engine dependent config
 categories = ['videos', 'music', 'files']
 paging = True
+meta = {'ipv6_support': True}
 
 # search-url
 url = 'https://thepiratebay.se/'

--- a/searx/engines/tokyotoshokan.py
+++ b/searx/engines/tokyotoshokan.py
@@ -20,6 +20,7 @@ from searx.utils import get_torrent_size, int_or_zero
 # engine dependent config
 categories = ['files', 'videos', 'music']
 paging = True
+meta = {'ipv6_support': True}
 
 # search-url
 base_url = 'https://www.tokyotosho.info/'

--- a/searx/engines/torrentz.py
+++ b/searx/engines/torrentz.py
@@ -21,6 +21,7 @@ from searx.utils import get_torrent_size
 # engine dependent config
 categories = ['files', 'videos', 'music']
 paging = True
+meta = {'ipv6_support': True}
 
 # search-url
 # https://torrentz2.eu/search?f=EXAMPLE&p=6

--- a/searx/engines/www1x.py
+++ b/searx/engines/www1x.py
@@ -17,6 +17,7 @@ from searx.url_utils import urlencode, urljoin
 # engine dependent config
 categories = ['images']
 paging = False
+meta = {'ipv6_support': True}
 
 # search-url
 base_url = 'https://1x.com'

--- a/searx/engines/yahoo_news.py
+++ b/searx/engines/yahoo_news.py
@@ -21,6 +21,7 @@ from searx.url_utils import urlencode
 categories = ['news']
 paging = True
 language_support = True
+meta = {'ipv6_support': True}
 
 # search-url
 search_url = 'https://news.search.yahoo.com/search?{query}&b={offset}&{lang}=uh3_news_web_gs_1&pz=10&xargs=0&vl=lang_{lang}'  # noqa

--- a/searx/engines/youtube_noapi.py
+++ b/searx/engines/youtube_noapi.py
@@ -18,6 +18,7 @@ categories = ['videos', 'music']
 paging = True
 language_support = False
 time_range_support = True
+meta = {'ipv6_support': True}
 
 # search-url
 base_url = 'https://www.youtube.com/results'

--- a/searx/poolrequests.py
+++ b/searx/poolrequests.py
@@ -57,7 +57,7 @@ else:
 
 class SessionSinglePool(requests.Session):
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         super(SessionSinglePool, self).__init__()
 
         # reuse the same adapters
@@ -74,7 +74,7 @@ class SessionSinglePool(requests.Session):
 
 def request(method, url, **kwargs):
     """same as requests/requests/api.py request(...) except it use SessionSinglePool and force proxies"""
-    session = SessionSinglePool()
+    session = SessionSinglePool(ipv6_support=kwargs.pop('ipv6_support', False))
     kwargs['proxies'] = settings['outgoing'].get('proxies') or None
     response = session.request(method=method, url=url, **kwargs)
     session.close()

--- a/searx/poolrequests.py
+++ b/searx/poolrequests.py
@@ -86,9 +86,12 @@ class SessionSinglePool(requests.Session):
                 if kwargs['ipv6_support'] and 'ipv6' in https_adapters['source_ip']:
                     self.mount('https://', next(https_adapters['source_ip']['ipv6']))
                     self.mount('http://', next(http_adapters['source_ip']['ipv6']))
-                else:
+                elif 'ipv4' in https_adapters['source_ip']:
                     self.mount('https://', next(https_adapters['source_ip']['ipv4']))
                     self.mount('http://', next(http_adapters['source_ip']['ipv4']))
+                else:
+                    self.mount('https://', next(https_adapters['default_ip']))
+                    self.mount('http://', next(http_adapters['default_ip']))
             else:
                 self.mount('https://', next(https_adapters['default_ip']))
                 self.mount('http://', next(http_adapters['default_ip']))

--- a/searx/poolrequests.py
+++ b/searx/poolrequests.py
@@ -42,7 +42,7 @@ class HTTPAdapterWithConnParams(requests.adapters.HTTPAdapter):
                               block=self._pool_block, **self._conn_params)
 
 
-def get_random_http_adapter(connect, maxsize, ips=False):
+def get_random_http_adapter_pool(connect, maxsize, ips=False):
     if ips:
         return dictrandom(HTTPAdapterWithConnParams(pool_connections=connect, pool_maxsize=maxsize,
                                                     source_address=(source_ip, 0))
@@ -63,15 +63,15 @@ if settings['outgoing'].get('source_ips'):
         https_adapters['source_ip'] = {}
 
         if len(ips['ipv4']) > 0:
-            http_adapters['source_ip']['ipv4'] = get_random_http_adapter(connect, maxsize, ips['ipv4'])
-            https_adapters['source_ip']['ipv4'] = get_random_http_adapter(connect, maxsize, ips['ipv4'])
+            http_adapters['source_ip']['ipv4'] = get_random_http_adapter_pool(connect, maxsize, ips['ipv4'])
+            https_adapters['source_ip']['ipv4'] = get_random_http_adapter_pool(connect, maxsize, ips['ipv4'])
 
         if len(ips['ipv6']) > 0:
-            http_adapters['source_ip']['ipv6'] = get_random_http_adapter(connect, maxsize, ips['ipv6'])
-            https_adapters['source_ip']['ipv6'] = get_random_http_adapter(connect, maxsize, ips['ipv6'])
+            http_adapters['source_ip']['ipv6'] = get_random_http_adapter_pool(connect, maxsize, ips['ipv6'])
+            https_adapters['source_ip']['ipv6'] = get_random_http_adapter_pool(connect, maxsize, ips['ipv6'])
 
-http_adapters['default_ip'] = get_random_http_adapter(connect, maxsize)
-https_adapters['default_ip'] = get_random_http_adapter(connect, maxsize)
+http_adapters['default_ip'] = get_random_http_adapter_pool(connect, maxsize)
+https_adapters['default_ip'] = get_random_http_adapter_pool(connect, maxsize)
 
 
 class SessionSinglePool(requests.Session):

--- a/searx/search.py
+++ b/searx/search.py
@@ -67,6 +67,8 @@ def send_http_request(engine, request_params, start_time, timeout_limit):
         req = requests_lib.post
         request_args['data'] = request_params['data']
 
+    request_args['ipv6_support'] = engine.meta['ipv6_support']
+
     # send the request
     response = req(request_params['url'], **request_args)
 

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -96,6 +96,8 @@ engines:
     timeout : 4.0
     disabled : True
     shortcut : bb
+    meta :
+        ipv6_support : True
 
   - name : ccc-tv
     engine : xpath
@@ -107,6 +109,8 @@ engines:
     categories : videos
     disabled : True
     shortcut : c3tv
+    meta :
+        ipv6_support : True
 
   - name : crossref
     engine : json_engine
@@ -297,6 +301,8 @@ engines:
     categories : files
     shortcut : gpa
     disabled : True
+    meta :
+        ipv6_support : True
 
   - name : google play movies
     engine        : xpath
@@ -307,6 +313,8 @@ engines:
     categories : videos
     shortcut : gpm
     disabled : True
+    meta :
+        ipv6_support : True
 
   - name : google play music
     engine        : xpath
@@ -317,6 +325,8 @@ engines:
     categories : music
     shortcut : gps
     disabled : True
+    meta :
+        ipv6_support : True
 
   - name : geektimes
     engine : xpath
@@ -353,6 +363,8 @@ engines:
     page_size : 20
     categories : it
     shortcut : ho
+    meta :
+        ipv6_support : True
 
   - name : ina
     engine : ina
@@ -386,6 +398,8 @@ engines:
     content_xpath : .//a[@class="domain"]
     categories : it
     shortcut : lo
+    meta :
+        ipv6_support : True
 
   - name : microsoft academic
     engine : json_engine
@@ -424,6 +438,8 @@ engines:
     timeout : 4.0
     disabled : True
     shortcut : or
+    meta :
+        ipv6_support : True
 
   - name : pdbe
     engine : pdbe
@@ -648,6 +664,8 @@ engines:
     content_xpath : //div[@class="entry"]/p/span[@class="domain"]
     timeout : 10.0
     disabled : True
+    meta :
+        ipv6_support : True
 
   - name : 1337x
     engine : 1337x

--- a/searx/utils.py
+++ b/searx/utils.py
@@ -330,3 +330,14 @@ def new_hmac(secret_key, url):
         return hmac.new(bytes(secret_key), url, hashlib.sha256).hexdigest()
     else:
         return hmac.new(bytes(secret_key, 'utf-8'), url, hashlib.sha256).hexdigest()
+
+
+class dictrandom:
+    def __init__(self, d):
+        self.d = list(d)
+
+    def __iter__(self):
+        return self
+
+    def next(self):
+        return choice(self.d)

--- a/searx/utils.py
+++ b/searx/utils.py
@@ -10,6 +10,7 @@ from imp import load_source
 from os.path import splitext, join
 from random import choice
 import sys
+import socket
 
 from searx.version import VERSION_STRING
 from searx.languages import language_codes
@@ -341,3 +342,23 @@ class dictrandom:
 
     def next(self):
         return choice(self.d)
+
+
+def part_ip_versions(ip_addresses):
+    ipv4 = []
+    ipv6 = []
+    for ip_address in ip_addresses:
+        try:
+            if socket.inet_pton(socket.AF_INET6, ip_address):
+                ipv6.append(ip_address)
+                continue
+        except socket.error:
+            pass
+        try:
+            if socket.inet_pton(socket.AF_INET, ip_address):
+                ipv4.append(ip_address)
+                continue
+        except socket.error:
+            pass
+        logger.debug('Invalid ip address specified: %s' % ip_address)
+    return {'ipv6': ipv6, 'ipv4': ipv4}

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -65,6 +65,20 @@ class TestUtils(SearxTestCase):
         for test_url, expected in data:
             self.assertEqual(utils.prettify_url(test_url, max_length=32), expected)
 
+    def test_part_ip_versions(self):
+        self.assertDictEqual(utils.part_ip_versions(['1.2.3.4']), {
+            'ipv4': ['1.2.3.4'],
+            'ipv6': []})
+        self.assertDictEqual(utils.part_ip_versions(['2001:0db8:0a0b:12f0:0000:0000:0000:0001']), {
+            'ipv4': [],
+            'ipv6': ['2001:0db8:0a0b:12f0:0000:0000:0000:0001']})
+        self.assertDictEqual(utils.part_ip_versions(['2001:0db8:0a0b:12f0:0000:0000:0000:0001', '1.2.3.4']), {
+            'ipv4': ['1.2.3.4'],
+            'ipv6': ['2001:0db8:0a0b:12f0:0000:0000:0000:0001']})
+        self.assertDictEqual(utils.part_ip_versions(['deadbeef']), {
+            'ipv4': [],
+            'ipv6': []})
+
 
 class TestHTMLTextExtractor(SearxTestCase):
 


### PR DESCRIPTION
Basically how it works is that in poolrequests.py, the source_ips from the config are extracted to `http(s)_adapters['source_ip']` by ip versions respectively.
Then, when it is needed, in `SessionSinglePool` the adapters are assigned by whether the engine supports ipv6 and there is at least one ipv6 source ip is present, or if not, if an ipv4 source ip is present. In any other case, the default interface is used.
`searx.utils.dictrandom` is an iterator wrapper for `random.choice`
The decision if an engine supports ipv6 is the following: a new attribute for every engine is introduced, called "meta", and the key ipv6_support of this dict decides it, which defaults to False. Overwriting this key in either the [engine].py or in settings.yml will cause the engine to "support ipv6".
The configuration of source ips are fault tolerant in a way that if there is an entry which is not a valid ip address, it ignores it, and writes a debug message telling that entry is invalid.
This PR should solve #1028
Since this PR rewrites some parts of how the poolrequests works, **I recommend extensive testing** especially with the combination of different source ips.