### PR TITLE
[add] seznam engine

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -723,6 +723,19 @@ engines:
     shortcut : du
     disabled : True
 
+  - name : seznam
+    shortcut: szn
+    engine: xpath
+    paging : True
+    search_url : https://search.seznam.cz/?q={query}&count=10&from={pageno}
+    results_xpath: //div[@class="Page-content"]//div[@class="Result "]
+    url_xpath : ./h3/a/@href
+    title_xpath : ./h3
+    content_xpath : .//p[@class="Result-description"]
+    first_page_num : 0
+    page_size : 10
+    disabled : True
+
 #  - name : yacy
 #    engine : yacy
 #    shortcut : ya


### PR DESCRIPTION
It adds new search engine for users from the Czech Republic (and therefore it is disabled by default). Seznam.cz is the biggest competitor to Google in the Czech Republic.