### PR TITLE
[fix] Change duckduckgo url to avoid error response

### DIFF
--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -27,7 +27,7 @@ supported_languages_url = 'https://duckduckgo.com/d2030.js'
 time_range_support = True
 
 # search-url
-url = 'https://duckduckgo.com/html?{query}&s={offset}&api=/d.js&o=json&dc={dc_param}'
+url = 'https://duckduckgo.com/html?{query}&s={offset}&dc={dc_param}'
 time_range_url = '&df={range}'
 
 time_range_dict = {'day': 'd',


### PR DESCRIPTION
This error is hard to reproduce, but sometimes requests to Duckduckgo will return an error.
Removing some parameters on the search URL seems to fix the error.

For example:
https://duckduckgo.com/html?q=query&api=/d.js&o=json will sometimes return an error message.
https://duckduckgo.com/html?q=query should never fail.