### PR TITLE
[Feature] Acgsou as a searchable engine

### DIFF
--- a/searx/engines/acgsou.py
+++ b/searx/engines/acgsou.py
@@ -28,14 +28,11 @@ xpath_title = './/td[3]/a[last()]'
 xpath_torrent_links = './/td[3]/a'
 xpath_filesize = './/td[4]/text()'
 
-# do search-request
 def request(query, params):
     query = urlencode({'keyword': query})
     params['url'] = search_url.format(query=query, offset=params['pageno'])
     return params
 
-
-# get response from search-request
 def response(resp):
     results = [] 
     dom = html.fromstring(resp.text)
@@ -46,23 +43,17 @@ def response(resp):
         magnet_link = "magnet:?xt=urn:btih:{}&tr=http://tracker.acgsou.com:2710/announce"
         torrent_link = ""
 
-        # category in which our torrent belongs
         try:
             category = extract_text(result.xpath(xpath_category)[0])
         except:
             pass
 
-        # torrent title
         page_a = result.xpath(xpath_title)[0]
         title = extract_text(page_a)
-
-        # link to the page
         href = base_url + page_a.attrib.get('href')
-        
-        #magnet link
+
         magnet_link = magnet_link.format(page_a.attrib.get('href')[5:-5])
 
-        # let's try to calculate the torrent size
         try:
             filesize_info = result.xpath(xpath_filesize)[0]
             filesize = filesize_info[:-2]
@@ -70,16 +61,14 @@ def response(resp):
             filesize = get_torrent_size(filesize, filesize_multiplier)
         except :
             pass
-
-        # content string contains all information not included into template
+        #I didn't add download/seed/leech count since as I figured out they are generated randowmly everytime
         content = 'Category: "{category}".'
         content = content.format(category=category)
-
+        
         results.append({'url': href,
                         'title': title,
                         'content': content,
                         'filesize': filesize,
                         'magnetlink': magnet_link,
                         'template': 'torrent.html'})
-
     return results

--- a/searx/engines/acgsou.py
+++ b/searx/engines/acgsou.py
@@ -1,0 +1,85 @@
+"""
+ Acgsou (Japanese Animation/Music/Comics Bittorrent tracker)
+
+ @website      https://www.acgsou.com/
+ @provide-api  no
+ @using-api    no
+ @results      HTML
+ @stable       no (HTML can change)
+ @parse        url, title, content, seed, leech, torrentfile
+"""
+
+from lxml import html
+from searx.engines.xpath import extract_text
+from searx.url_utils import urlencode
+from searx.utils import get_torrent_size, int_or_zero
+
+# engine dependent config
+categories = ['files', 'images', 'videos', 'music']
+paging = True
+
+# search-url
+base_url = 'https://www.acgsou.com/'
+search_url = base_url + 'search.php?{query}&page={offset}'
+# xpath queries
+xpath_results = '//table[contains(@class, "list_style table_fixed")]//tr[not(th)]'
+xpath_category = './/td[2]/a[1]'
+xpath_title = './/td[3]/a[last()]'
+xpath_torrent_links = './/td[3]/a'
+xpath_filesize = './/td[4]/text()'
+
+# do search-request
+def request(query, params):
+    query = urlencode({'keyword': query})
+    params['url'] = search_url.format(query=query, offset=params['pageno'])
+    return params
+
+
+# get response from search-request
+def response(resp):
+    results = [] 
+    dom = html.fromstring(resp.text)
+    print(resp.text)
+    for result in dom.xpath(xpath_results): 
+        # defaults
+        filesize = 0
+        magnet_link = "magnet:?xt=urn:btih:{}&tr=http://tracker.acgsou.com:2710/announce"
+        torrent_link = ""
+
+        # category in which our torrent belongs
+        try:
+            category = extract_text(result.xpath(xpath_category)[0])
+        except:
+            pass
+
+        # torrent title
+        page_a = result.xpath(xpath_title)[0]
+        title = extract_text(page_a)
+
+        # link to the page
+        href = base_url + page_a.attrib.get('href')
+        
+        #magnet link
+        magnet_link = magnet_link.format(page_a.attrib.get('href')[5:-5])
+
+        # let's try to calculate the torrent size
+        try:
+            filesize_info = result.xpath(xpath_filesize)[0]
+            filesize = filesize_info[:-2]
+            filesize_multiplier = filesize_info[-2:]
+            filesize = get_torrent_size(filesize, filesize_multiplier)
+        except :
+            pass
+
+        # content string contains all information not included into template
+        content = 'Category: "{category}".'
+        content = content.format(category=category)
+
+        results.append({'url': href,
+                        'title': title,
+                        'content': content,
+                        'filesize': filesize,
+                        'magnetlink': magnet_link,
+                        'template': 'torrent.html'})
+
+    return results

--- a/searx/engines/acgsou.py
+++ b/searx/engines/acgsou.py
@@ -28,16 +28,18 @@ xpath_title = './/td[3]/a[last()]'
 xpath_torrent_links = './/td[3]/a'
 xpath_filesize = './/td[4]/text()'
 
+
 def request(query, params):
     query = urlencode({'keyword': query})
     params['url'] = search_url.format(query=query, offset=params['pageno'])
     return params
 
+
 def response(resp):
     results = [] 
     dom = html.fromstring(resp.text)
     print(resp.text)
-    for result in dom.xpath(xpath_results): 
+    for result in dom.xpath(xpath_results):
         # defaults
         filesize = 0
         magnet_link = "magnet:?xt=urn:btih:{}&tr=http://tracker.acgsou.com:2710/announce"
@@ -59,12 +61,12 @@ def response(resp):
             filesize = filesize_info[:-2]
             filesize_multiplier = filesize_info[-2:]
             filesize = get_torrent_size(filesize, filesize_multiplier)
-        except :
+        except:
             pass
         #I didn't add download/seed/leech count since as I figured out they are generated randowmly everytime
         content = 'Category: "{category}".'
         content = content.format(category=category)
-        
+
         results.append({'url': href,
                         'title': title,
                         'content': content,

--- a/searx/engines/acgsou.py
+++ b/searx/engines/acgsou.py
@@ -63,7 +63,7 @@ def response(resp):
             filesize = get_torrent_size(filesize, filesize_multiplier)
         except:
             pass
-        #I didn't add download/seed/leech count since as I figured out they are generated randowmly everytime
+        # I didn't add download/seed/leech count since as I figured out they are generated randowmly everytime
         content = 'Category: "{category}".'
         content = content.format(category=category)
 

--- a/searx/engines/acgsou.py
+++ b/searx/engines/acgsou.py
@@ -36,7 +36,7 @@ def request(query, params):
 
 
 def response(resp):
-    results = [] 
+    results = []
     dom = html.fromstring(resp.text)
     print(resp.text)
     for result in dom.xpath(xpath_results):

--- a/searx/engines/acgsou.py
+++ b/searx/engines/acgsou.py
@@ -63,7 +63,7 @@ def response(resp):
             filesize = get_torrent_size(filesize, filesize_multiplier)
         except:
             pass
-        # I didn't add download/seed/leech count since as I figured out they are generated randowmly everytime
+        # I didn't add download/seed/leech count since as I figured out they are generated randomly everytime
         content = 'Category: "{category}".'
         content = content.format(category=category)
 

--- a/searx/engines/acgsou.py
+++ b/searx/engines/acgsou.py
@@ -38,7 +38,6 @@ def request(query, params):
 def response(resp):
     results = []
     dom = html.fromstring(resp.text)
-    print(resp.text)
     for result in dom.xpath(xpath_results):
         # defaults
         filesize = 0

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -433,6 +433,12 @@ engines:
     engine : nyaa
     shortcut : nt
     disabled : True
+  
+  - name : acgsou
+    engine : acgsou
+    shortcut : acg
+    disabled : True
+    timeout: 5.0
 
   - name : openairedatasets
     engine : json_engine

--- a/tests/unit/engines/test_acgsou.py
+++ b/tests/unit/engines/test_acgsou.py
@@ -24,14 +24,14 @@ class TestAcgsouEngine(SearxTestCase):
 <table id="listTable" class="list_style table_fixed">
   <thead class="tcat">
       <tr>
-        <th axis="string" class="l1 tableHeaderOver">发布时间</th>
-        <th axis="string" class="l2 tableHeaderOver">分类</th>
-        <th axis="string" class="l3 tableHeaderOver">资源名称</th>
-        <th axis="size" class="l4 tableHeaderOver">大小</th>
-        <th axis="number" class="l5 tableHeaderOver">种子</th>
-        <th axis="number" class="l6 tableHeaderOver">下载</th>
-        <th axis="number" class="l7 tableHeaderOver">完成</th>
-        <th axis="string" class="l8 tableHeaderOver">发布者/联盟</th>
+        <th axis="string" class="l1 tableHeaderOver">test</th>
+        <th axis="string" class="l2 tableHeaderOver">test</th>
+        <th axis="string" class="l3 tableHeaderOver">test</th>
+        <th axis="size" class="l4 tableHeaderOver">test</th>
+        <th axis="number" class="l5 tableHeaderOver">test</th>
+        <th axis="number" class="l6 tableHeaderOver">test</th>
+        <th axis="number" class="l7 tableHeaderOver">test</th>
+        <th axis="string" class="l8 tableHeaderOver">test</th>
       </tr>
   </thead>
   <tbody class="tbody" id="data_list">

--- a/tests/unit/engines/test_acgsou.py
+++ b/tests/unit/engines/test_acgsou.py
@@ -1,0 +1,67 @@
+from collections import defaultdict
+import mock
+from searx.engines import acgsou
+from searx.testing import SearxTestCase
+
+
+class TestAcgsouEngine(SearxTestCase):
+
+    def test_request(self):
+        query = 'test_query'
+        dic = defaultdict(dict)
+        dic['pageno'] = 1
+        params = acgsou.request(query, dic)
+        self.assertTrue('url' in params)
+        self.assertTrue(query in params['url'])
+        self.assertTrue('acgsou.com' in params['url'])
+
+    def test_response(self):
+        resp = mock.Mock(text='<html></html>')
+        self.assertEqual(acgsou.response(resp), [])
+
+        html = """
+<table id="listTable" class="list_style table_fixed">
+  <thead class="tcat">
+      <tr>
+      tablehead
+      </tr>
+  </thead>
+  <tbody class="tbody" id="data_list">
+              <tr class="alt1 ">
+        <td nowrap="nowrap">date</td>
+        <td><a href="category.html">testcategory</a></td>
+        <td style="text-align:left;">
+            <a href="show-torrentid.html" target="_blank">torrentname</a>
+        </td>
+        <td>1MB</td>
+        <td nowrap="nowrap">
+            <span class="bts_1">
+            29
+            </span>
+        </td>
+        <td nowrap="nowrap">
+            <span class="btl_1">
+            211
+        </span>
+        </td>
+        <td nowrap="nowrap">
+        <span class="btc_">
+            168
+        </span>
+        </td>
+        <td><a href="random.html">user</a></td>
+      </tr>
+</table>
+        """
+
+        resp = mock.Mock(text=html)
+        results = acgsou.response(resp)
+
+        self.assertEqual(type(results), list)
+        self.assertEqual(len(results), 1)
+
+        r = results[0]
+        self.assertEqual(r['url'], 'https://www.acgsou.com/show-torrentid.html')
+        self.assertEqual(r['content'], 'Category: "testcategory".')
+        self.assertEqual(r['title'], 'torrentname')
+        self.assertEqual(r['filesize'], 1048576)

--- a/tests/unit/engines/test_acgsou.py
+++ b/tests/unit/engines/test_acgsou.py
@@ -20,14 +20,22 @@ class TestAcgsouEngine(SearxTestCase):
         self.assertEqual(acgsou.response(resp), [])
 
         html = """
+        <html>
 <table id="listTable" class="list_style table_fixed">
   <thead class="tcat">
       <tr>
-      tablehead
+        <th axis="string" class="l1 tableHeaderOver">发布时间</th>
+        <th axis="string" class="l2 tableHeaderOver">分类</th>
+        <th axis="string" class="l3 tableHeaderOver">资源名称</th>
+        <th axis="size" class="l4 tableHeaderOver">大小</th>
+        <th axis="number" class="l5 tableHeaderOver">种子</th>
+        <th axis="number" class="l6 tableHeaderOver">下载</th>
+        <th axis="number" class="l7 tableHeaderOver">完成</th>
+        <th axis="string" class="l8 tableHeaderOver">发布者/联盟</th>
       </tr>
   </thead>
   <tbody class="tbody" id="data_list">
-              <tr class="alt1 ">
+ <tr class="alt1 ">
         <td nowrap="nowrap">date</td>
         <td><a href="category.html">testcategory</a></td>
         <td style="text-align:left;">
@@ -51,7 +59,9 @@ class TestAcgsouEngine(SearxTestCase):
         </td>
         <td><a href="random.html">user</a></td>
       </tr>
+      </tbody>
 </table>
+</html>
         """
 
         resp = mock.Mock(text=html)


### PR DESCRIPTION
Includes acgsou.com as a searchable engine. Doesn't show seed/leech/download information because, as I figured out, for some reason it is randomly generated on client's side every time the page is reloaded