### PR TITLE
Fix yacy engine

### DIFF
--- a/searx/engines/yacy.py
+++ b/searx/engines/yacy.py
@@ -74,8 +74,17 @@ def response(resp):
     for result in search_results[0].get('items', []):
         # parse image results
         if result.get('image'):
+
+            result_url = ''
+            if 'url' in result:
+                result_url = result['url']
+            elif 'link' in result:
+                result_url = result['link']
+            else:
+                continue
+
             # append result
-            results.append({'url': result['url'],
+            results.append({'url': result_url,
                             'title': result['title'],
                             'content': '',
                             'img_src': result['image'],


### PR DESCRIPTION
Previously, "url" was not found in the result json, so the engine crashed. Now the engine looks for both "url" and "link" in results to get the URL of a result.

Closes #1064