### PR TITLE
Various small bug fixes

### DIFF
--- a/searx/results.py
+++ b/searx/results.py
@@ -212,11 +212,20 @@ class ResultContainer(object):
 
         # check for duplicates
         duplicated = False
+        result_template = result.get('template')
         for merged_result in self._merged_results:
             if compare_urls(result['parsed_url'], merged_result['parsed_url'])\
-               and result.get('template') == merged_result.get('template'):
-                duplicated = merged_result
-                break
+               and result_template == merged_result.get('template'):
+                if result_template != 'images.html':
+                    # not an image, same template, same url : it's a duplicate
+                    duplicated = merged_result
+                    break
+                else:
+                    # it's an image
+                    # it's a duplicate if the parsed_url, template and img_src are differents
+                    if result.get('img_src', '') == merged_result.get('img_src', ''):
+                        duplicated = merged_result
+                        break
 
         # merge duplicates together
         if duplicated:

--- a/searx/search.py
+++ b/searx/search.py
@@ -198,6 +198,13 @@ def default_request_params():
     }
 
 
+# remove duplicate queries.
+# FIXME: does not fix "!music !soundcloud", because the categories are 'none' and 'music'
+def deduplicate_query_engines(query_engines):
+    uniq_query_engines = {q["category"] + '|' + q["name"]: q for q in query_engines}
+    return uniq_query_engines.values()
+
+
 def get_search_query_from_webapp(preferences, form):
     # no text for the query ?
     if not form.get('q'):
@@ -327,6 +334,8 @@ def get_search_query_from_webapp(preferences, form):
                                       'name': engine.name}
                                      for engine in categories[categ]
                                      if (engine.name, categ) not in disabled_engines)
+
+    query_engines = deduplicate_query_engines(query_engines)
 
     return (SearchQuery(query, query_engines, query_categories,
                         query_lang, query_safesearch, query_pageno, query_time_range),

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -707,7 +707,7 @@ engines:
     shortcut : 1337x
     disabled : True
 
-  - name : Duden
+  - name : duden
     engine : duden
     shortcut : du
     disabled : True

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -916,7 +916,7 @@ def page_not_found(e):
 
 
 def run():
-    logger.debug('starting webserver on %s:%s', settings['server']['port'], settings['server']['bind_address'])
+    logger.debug('starting webserver on %s:%s', settings['server']['bind_address'], settings['server']['port'])
     app.run(
         debug=searx_debug,
         use_debugger=searx_debug,


### PR DESCRIPTION
* the query "!wp !wp test" sends only one request to wikipedia (but not "!general !wp" because the category for "!wp" is "none")
* don't merge image results if the img_src is different
* ```searx/settings.yml```: make sure all engine names are lower case
* ```searx/engines/__init__.py```: make sure then engine name is lower case 
* ```searx/engines/__init__.py```: debug message "%s engine initialized" displays the right engine name
* ```searx/webapp.py```: fix the debug message "starting webserver on ip:port" (instead of "port:ip")
