### PR TITLE
Workaround for pip problem in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN echo "@commuedge http://nl.alpinelinux.org/alpine/edge/community" >> /etc/ap
     ca-certificates \
     tini@commuedge \
  && pip install --upgrade pip \
- && pip install --no-cache -r requirements.txt \
+ && pip install --no-cache --no-use-pep517 -r requirements.txt \
  && apk del \
     build-base \
     python-dev \


### PR DESCRIPTION
The following exception is thrown when building the current Dockerfile. (Reported in https://github.com/asciimoo/searx/issues/1495#issuecomment-457484148)
```
Exception:
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/pip/_internal/cli/base_command.py", line 176, in main
    status = self.run(options, args)
  File "/usr/lib/python2.7/site-packages/pip/_internal/commands/install.py", line 346, in run
    session=session, autobuilding=True
  File "/usr/lib/python2.7/site-packages/pip/_internal/wheel.py", line 886, in build
    assert have_directory_for_build
AssertionError
```
It is a bug in `pip`: https://github.com/pypa/pip/issues/6197
This PR follows the workaround proposed in the issue above. It adds `--no-use-pep517` flag to `pip install`.