### PR TITLE
Creating setting to enforce a minimum safe search.

### DIFF
--- a/searx/search.py
+++ b/searx/search.py
@@ -240,7 +240,9 @@ def get_search_query_from_webapp(preferences, form):
         query_safesearch = preferences.get_value('safesearch')
 
     # safesearch : second check
-    if query_safesearch < 0 or query_safesearch > 2:
+    minimum_safe_search = int(settings['search'].get('minimum_safe_search', 0))
+    if query_safesearch < 0 or query_safesearch > 2 or query_safesearch < minimum_safe_search:
+        print(query_safesearch, minimum_safe_search)
         raise SearxParameterException('safesearch', query_safesearch)
 
     # get time_range

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -4,6 +4,7 @@ general:
 
 search:
     safe_search : 0 # Filter results. 0: None, 1: Moderate, 2: Strict
+    minimum_safe_search : 0 # Enforce a minimum safe_search
     autocomplete : "" # Existing autocomplete backends: "dbpedia", "duckduckgo", "google", "startpage", "wikipedia" - leave blank to turn it off by default
     language : "en-US"
     ban_time_on_fail : 5 # ban time in seconds after engine errors


### PR DESCRIPTION
- Adding `search.minimum_safe_search` to `settings.yml` which allows the instance host to enforce a minimum safe search allowed on their instance.

This still needs support in the UI (hiding the options that would raise an Exception).  I looked around for how to get the value of a setting, but I didn't see anything.  **How do I get the value of a setting from `settings.yml` in a UI template?**