### PR TITLE
[fix] Missing favicon images in oscar and simple themes

### DIFF
--- a/searx/templates/oscar/macros.html
+++ b/searx/templates/oscar/macros.html
@@ -5,7 +5,7 @@
 
 <!-- Draw favicon -->
 {% macro draw_favicon(favicon) -%}
-    <img width="32" height="32" class="favicon" src="{{ url_for('static', filename='/themes/oscar/img/icons/' + favicon + '.png') }}" alt="{{ favicon }}" />
+    <img width="32" height="32" class="favicon" src="{{ url_for('static', filename='themes/oscar/img/icons/' + favicon + '.png') }}" alt="{{ favicon }}" />
 {%- endmacro %}
 
 {%- macro result_link(url, title, classes='') -%}

--- a/searx/templates/simple/macros.html
+++ b/searx/templates/simple/macros.html
@@ -9,7 +9,7 @@
 
 <!-- Draw favicon -->
 {% macro draw_favicon(favicon) -%}
-    <img width="14" height="14" class="favicon" src="{{ url_for('static', filename='/themes/simple/img/icons/' + favicon + '.png') }}" alt="{{ favicon }}" />
+    <img width="14" height="14" class="favicon" src="{{ url_for('static', filename='themes/simple/img/icons/' + favicon + '.png') }}" alt="{{ favicon }}" />
 {%- endmacro %}
 
 {% macro result_open_link(url, classes='') -%}


### PR DESCRIPTION
On my setup:
- Searx 0.12.0
- Apache 2.4.25
- Debian 9

Everything is fine but the favicons (i.e. when a Wikipedia page appears in the results) whose URL features a double-slash `//`, throwing off searx and generating 404 errors.

Ex: https://searx.domain.com/static//themes/oscar/img/icons/wikipedia.png

I found the mistake in the template macro with the parameter `filename` of the function `url_for` that doesn't need a leading `/`. Removing the leading slash fixes the missing image issue.

Successfully tested locally.