### PR TITLE
[fix] Small fixes in Preferences view's text

### DIFF
--- a/searx/answerers/random/answerer.py
+++ b/searx/answerers/random/answerer.py
@@ -70,4 +70,4 @@ def answer(query):
 def self_info():
     return {'name': gettext('Random value generator'),
             'description': gettext('Generate different random values'),
-            'examples': [u'random {}'.format(x) for x in random_types]}
+            'examples': [u'random {}'.format(x.decode('utf-8')) for x in random_types]}

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -792,7 +792,7 @@ locales:
     te : తెలుగు (telugu)
     tr : Türkçe (Turkish)
     uk : українська мова (Ukrainian)
-    vi : tiếng việt (㗂越)
+    vi : tiếng việt (Vietnamese)
     zh : 中文 (Chinese)
     zh_TW : 國語 (Taiwanese Mandarin)
 

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -166,9 +166,6 @@ def get_locale():
        and request.form['locale'] in settings['locales']:
         locale = request.form['locale']
 
-    if locale == 'zh_TW':
-        locale = 'zh_Hant_TW'
-
     return locale
 
 


### PR DESCRIPTION
This fixes the following bugs:

1. With Python 3 the random answerer's examples are being rendered as ``random b'string', random b'int', random b'float', random b'sha256', random b'uuid'``.

2. In the interface language dropdown, the Vietnamese option has the Chinese name of the language inside the parenthesis rather than the English version like all the other options.

3. When the interface language is set to Taiwanese Chinese and you return to the Preferences view, the interface language dropdown shows Arabic as the selected language (reported in #1532).

About the last one: The ``locale = 'zh_Hant_TW'`` line is not needed anyway because Flask Babel already converts zh_TW to zh_Hant_TW by itself.