### PR TITLE
[FIX] image_proxify

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -295,6 +295,9 @@ def image_proxify(url):
     if not request.preferences.get_value('image_proxy'):
         return url
 
+    if url.startswith('data:image/jpeg;base64,'):
+        return url
+
     if settings.get('result_proxy'):
         return proxify(url)
 


### PR DESCRIPTION
It ignores base64 encoded jpeg when image proxyfying is active. It fixes e.g. previews in google videos engine.