### PR TITLE
[Scripts] Force upgrade requirements.

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -18,12 +18,12 @@ ACTION="$1"
 update_packages() {
     pip install --upgrade pip
     pip install --upgrade setuptools
-    pip install -r "$BASE_DIR/requirements.txt"
+    pip install -Ur "$BASE_DIR/requirements.txt"
 }
 
 update_dev_packages() {
     update_packages
-    pip install -r "$BASE_DIR/requirements-dev.txt"
+    pip install -Ur "$BASE_DIR/requirements-dev.txt"
 }
 
 install_geckodriver() {


### PR DESCRIPTION
Force the upgrade of requirements with pip. At the moment, if the version
in the requirement file is changed, there will be no effect, because the
dependencies is already present.