### PR TITLE
add pubmed engine

### DIFF
--- a/searx/engines/pubmed.py
+++ b/searx/engines/pubmed.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+
+"""
+ PubMed (Scholar publications)
+
+ @website     https://www.ncbi.nlm.nih.gov/pubmed/
+ @provide-api yes (https://www.ncbi.nlm.nih.gov/home/develop/api/)
+
+ @using-api   yes
+ @results     XML
+ @stable      yes
+ @parse       url, title, publishedDate, content
+ More info on api: https://www.ncbi.nlm.nih.gov/books/NBK25501/
+"""
+
+from lxml import etree
+from datetime import datetime
+from searx.url_utils import urlencode
+import urllib2
+
+
+categories = ['science']
+
+base_url = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi'\
+           + '?db=pubmed&{query}&retstart={offset}&retmax={hits}'
+
+# engine dependent config
+number_of_results = 10
+pubmed_url = 'https://www.ncbi.nlm.nih.gov/pubmed/'
+
+
+def request(query, params):
+    # basic search
+    offset = (params['pageno'] - 1) * number_of_results
+
+    string_args = dict(query=urlencode({'term': query}),
+                       offset=offset,
+                       hits=number_of_results)
+
+    params['url'] = base_url.format(**string_args)
+
+    return params
+
+
+def response(resp):
+    results = []
+
+    # First retrieve notice of each result
+    pubmed_retrieve_api_url = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?'\
+                              + 'db=pubmed&retmode=xml&id={pmids_string}'
+
+    pmids_results = etree.XML(resp.text.encode('utf8'))
+    pmids = pmids_results.xpath('//eSearchResult/IdList/Id')
+    pmids_string = ''
+
+    for item in pmids:
+        pmids_string += item.text + ','
+
+    retrieve_notice_args = dict(pmids_string=pmids_string)
+
+    retrieve_url_encoded = pubmed_retrieve_api_url.format(**retrieve_notice_args)
+
+    search_results_xml = urllib2.urlopen(retrieve_url_encoded).read()
+    search_results = etree.XML(search_results_xml).xpath('//PubmedArticleSet/PubmedArticle/MedlineCitation')
+
+    for entry in search_results:
+        title = entry.xpath('.//Article/ArticleTitle')[0].text
+
+        # Optional: redirect directly to article page and if no DOI, redirect to PubMed
+        # try:
+        #     doi = entry.xpath('.//Article/ELocationID[@EIdType="doi"]')[0].text
+        #     doi_resoler_url = 'http://oadoi.org/'
+        #     url = doi_resolver_url + doi
+        # except:
+        pmid = entry.xpath('.//PMID')[0].text
+        url = pubmed_url + pmid
+
+        returned_content = entry.xpath('.//Abstract/AbstractText')[0].text
+
+        # Optional: if a doi is available, add it to the snipppet and make it clickable
+        # try:
+        #     doi = entry.xpath('.//ELocationID[@EIdType="doi"]')[0].text
+        #     doi_resolver_url = 'http://oadoi.org/'
+        #     resolve_doi_html = '<a href="' + doi_resolver_url + doi + '">' + doi + '</a> '
+        #     content = resolve_doi_html + returned_content
+        # except:
+        #     content = returned_content
+
+        if len(returned_content) > 300:
+                    content = returned_content[0:300] + "..."
+        # TODO: center snippet on query term
+
+        publishedDate = datetime.strptime(entry.xpath('.//DateCreated/Year')[0].text
+                                          + '-' + entry.xpath('.//DateCreated/Month')[0].text
+                                          + '-' + entry.xpath('.//DateCreated/Day')[0].text, '%Y-%m-%d')
+
+        res_dict = {'url': url,
+                    'title': title,
+                    'publishedDate': publishedDate,
+                    'content': content}
+
+        results.append(res_dict)
+
+    return results

--- a/searx/engines/pubmed.py
+++ b/searx/engines/pubmed.py
@@ -16,7 +16,12 @@
 from lxml import etree
 from datetime import datetime
 from searx.url_utils import urlencode
-import urllib2
+try:
+    # For Python 3.0 and later
+    from urllib.request import urlopen
+except ImportError:
+    # Fall back to Python 2's urllib2
+    from urllib2 import urlopen
 
 
 categories = ['science']
@@ -60,7 +65,7 @@ def response(resp):
 
     retrieve_url_encoded = pubmed_retrieve_api_url.format(**retrieve_notice_args)
 
-    search_results_xml = urllib2.urlopen(retrieve_url_encoded).read()
+    search_results_xml = urlopen(retrieve_url_encoded).read()
     search_results = etree.XML(search_results_xml).xpath('//PubmedArticleSet/PubmedArticle/MedlineCitation')
 
     for entry in search_results:

--- a/searx/engines/pubmed.py
+++ b/searx/engines/pubmed.py
@@ -54,7 +54,12 @@ def response(resp):
     pubmed_retrieve_api_url = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?'\
                               + 'db=pubmed&retmode=xml&id={pmids_string}'
 
-    pmids_results = etree.XML(resp.text.encode('utf8'))
+    # handle Python2 vs Python3 management of bytes and strings
+    try:
+        pmids_results = etree.XML(resp.text.encode('utf-8'))
+    except AttributeError:
+        pmids_results = etree.XML(resp.text)
+
     pmids = pmids_results.xpath('//eSearchResult/IdList/Id')
     pmids_string = ''
 

--- a/searx/engines/pubmed.py
+++ b/searx/engines/pubmed.py
@@ -15,13 +15,7 @@
 
 from lxml import etree
 from datetime import datetime
-from searx.url_utils import urlencode
-try:
-    # For Python 3.0 and later
-    from urllib.request import urlopen
-except ImportError:
-    # Fall back to Python 2's urllib2
-    from urllib2 import urlopen
+from searx.url_utils import urlencode, urlopen
 
 
 categories = ['science']

--- a/searx/engines/pubmed.py
+++ b/searx/engines/pubmed.py
@@ -75,7 +75,10 @@ def response(resp):
         pmid = entry.xpath('.//PMID')[0].text
         url = pubmed_url + pmid
 
-        returned_content = entry.xpath('.//Abstract/AbstractText')[0].text
+        try:
+            content = entry.xpath('.//Abstract/AbstractText')[0].text
+        except:
+            content = 'No abstract is available for this publication.'
 
         # Optional: if a doi is available, add it to the snipppet and make it clickable
         # try:
@@ -86,8 +89,8 @@ def response(resp):
         # except:
         #     content = returned_content
 
-        if len(returned_content) > 300:
-                    content = returned_content[0:300] + "..."
+        if len(content) > 300:
+                    content = content[0:300] + "..."
         # TODO: center snippet on query term
 
         publishedDate = datetime.strptime(entry.xpath('.//DateCreated/Year')[0].text

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -441,6 +441,11 @@ engines:
     shortcut : tpb
     url: https://pirateproxy.red/
     timeout : 3.0
+    
+  - name : pubmed
+    engine : pubmed
+    shortcut : pub
+    categories: science
 
   - name : qwant
     engine : qwant

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1,3 +1,4 @@
+ed
 general:
     debug : False # Debug mode, only for development
     instance_name : "searx" # displayed name
@@ -18,20 +19,18 @@ server:
 ui:
     static_path : "" # Custom static path - leave it blank if you didn't change
     templates_path : "" # Custom templates path - leave it blank if you didn't change
-    default_theme : oscar # ui theme
-    default_locale : "" # Default interface locale - leave blank to detect from browser information or use codes from the 'locales' config section
+    default_theme : oscar # ui theme    default_locale : "" # Default interface locale - leave blank to detect from browser information or use codes from the 'locales' config section
 
 # searx supports result proxification using an external service: https://github.com/asciimoo/morty
 # uncomment below section if you have running morty proxy
 #result_proxy:
-#    url : http://127.0.0.1:3000/
-#    key : your_morty_proxy_key
+#    url : http://127.0.0.1:3000/#    key : your_morty_proxy_key
 
 outgoing: # communication with search engines
     request_timeout : 2.0 # seconds
     useragent_suffix : "" # suffix of searx_useragent, could contain informations like an email address to the administrator
     pool_connections : 100 # Number of different hosts
-    pool_maxsize : 10 # Number of simultaneous requests by host
+    pool_maxsize : 10 # Number of simultaneous requests by hostpubmed
 # uncomment below section if you want to use a proxy
 # see http://docs.python-requests.org/en/latest/user/advanced/#proxies
 # SOCKS proxies are also supported: see http://docs.python-requests.org/en/master/user/advanced/#socks
@@ -446,6 +445,7 @@ engines:
     engine : pubmed
     shortcut : pub
     categories: science
+    oa_first : false
 
   - name : qwant
     engine : qwant

--- a/searx/url_utils.py
+++ b/searx/url_utils.py
@@ -3,6 +3,7 @@ from sys import version_info
 if version_info[0] == 2:
     from urllib import quote, quote_plus, unquote, urlencode
     from urlparse import parse_qsl, urljoin, urlparse, urlunparse, ParseResult
+    from urllib2 import urlopen
 else:
     from urllib.parse import (
         parse_qsl,
@@ -15,6 +16,7 @@ else:
         urlunparse,
         ParseResult
     )
+    from urllib.request import urlopen
 
 
 __export__ = (parse_qsl,

--- a/tests/unit/engines/test_pubmed.py
+++ b/tests/unit/engines/test_pubmed.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+from collections import defaultdict
+import mock
+from searx.engines import pubmed
+from searx.testing import SearxTestCase
+
+
+class TestPubmedEngine(SearxTestCase):
+
+    def test_request(self):
+        query = 'test_query'
+        dicto = defaultdict(dict)
+        dicto['pageno'] = 1
+        params = pubmed.request(query, dicto)
+        self.assertIn('url', params)
+        self.assertIn('eutils.ncbi.nlm.nih.gov/', params['url'])
+        self.assertIn('term', params['url'])
+
+    def test_response(self):
+        self.assertRaises(AttributeError, pubmed.response, None)
+        self.assertRaises(AttributeError, pubmed.response, [])
+        self.assertRaises(AttributeError, pubmed.response, '')
+        self.assertRaises(AttributeError, pubmed.response, '[]')
+
+        response = mock.Mock(text='<PubmedArticleSet></PubmedArticleSet>')
+        self.assertEqual(pubmed.response(response), [])
+
+        xml_mock = """<eSearchResult><Count>1</Count><RetMax>1</RetMax><RetStart>0</RetStart><IdList>
+<Id>1</Id>
+</IdList></eSearchResult>
+"""
+# The engine retrieves abstracts with a second api call, hence testing indirectly
+#         xml_res_mock = """<PubmedArticleSet>
+# <PubmedArticle>
+#     <MedlineCitation Status="MEDLINE" Owner="NLM">
+#         <PMID Version="1">87654321</PMID>
+#         <DateCreated>
+#             <Year>2000</Year>
+#             <Month>01</Month>
+#             <Day>01</Day>
+#         </DateCreated>
+#         <DateCompleted>
+#             <Year>2000</Year>
+#             <Month>01</Month>
+#             <Day>01</Day>
+#         </DateCompleted>
+#         <DateRevised>
+#             <Year>2000</Year>
+#             <Month>01</Month>
+#             <Day>01</Day>
+#         </DateRevised>
+#         <Article PubModel="Print-Electronic">
+#             <Journal>
+#                 <ISSN IssnType="Electronic">1111-1111</ISSN>
+#                 <JournalIssue CitedMedium="Internet">
+#                     <Volume>01</Volume>
+#                     <Issue>1</Issue>
+#                     <PubDate>
+#                         <Year>2000</Year>
+#                         <Month>Jan</Month>
+#                     </PubDate>
+#                 </JournalIssue>
+#                 <Title>Journal of Anything</Title>
+#                 <ISOAbbreviation>J. An.</ISOAbbreviation>
+#             </Journal>
+#             <ArticleTitle>This experiment was something.</ArticleTitle>
+#             <Pagination>
+#                 <MedlinePgn>111-11</MedlinePgn>
+#             </Pagination>
+#             <ELocationID EIdType="doi" ValidYN="Y">10.1000/xyz123</ELocationID>
+#             <Abstract>
+#                 <AbstractText>This experiment was abstract. In fact that was a Gedanken Experiment.</AbstractText>
+#             </Abstract>
+#             <AuthorList CompleteYN="Y">
+#                 <Author ValidYN="Y">
+#                     <LastName>Nietsnie</LastName>
+#                     <ForeName>Derfla</ForeName>
+#                     <Initials>N</Initials>
+#                     <AffiliationInfo>
+#                         <Affiliation>University of the world.</Affiliation>
+#                     </AffiliationInfo>
+#                 </Author>
+#             </AuthorList>
+#             <Language>eng</Language>
+#             <PublicationTypeList>
+#                 <PublicationType UI="D016428">Journal Article</PublicationType>
+#                 <PublicationType UI="D013485">Research Support, Non-U.S. Gov't</PublicationType>
+#             </PublicationTypeList>
+#             <ArticleDate DateType="Electronic">
+#                 <Year>2000</Year>
+#                 <Month>01</Month>
+#                 <Day>01</Day>
+#             </ArticleDate>
+#         </Article>
+#         <MedlineJournalInfo>
+#             <Country>Germany</Country>
+#             <MedlineTA>J An</MedlineTA>
+#             <NlmUniqueID>87654321</NlmUniqueID>
+#             <ISSNLinking>1111-1111</ISSNLinking>
+#         </MedlineJournalInfo>
+#     </MedlineCitation>
+#     <PubmedData>
+#         <ArticleIdList>
+#             <ArticleId IdType="pubmed">12345678</ArticleId>
+#             <ArticleId IdType="doi">10.1000/xyz123</ArticleId>
+#         </ArticleIdList>
+#     </PubmedData>
+# </PubmedArticle>
+# </PubmedArticleSet>"""
+
+        response = mock.Mock(text=xml_mock.encode('utf-8'))
+        results = pubmed.response(response)
+        self.assertEqual(type(results), list)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['content'], 'No abstract is available for this publication.')


### PR DESCRIPTION
PubMed is an index agregating life science literature.

Specificities:
-  to get results, two requests have to be made: one to get PMIDs (PubMed IDs) and one to get abstracts, hence snippets. The first one is made in `request`, the second one by making a second request. This might break the design principles of Searx, please tell me if there is a convention on how to do it
- from a result, it is possible to link to the PubMed notice, as well as use the DOI when available. How can one add HTML to the "content" section of a result? That would enable to use both