### PR TITLE
Fix bing "garbage" results

### DIFF
--- a/searx/engines/bing.py
+++ b/searx/engines/bing.py
@@ -16,7 +16,7 @@
 from lxml import html
 from searx.engines.xpath import extract_text
 from searx.url_utils import urlencode
-from searx.utils import match_language
+from searx.utils import match_language, gen_useragent
 
 # engine dependent config
 categories = ['general']
@@ -43,6 +43,9 @@ def request(query, params):
         offset=offset)
 
     params['url'] = base_url + search_path
+
+    params['headers']['User-Agent'] = gen_useragent('Windows NT 6.3; WOW64')
+
     return params
 
 

--- a/searx/utils.py
+++ b/searx/utils.py
@@ -57,9 +57,9 @@ blocked_tags = ('script',
                 'style')
 
 
-def gen_useragent():
+def gen_useragent(os=None):
     # TODO
-    return ua.format(os=choice(ua_os), version=choice(ua_versions))
+    return ua.format(os=os or choice(ua_os), version=choice(ua_versions))
 
 
 def searx_useragent():


### PR DESCRIPTION
This should fix #1275.

For some reason, it looks like using only Windows based user-agents gets the good results, while using a Linux based user-agent leads to more inconsistent results. Strangely enough, I can't reproduce this bug in a browser. I tried changing other HTTP headers, but didn't find any significant improvement.