### PR TITLE
#1398 replaced parameter 'lang' with 'language'

### DIFF
--- a/dev/search_api.html
+++ b/dev/search_api.html
@@ -65,7 +65,7 @@ results based on this syntax, you might not get the results you wanted.</p>
 </div>
 <p>Comma separated list, specifies the active search engines.</p>
 <p>Optional.</p>
-<div class="code sh highlight-default"><div class="highlight"><pre><span></span><span class="n">lang</span>
+<div class="code sh highlight-default"><div class="highlight"><pre><span></span><span class="n">language</span>
 </pre></div>
 </div>
 <p>Code of the language.</p>


### PR DESCRIPTION
this is bug in the documentation. The code uses 'langugage' parameter