### PR TITLE
Add flake8 to find syntax errors & undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,12 @@ before_install:
 install:
   - ./manage.sh npm_packages
   - ./manage.sh update_dev_packages
-  - pip install codecov
+  - pip install codecov flake8
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
   - ./manage.sh styles
   - ./manage.sh grunt_build


### PR DESCRIPTION
There is at least one print statement that is not Python 3 compatible and many undefined names which may raise NameError at runtime.  Flake8 runs in two passes: The first looks at critical issues in stop-the-build mode and the second looks at style violations in everything-is-a-warning mode.