### PR TITLE
[fix] Stop engine from sending duplicated requests

### DIFF
--- a/searx/query.py
+++ b/searx/query.py
@@ -113,19 +113,16 @@ class RawTextQuery(object):
                     parse_next = True
                     engine_name = engine_shortcuts[prefix]
                     if engine_name in engines:
-                        for engine_category in engines[engine_name].categories:
-                            self.engines.append({'category': engine_category,
-                                                 'name': engine_name,
-                                                 'from_bang': True})
+                        self.engines.append({'category': 'none',
+                                             'name': engine_name,
+                                             'from_bang': True})
 
                 # check if prefix is equal with engine name
                 elif prefix in engines:
                     parse_next = True
-                    if prefix in engines:
-                        for engine_category in engines[prefix].categories:
-                            self.engines.append({'category': engine_category,
-                                                 'name': prefix,
-                                                 'from_bang': True})
+                    self.engines.append({'category': 'none',
+                                         'name': prefix,
+                                         'from_bang': True})
 
                 # check if prefix is equal with categorie name
                 elif prefix in categories:


### PR DESCRIPTION
If you search `!youtube example` two requests are being sent to YouTube.
This happens every time you use a bang to call an engine that supports more than one category.

That was originally added in #1136 in order to support Findx, but now that engine is gone and as far as I know no other engine requires this.