### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN echo "@commuedge http://nl.alpinelinux.org/alpine/edge/community" >> /etc/ap
     openssl-dev \
     ca-certificates \
     tini@commuedge \
+ && pip install --upgrade pip   
  && pip install --no-cache -r requirements.txt \
  && apk del \
     build-base \


### PR DESCRIPTION
- Fix for docker image build error "Could not find a version that satisfies the requirement cffi!=1.11.3,>=1.7 (from versions: )"