### PR TITLE
Improve infinite scroll (and with it fixing a bug)

### DIFF
--- a/searx/static/plugins/js/infinite_scroll.js
+++ b/searx/static/plugins/js/infinite_scroll.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
     var win = $(window);
     win.scroll(function() {
-        if ($(document).height() - win.height() == win.scrollTop()) {
+        if ($(document).height() - win.height() - win.scrollTop() < 150) {
             var formData = $('#pagination form:last').serialize();
             if (formData) {
                 $('#pagination').html('<div class="loading-spinner"></div>');


### PR DESCRIPTION
This improves the user experience by loading in the next entries shortly before him getting to the bottom of the page. It makes the scrolling more smooth without a break in between.

It also fixes an error on my browser that scrolling never hits the defined number needed to load the next results. When I debugged it I hit `.scrolltop` of 1092.5 and the `doc.height - win.height` of 1093, so the condition was never true. See screenshot: 
![image](https://user-images.githubusercontent.com/9467802/58896183-c57e2980-86f5-11e9-93af-dc2db54f6c1b.png)

It may even be better to load the next results even earlier. ATM I set it to 150px before hitting the bottom of the page.