### PR TITLE
remove the option of sourcing manage.sh

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -3,14 +3,6 @@
 BASE_DIR="$(dirname -- "`readlink -f -- "$0"`")"
 export PATH="$BASE_DIR/node_modules/.bin":$PATH
 
-# the script can be sourced to update the PATH
-# see https://stackoverflow.com/questions/2683279/how-to-detect-if-a-script-is-being-sourced
-if [ $_ != $0 ]; then
-    unset BASE_DIR
-    # sourced : exit now
-    return
-fi
-
 # subshell
 PYTHONPATH="$BASE_DIR"
 SEARX_DIR="$BASE_DIR/searx"

--- a/manage.sh
+++ b/manage.sh
@@ -48,7 +48,7 @@ install_geckodriver() {
 
     if [ -z "$1" ]; then
         if [ -z "$VIRTUAL_ENV" ]; then
-            echo "geckodriver can't be installed because VIRTUAL_ENV is not set, you should download it from\n  $GECKODRIVER_URL"
+            printf "geckodriver can't be installed because VIRTUAL_ENV is not set, you should download it from\n  %s" "$GECKODRIVER_URL"
             exit
         else
             GECKODRIVER_DIR="$VIRTUAL_ENV/bin"
@@ -58,7 +58,7 @@ install_geckodriver() {
         mkdir -p -- "$GECKODRIVER_DIR"
     fi
 
-    echo "Installing $GECKODRIVER_DIR/geckodriver from\n  $GECKODRIVER_URL"
+    printf "Installing %s/geckodriver from\n  %s" "$GECKODRIVER_DIR" "$GECKODRIVER_URL"
 
     FILE="`mktemp`"
     wget -qO "$FILE" -- "$GECKODRIVER_URL" && tar xz -C "$GECKODRIVER_DIR" -f "$FILE" geckodriver


### PR DESCRIPTION
From now on, there is no point in sourcing `manage.sh`.

My `/bin/sh` does not support this form of detection if a script is sourced or not. Thus, I am not able to run any of the commands, because it always returns before performing anything. Because of incompatibility, I would like to remove it.
Another solution could be changing `/bin/sh` to `/bin/bash`, so sourcing would work. However, `node_modules/.bin` is placed under the folder `searx` which is not a universal path to grunt. In my case it is under a different directory. I propose to let the developer set his/her own `PATH` without any interference from `manage.sh`.
Removing this part ensures that the script can be run without any problem and lets developers manage their own environment.

What do you think @dalf?