### PR TITLE
add: Search with multiple languages (solves #1344)

### DIFF
--- a/searx/search.py
+++ b/searx/search.py
@@ -216,13 +216,13 @@ def get_search_query_from_webapp(preferences, form):
     if len(raw_text_query.languages):
         query_lang = raw_text_query.languages
     elif 'language' in form:
-        query_lang = [ form.get('language') ]
+        query_lang = [form.get('language')]
     else:
-        query_lang = [ preferences.get_value('language') ]
+        query_lang = [preferences.get_value('language')]
 
     # provides backwards compatibility for requests using old language default
     if query_lang == 'all':
-        query_lang = [ settings['search']['language'] ]
+        query_lang = [settings['search']['language']]
 
     # check language
     for lang in query_lang:

--- a/searx/utils.py
+++ b/searx/utils.py
@@ -343,6 +343,10 @@ def _match_language(lang_code, lang_list=[], custom_aliases={}):
 
 # get the language code from lang_list that best matches locale_code
 def match_language(locale_code, lang_list=[], custom_aliases={}, fallback='en-US'):
+    # If more than one language provided, select the first one as primary
+    if type(locale_code) is list:
+        locale_code = locale_code[0]
+
     # try to get language from given locale_code
     language = _match_language(locale_code, lang_list, custom_aliases)
     if language:


### PR DESCRIPTION
Now users can use the following syntax to search with multiple
languages:

```
:en :ja conoha test
```

The first language will be the primary language.

However, a related change to the settings interface is NOT implemented
yet, so this feature is only for advanced users now.

Signed-off-by: SilverBut <SilverBut@users.noreply.github.com>