### PR TITLE
Add addr setup via SEARX_BIND_ADDRESS

### DIFF
--- a/searx/__init__.py
+++ b/searx/__init__.py
@@ -91,3 +91,5 @@ logger.info('Initialisation done')
 
 if 'SEARX_SECRET' in environ:
     settings['server']['secret_key'] = environ['SEARX_SECRET']
+if 'SEARX_BIND_ADDRESS' in environ:
+    settings['server']['bind_address'] = environ['SEARX_BIND_ADDRESS']


### PR DESCRIPTION
To avoid a `sed` on meta-address in settings.yml. This is very useful in docker environment and developer mode. Here an example of usage `SEARX_BIND_ADDRESS=0.0.0.0 python searx/webapp.py`