### PR TITLE
[fix] Force English results in Google when using en-US

### DIFF
--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -91,7 +91,7 @@ url_map = 'https://www.openstreetmap.org/'\
 search_path = '/search'
 search_url = ('https://{hostname}' +
               search_path +
-              '?{query}&start={offset}&gws_rd=cr&gbv=1&lr={lang}&ei=x')
+              '?{query}&start={offset}&gws_rd=cr&gbv=1&lr={lang}&hl={lang_short}&ei=x')
 
 time_range_search = "&tbs=qdr:{range}"
 time_range_dict = {'day': 'd',
@@ -175,10 +175,6 @@ def request(query, params):
     else:
         country = 'US'
 
-    # temporary fix until a way of supporting en-US is found
-    if language == 'en-US':
-        country = 'GB'
-
     url_lang = 'lang_' + language
 
     if use_locale_domain:
@@ -191,7 +187,8 @@ def request(query, params):
     params['url'] = search_url.format(offset=offset,
                                       query=urlencode({'q': query}),
                                       hostname=google_hostname,
-                                      lang=url_lang)
+                                      lang=url_lang,
+                                      lang_short=language)
     if params['time_range'] in time_range_dict:
         params['url'] += time_range_search.format(range=time_range_dict[params['time_range']])
 

--- a/tests/unit/engines/test_google.py
+++ b/tests/unit/engines/test_google.py
@@ -26,16 +26,19 @@ class TestGoogleEngine(SearxTestCase):
         self.assertIn('url', params)
         self.assertIn(query, params['url'])
         self.assertIn('google.fr', params['url'])
+        self.assertIn('fr', params['url'])
         self.assertIn('fr', params['headers']['Accept-Language'])
 
         dicto['language'] = 'en-US'
         params = google.request(query, dicto)
-        self.assertIn('google.co', params['url'])
+        self.assertIn('google.com', params['url'])
+        self.assertIn('en', params['url'])
         self.assertIn('en', params['headers']['Accept-Language'])
 
         dicto['language'] = 'zh'
         params = google.request(query, dicto)
         self.assertIn('google.com', params['url'])
+        self.assertIn('zh-CN', params['url'])
         self.assertIn('zh-CN', params['headers']['Accept-Language'])
 
     def test_response(self):


### PR DESCRIPTION
This should remove the need to use en-GB in place of en-US results.