### PR TITLE
Fixed the currency_convert engine.

### DIFF
--- a/searx/engines/currency_convert.py
+++ b/searx/engines/currency_convert.py
@@ -44,15 +44,15 @@ def request(query, params):
         # wrong query
         return params
 
-    ammount, from_currency, to_currency = m.groups()
-    ammount = float(ammount)
+    amount, from_currency, to_currency = m.groups()
+    amount = float(amount)
     from_currency = name_to_iso4217(from_currency.strip())
     to_currency = name_to_iso4217(to_currency.strip())
 
     q = (from_currency + to_currency).upper()
 
     params['url'] = url.format(from_currency, to_currency)
-    params['ammount'] = ammount
+    params['amount'] = amount
     params['from'] = from_currency
     params['to'] = to_currency
     params['from_name'] = iso4217_to_name(from_currency, 'en')
@@ -73,9 +73,9 @@ def response(resp):
         return results
 
     answer = '{0} {1} = {2} {3}, 1 {1} ({5}) = {4} {3} ({6})'.format(
-        resp.search_params['ammount'],
+        resp.search_params['amount'],
         resp.search_params['from'],
-        resp.search_params['ammount'] * conversion_rate,
+        resp.search_params['amount'] * conversion_rate,
         resp.search_params['to'],
         conversion_rate,
         resp.search_params['from_name'],

--- a/tests/unit/engines/test_currency_convert.py
+++ b/tests/unit/engines/test_currency_convert.py
@@ -23,7 +23,7 @@ class TestCurrencyConvertEngine(SearxTestCase):
 
     def test_response(self):
         dicto = defaultdict(dict)
-        dicto['ammount'] = float(10)
+        dicto['amount'] = float(10)
         dicto['from'] = "GBP"
         dicto['to'] = "USD"
         dicto['from_name'] = "pound sterling"

--- a/tests/unit/engines/test_currency_convert.py
+++ b/tests/unit/engines/test_currency_convert.py
@@ -17,7 +17,7 @@ class TestCurrencyConvertEngine(SearxTestCase):
         query = b'convert 10 Pound Sterlings to United States Dollars'
         params = currency_convert.request(query, dicto)
         self.assertIn('url', params)
-        self.assertIn('finance.yahoo.com', params['url'])
+        self.assertIn('finance.google.com', params['url'])
         self.assertIn('GBP', params['url'])
         self.assertIn('USD', params['url'])
 
@@ -31,13 +31,14 @@ class TestCurrencyConvertEngine(SearxTestCase):
         response = mock.Mock(text='a,b,c,d', search_params=dicto)
         self.assertEqual(currency_convert.response(response), [])
 
-        csv = "2,0.5,1"
-        response = mock.Mock(text=csv, search_params=dicto)
+        body = "<span class=bld>0.5 {}</span>".format(dicto['to'])
+        response = mock.Mock(text=body, search_params=dicto)
         results = currency_convert.response(response)
         self.assertEqual(type(results), list)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['answer'], '10.0 GBP = 5.0 USD, 1 GBP (pound sterling)' +
                          ' = 0.5 USD (United States dollar)')
-        now_date = datetime.now().strftime('%Y%m%d')
-        self.assertEqual(results[0]['url'], 'https://finance.yahoo.com/currency/converter-results/' +
-                                            now_date + '/10.0-gbp-to-usd.html')
+
+        target_url = 'https://finance.google.com/finance?q={}{}'.format(
+            dicto['from'], dicto['to'])
+        self.assertEqual(results[0]['url'], target_url)


### PR DESCRIPTION
Yahoo has decided to take down their finance API. Consequently searx's currency conversion engine has stopped working as well. This PR replaces it with Google's finance API.

Yahoo's justification:
> It has come to our attention that this service is being used in violation of the Yahoo Terms of Service. As such, the service is being discontinued. For all future markets and equities data research, please refer to finance.yahoo.com.