### PR TITLE
Fix bing image thumbnail path

### DIFF
--- a/searx/engines/bing_images.py
+++ b/searx/engines/bing_images.py
@@ -88,9 +88,7 @@ def response(resp):
 
         url = json_data.get('purl')
         img_src = json_data.get('murl')
-
-        thumb_json_data = loads(_quote_keys_regex.sub(r'\1"\2": \3', link.attrib.get('mad')))
-        thumbnail = thumb_json_data.get('turl')
+        thumbnail = json_data.get('turl')
 
         # append result
         results.append({'template': 'images.html',

--- a/tests/unit/engines/test_bing_images.py
+++ b/tests/unit/engines/test_bing_images.py
@@ -52,7 +52,7 @@ class TestBingImagesEngine(SearxTestCase):
                 <li>
                     <div>
                         <div class="imgpt">
-                            <a m='{"purl":"page_url","murl":"img_url"}' mad='{"turl":"thumb_url"}'>
+                            <a m='{"purl":"page_url","murl":"img_url","turl":"thumb_url"}'>
                                 <img src="" alt="alt text" />
                             </a>
                         </div>
@@ -60,7 +60,7 @@ class TestBingImagesEngine(SearxTestCase):
                     </div>
                     <div>
                         <div class="imgpt">
-                            <a m='{"purl":"page_url2","murl":"img_url2"}' mad='{"turl":"thumb_url2"}'>
+                            <a m='{"purl":"page_url2","murl":"img_url2","turl":"thumb_url2"}'>
                                 <img src="" alt="alt text 2" />
                             </a>
                         </div>
@@ -71,7 +71,7 @@ class TestBingImagesEngine(SearxTestCase):
                 <li>
                     <div>
                         <div class="imgpt">
-                            <a m='{"purl":"page_url3","murl":"img_url3"}' mad='{"turl":"thumb_url3"}'>
+                            <a m='{"purl":"page_url3","murl":"img_url3","turl":"thumb_url3"}'>
                                 <img src="" alt="alt text 3" />
                             </a>
                         </div>


### PR DESCRIPTION
Avoid following error by updating thumbnail xpath for bing_images engine.

```
Traceback (most recent call last):
  File "/usr/local/searx/searx/search.py", line 105, in search_one_request_safe
    search_results = search_one_request(engine, query, request_params)
  File "/usr/local/searx/searx/search.py", line 88, in search_one_request
    return engine.response(response)
  File "/usr/local/searx/searx/engines/bing_images.py", line 92, in response
    thumb_json_data = loads(_quote_keys_regex.sub(r'\1"\2": \3', link.attrib.get('mad')))
TypeError: expected string or buffer
ERROR:searx.search:engine bing images : exception : expected string or buffer
```