### PR TITLE
Make Python 3 able to read settings files with Unicode characters

### DIFF
--- a/searx/__init__.py
+++ b/searx/__init__.py
@@ -50,7 +50,7 @@ if not settings_path:
     raise Exception('settings.yml not found')
 
 # load settings
-with open(settings_path) as settings_yaml:
+with open(settings_path, 'rb') as settings_yaml:
     settings = load(settings_yaml)
 
 '''

--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -36,7 +36,7 @@ engines = {}
 
 categories = {'general': []}
 
-languages = loads(open(engine_dir + '/../data/engines_languages.json').read())
+languages = loads(open(engine_dir + '/../data/engines_languages.json', 'rb').read())
 
 engine_shortcuts = {}
 engine_default_args = {'paging': False,

--- a/searx/engines/currency_convert.py
+++ b/searx/engines/currency_convert.py
@@ -94,7 +94,7 @@ def load():
     global db
 
     current_dir = os.path.dirname(os.path.realpath(__file__))
-    json_data = open(current_dir + "/../data/currencies.json").read()
+    json_data = open(current_dir + "/../data/currencies.json", 'rb').read()
 
     db = json.loads(json_data)
 


### PR DESCRIPTION
SearX currently doesn't start up when run with Python 3 as it tries to parse the
settings.yml file with ASCII codecs.
Python 3 requires that files with Unicode characters be read with a 'b' flag.
This also works with Python 2 and hence can be integrated into the main source
code.

Tested with the latest Python 3.6.4rc1 on Debian unstable.

Signed-off-by: Joseph Nuthalapati <njoseph@thoughtworks.com>