### PR TITLE
Switched currency converter to duckduckgo and added Bitcoin to currency list

### DIFF
--- a/searx/data/currencies.json
+++ b/searx/data/currencies.json
@@ -6163,9 +6163,21 @@
         ], 
         "scellino keniota": [
             "KES"
-        ]
+        ],
+	"bitcoin": [
+		"XBT"
+	]	
     }, 
     "iso4217": {
+	"XBT":{
+	    "fr": "Bitcoin", 
+            "en": "Bitcoin", 
+            "nl": "Bitcoin", 
+            "de": "Bitcoin", 
+            "it": "Bitcoin", 
+            "hu": "Bitcoin", 
+            "es": "Bitcoin"
+	},	
         "DZD": {
             "fr": "Dinar alg\u00e9rien", 
             "en": "Algerian dinar", 

--- a/searx/engines/currency_convert.py
+++ b/searx/engines/currency_convert.py
@@ -44,7 +44,6 @@ def request(query, params):
     if not m:
         # wrong query
         return params
-
     amount, from_currency, to_currency = m.groups()
     amount = float(amount)
     from_currency = name_to_iso4217(from_currency.strip())
@@ -64,7 +63,7 @@ def request(query, params):
 
 def response(resp):
     """remove first and last lines to get only json"""
-    json_resp = resp.text[resp.text.find('\n')+1:resp.text.rfind('\n')-2]
+    json_resp = resp.text[resp.text.find('\n') + 1:resp.text.rfind('\n') - 2]
     results = []
     try:
         conversion_rate = float(json.loads(json_resp)['conversion']['converted-amount'])

--- a/searx/engines/currency_convert.py
+++ b/searx/engines/currency_convert.py
@@ -11,7 +11,7 @@ if sys.version_info[0] == 3:
     unicode = str
 
 categories = []
-url = 'https://finance.google.com/finance/converter?a=1&from={0}&to={1}'
+url = 'https://duckduckgo.com/js/spice/currency/1/{0}/{1}'
 weight = 100
 
 parser_re = re.compile(b'.*?(\\d+(?:\\.\\d+)?) ([^.0-9]+) (?:in|to) ([^.0-9]+)', re.I)
@@ -63,16 +63,13 @@ def request(query, params):
 
 
 def response(resp):
+    """remove first and last lines to get only json"""
+    json_resp = resp.text[resp.text.find('\n')+1:resp.text.rfind('\n')-2]
     results = []
-    pat = '<span class=bld>(.+) {0}</span>'.format(
-        resp.search_params['to'].upper())
-
     try:
-        conversion_rate = re.findall(pat, resp.text)[0]
-        conversion_rate = float(conversion_rate)
+        conversion_rate = float(json.loads(json_resp)['conversion']['converted-amount'])
     except:
         return results
-
     answer = '{0} {1} = {2} {3}, 1 {1} ({5}) = {4} {3} ({6})'.format(
         resp.search_params['amount'],
         resp.search_params['from'],
@@ -83,7 +80,7 @@ def response(resp):
         resp.search_params['to_name'],
     )
 
-    url = 'https://finance.google.com/finance?q={0}{1}'.format(
+    url = 'https://duckduckgo.com/js/spice/currency/1/{0}/{1}'.format(
         resp.search_params['from'].upper(), resp.search_params['to'])
 
     results.append({'answer': answer, 'url': url})

--- a/tests/unit/engines/test_currency_convert.py
+++ b/tests/unit/engines/test_currency_convert.py
@@ -30,8 +30,20 @@ class TestCurrencyConvertEngine(SearxTestCase):
         dicto['to_name'] = "United States dollar"
         response = mock.Mock(text='a,b,c,d', search_params=dicto)
         self.assertEqual(currency_convert.response(response), [])
-
-        body = "ddg_spice_currency(\n{\n\"conversion\":{\n\"converted-amount\": \"0.5\"\n}\n\"topConversions\":[\n{\n},\n{\n}\n]\n}\n);"
+        body = """ddg_spice_currency(
+            {
+                "conversion":{
+                    "converted-amount": "0.5"
+                },
+                "topConversions":[
+                    {
+                    },
+                    {
+                    }
+                ]
+            }
+        );
+        """
         response = mock.Mock(text=body, search_params=dicto)
         results = currency_convert.response(response)
         self.assertEqual(type(results), list)

--- a/tests/unit/engines/test_currency_convert.py
+++ b/tests/unit/engines/test_currency_convert.py
@@ -17,7 +17,7 @@ class TestCurrencyConvertEngine(SearxTestCase):
         query = b'convert 10 Pound Sterlings to United States Dollars'
         params = currency_convert.request(query, dicto)
         self.assertIn('url', params)
-        self.assertIn('finance.google.com', params['url'])
+        self.assertIn('duckduckgo.com', params['url'])
         self.assertIn('GBP', params['url'])
         self.assertIn('USD', params['url'])
 
@@ -31,7 +31,7 @@ class TestCurrencyConvertEngine(SearxTestCase):
         response = mock.Mock(text='a,b,c,d', search_params=dicto)
         self.assertEqual(currency_convert.response(response), [])
 
-        body = "<span class=bld>0.5 {}</span>".format(dicto['to'])
+        body = "ddg_spice_currency(\n{\n\"conversion\":{\n\"converted-amount\": \"0.5\"\n}\n\"topConversions\":[\n{\n},\n{\n}\n]\n}\n);"
         response = mock.Mock(text=body, search_params=dicto)
         results = currency_convert.response(response)
         self.assertEqual(type(results), list)
@@ -39,6 +39,6 @@ class TestCurrencyConvertEngine(SearxTestCase):
         self.assertEqual(results[0]['answer'], '10.0 GBP = 5.0 USD, 1 GBP (pound sterling)' +
                          ' = 0.5 USD (United States dollar)')
 
-        target_url = 'https://finance.google.com/finance?q={}{}'.format(
+        target_url = 'https://duckduckgo.com/js/spice/currency/1/{}/{}'.format(
             dicto['from'], dicto['to'])
         self.assertEqual(results[0]['url'], target_url)


### PR DESCRIPTION
Switched currency converter to duckduckgo because parsing google finance is not working anymore (when trying to request https://finance.google.com/finance/converter?a=1&from=USD&to=EUR it either responds with "finance search result" or times out).
Also added Bitcoin to currency list since it is supported by duckduckgo's currency converter