### PR TITLE
Add --no-cache to tell apk to not cache packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ RUN addgroup -g ${SEARX_GID} searx && \
 
 COPY requirements.txt ./requirements.txt
 
-RUN apk -U upgrade \
- && apk add -t build-dependencies \
+RUN apk upgrade --no-cache \
+ && apk add --no-cache -t build-dependencies \
     build-base \
     py3-setuptools \
     python3-dev \
@@ -36,7 +36,7 @@ RUN apk -U upgrade \
     openssl-dev \
     tar \
     git \
- && apk add \
+ && apk add --no-cache \
     ca-certificates \
     su-exec \
     python3 \
@@ -48,8 +48,7 @@ RUN apk -U upgrade \
     uwsgi-python3 \
  && pip3 install --upgrade pip \
  && pip3 install --no-cache -r requirements.txt \
- && apk del build-dependencies \
- && rm -f /var/cache/apk/*
+ && apk del build-dependencies
 
 COPY --chown=searx:searx . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
 FROM alpine:3.10
+ENTRYPOINT ["/sbin/tini","--","/usr/local/searx/dockerfiles/docker-entrypoint.sh"]
+EXPOSE 8080
+VOLUME /etc/searx
+VOLUME /var/log/uwsgi
+RUN addgroup -g ${SEARX_GID} searx && \
+    adduser -u ${SEARX_UID} -D -h /usr/local/searx -s /bin/sh -G searx searx
 
-ARG VERSION_GITCOMMIT=unknow
-ARG SEARX_GIT_VERSION=unknow
+ARG VERSION_GITCOMMIT=unknown
+ARG SEARX_GIT_VERSION=unknown
 
-ARG SEARX_GID=1000
-ARG SEARX_UID=1000
+ARG SEARX_GID=977
+ARG SEARX_UID=977
 
 ARG TIMESTAMP_SETTINGS=0
 ARG TIMESTAMP_UWSGI=0
@@ -14,14 +20,9 @@ ARG LABEL_VCS_URL=
 ENV BASE_URL= \
     MORTY_KEY= \
     MORTY_URL=
-EXPOSE 8080
-VOLUME /etc/searx
-VOLUME /var/log/uwsgi
 
 WORKDIR /usr/local/searx
 
-RUN addgroup -g ${SEARX_GID} searx && \
-    adduser -u ${SEARX_UID} -D -h /usr/local/searx -s /bin/sh -G searx searx
 
 COPY requirements.txt ./requirements.txt
 
@@ -59,7 +60,6 @@ RUN su searx -c "/usr/bin/python3 -m compileall -q searx"; \
       echo "VERSION_STRING = VERSION_STRING + \"-$VERSION_GITCOMMIT\"" >> /usr/local/searx/searx/version.py; \
     fi
 
-ENTRYPOINT ["/sbin/tini","--","/usr/local/searx/dockerfiles/docker-entrypoint.sh"]
 
 # Keep this argument at the end since it change each time
 ARG LABEL_DATE=

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,15 @@ ENTRYPOINT ["/sbin/tini","--","/usr/local/searx/dockerfiles/docker-entrypoint.sh
 EXPOSE 8080
 VOLUME /etc/searx
 VOLUME /var/log/uwsgi
-RUN addgroup -g ${SEARX_GID} searx && \
-    adduser -u ${SEARX_UID} -D -h /usr/local/searx -s /bin/sh -G searx searx
 
 ARG VERSION_GITCOMMIT=unknown
 ARG SEARX_GIT_VERSION=unknown
 
 ARG SEARX_GID=977
 ARG SEARX_UID=977
+
+RUN addgroup -g ${SEARX_GID} searx && \
+    adduser -u ${SEARX_UID} -D -h /usr/local/searx -s /bin/sh -G searx searx
 
 ARG TIMESTAMP_SETTINGS=0
 ARG TIMESTAMP_UWSGI=0


### PR DESCRIPTION
1. Add `--no-cache` to `apk upgrade` and `apk add` calls. This eliminates the need to delete the package cache. 

2. Some other minor optimizations mostly around metadata where order does not matter, but you want to delay cache invalidation.