### PR TITLE
[mod] Separate index and search routes

### DIFF
--- a/searx/static/plugins/js/infinite_scroll.js
+++ b/searx/static/plugins/js/infinite_scroll.js
@@ -9,7 +9,7 @@ function loadNextPage() {
         $('#pagination').html('<div class="loading-spinner"></div>');
         $.ajax({
             type: "POST",
-            url: './',
+            url: $('#search_form').prop('action'),
             data: formData,
             dataType: 'html',
             success: function(data) {

--- a/searx/templates/__common__/opensearch.xml
+++ b/searx/templates/__common__/opensearch.xml
@@ -6,9 +6,9 @@
   <Image>{{ urljoin(host, url_for('static', filename='img/favicon.png')) }}</Image>
   <LongName>searx metasearch</LongName>
   {% if opensearch_method == 'get' %}
-    <Url rel="results" type="text/html" method="get" template="{{ host }}?q={searchTerms}"/>
+    <Url rel="results" type="text/html" method="get" template="{{ url_for('search', _external=True) }}?q={searchTerms}"/>
   {% else %}
-    <Url rel="results" type="text/html" method="post" template="{{ host }}">
+    <Url rel="results" type="text/html" method="post" template="{{ url_for('search', _external=True) }}">
         <Param name="q" value="{searchTerms}" />
     </Url>
   {% endif %}

--- a/searx/templates/__common__/opensearch_response_rss.xml
+++ b/searx/templates/__common__/opensearch_response_rss.xml
@@ -4,7 +4,7 @@
      xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Searx search: {{ q|e }}</title>
-    <link>{{ base_url }}?q={{ q|e }}</link>
+    <link>{{ url_for('search', _external=True) }}?q={{ q|e }}</link>
     <description>Search results for "{{ q|e }}" - searx</description>
     <opensearch:totalResults>{{ number_of_results }}</opensearch:totalResults>
     <opensearch:startIndex>1</opensearch:startIndex>

--- a/searx/templates/courgette/results.html
+++ b/searx/templates/courgette/results.html
@@ -1,6 +1,6 @@
 {% extends "courgette/base.html" %}
 {% block title %}{{ q|e }} - {% endblock %}
-{% block meta %}<link rel="alternate" type="application/rss+xml" title="Searx search: {{ q|e }}" href="{{ url_for('index') }}?q={{ q|urlencode }}&amp;format=rss&amp;{% for category in selected_categories %}category_{{ category }}=1&amp;{% endfor %}pageno={{ pageno }}">{% endblock %}
+{% block meta %}<link rel="alternate" type="application/rss+xml" title="Searx search: {{ q|e }}" href="{{ url_for('search', _external=True) }}?q={{ q|urlencode }}&amp;format=rss&amp;{% for category in selected_categories %}category_{{ category }}=1&amp;{% endfor %}pageno={{ pageno }}">{% endblock %}
 {% block content %}
 <div class="right"><a href="{{ url_for('preferences') }}" id="preferences"><span>{{ _('preferences') }}</span></a></div>
 <div class="small search center">
@@ -10,12 +10,12 @@
     <div id="sidebar">
         <div id="search_url">
             {{ _('Search URL') }}:
-            <input type="text" value="{{ base_url }}?q={{ q|urlencode }}{% if selected_categories %}&amp;categories={{ selected_categories|join(",") | replace(' ','+') }}{% endif %}{% if pageno > 1 %}&amp;pageno={{ pageno }}{% endif %}" readonly />
+            <input type="text" value="{{ url_for('search', _external=True) }}?q={{ q|urlencode }}{% if selected_categories %}&amp;categories={{ selected_categories|join(",") | replace(' ','+') }}{% endif %}{% if pageno > 1 %}&amp;pageno={{ pageno }}{% endif %}" readonly />
         </div>
         <div id="apis">
             {{ _('Download results') }}<br />
             {% for output_type in ('csv', 'json', 'rss') %}
-            <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}">
+            <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}">
                 <div class="left">
                     <input type="hidden" name="q" value="{{ q|e }}" />
                     <input type="hidden" name="format" value="{{ output_type }}" />
@@ -41,7 +41,7 @@
     {% if suggestions %}
     <div id="suggestions"><span>{{ _('Suggestions') }}</span>
         {% for suggestion in suggestions %}
-        <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}">
+        <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}">
             <input type="hidden" name="q" value="{{ suggestion.url }}">
             <input type="submit" value="{{ suggestion.title }}" />
         </form>
@@ -60,7 +60,7 @@
     {% if paging %}
     <div id="pagination">
         {% if pageno > 1 %}
-            <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}">
+            <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}">
                 <div class="left">
                     <input type="hidden" name="q" value="{{ q|e }}" />
                     {% for category in selected_categories %}
@@ -71,7 +71,7 @@
                 </div>
             </form>
         {% endif %}
-        <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}">
+        <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}">
             <div class="left">
                 {% for category in selected_categories %}
                 <input type="hidden" name="category_{{ category }}" value="1"/>

--- a/searx/templates/courgette/search.html
+++ b/searx/templates/courgette/search.html
@@ -1,4 +1,4 @@
-<form method="{{ method or 'POST' }}" action="{{ url_for('index') }}" id="search_form">
+<form method="{{ method or 'POST' }}" action="{{ url_for('search') }}" id="search_form">
     <div id="search_wrapper">
         <input type="text" autofocus placeholder="{{ _('Search for...') }}" id="q" class="q" name="q" tabindex="1" autocomplete="off" {% if q %}value="{{ q }}"{% endif %}/>
         <input type="submit" value="search" id="search_submit" />

--- a/searx/templates/legacy/infobox.html
+++ b/searx/templates/legacy/infobox.html
@@ -36,7 +36,7 @@
         <div>
             <h3><bdi>{{ topic.name }}</bdi></h3>
             {% for suggestion in topic.suggestions %}
-            <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}">
+            <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}">
                 <input type="hidden" name="q" value="{{ suggestion }}">
                 <input type="submit" value="{{ suggestion }}" />
             </form>

--- a/searx/templates/legacy/results.html
+++ b/searx/templates/legacy/results.html
@@ -1,6 +1,6 @@
 {% extends "legacy/base.html" %}
 {% block title %}{{ q|e }} - {% endblock %}
-{% block meta %}<link rel="alternate" type="application/rss+xml" title="Searx search: {{ q|e }}" href="{{ url_for('index') }}?q={{ q|urlencode }}&amp;format=rss&amp;{% for category in selected_categories %}category_{{ category }}=1&amp;{% endfor %}pageno={{ pageno }}">{% endblock %}
+{% block meta %}<link rel="alternate" type="application/rss+xml" title="Searx search: {{ q|e }}" href="{{ url_for('search', _external=True) }}?q={{ q|urlencode }}&amp;format=rss&amp;{% for category in selected_categories %}category_{{ category }}=1&amp;{% endfor %}pageno={{ pageno }}">{% endblock %}
 {% block content %}
 <div class="preferences_container right"><a href="{{ url_for('preferences') }}" id="preferences"><span>preferences</span></a></div>
 <div class="small search center">
@@ -11,12 +11,12 @@
 
         <div id="search_url">
             {{ _('Search URL') }}:
-            <input type="text" value="{{ base_url }}?q={{ q|urlencode }}{% if selected_categories %}&amp;categories={{ selected_categories|join(",") | replace(' ','+') }}{% endif %}{% if pageno > 1 %}&amp;pageno={{ pageno }}{% endif %}" readonly />
+            <input type="text" value="{{ url_for('search', _external=True) }}?q={{ q|urlencode }}{% if selected_categories %}&amp;categories={{ selected_categories|join(",") | replace(' ','+') }}{% endif %}{% if pageno > 1 %}&amp;pageno={{ pageno }}{% endif %}" readonly />
         </div>
         <div id="apis">
         {{ _('Download results') }}
         {% for output_type in ('csv', 'json', 'rss') %}
-        <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}">
+        <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}">
             <div class="left">
             <input type="hidden" name="q" value="{{ q|e }}" />
             <input type="hidden" name="format" value="{{ output_type }}" />
@@ -47,7 +47,7 @@
     <div id="suggestions"><span id="suggestions-title">{{ _('Suggestions') }} : </span>
         {% set first = true %}
         {% for suggestion in suggestions %}
-        {% if not first %} &bull; {% endif %}<form method="{{ method or 'POST' }}" action="{{ url_for('index') }}">
+        {% if not first %} &bull; {% endif %}<form method="{{ method or 'POST' }}" action="{{ url_for('search') }}">
             <input type="hidden" name="q" value="{{ suggestion.url }}">
             <input type="submit" class="suggestion" value="{{ suggestion.title }}" />
         </form>
@@ -75,7 +75,7 @@
     {% if paging %}
     <div id="pagination">
         {% if pageno > 1 %}
-            <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}">
+            <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}">
                 <div class="{% if rtl %}right{% else %}left{% endif %}">
                 <input type="hidden" name="q" value="{{ q|e }}" />
                 {% for category in selected_categories %}
@@ -86,7 +86,7 @@
                 </div>
             </form>
         {% endif %}
-        <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}">
+        <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}">
             <div class="{% if rtl %}left{% else %}right{% endif %}">
                 {% for category in selected_categories %}
                 <input type="hidden" name="category_{{ category }}" value="1"/>

--- a/searx/templates/legacy/search.html
+++ b/searx/templates/legacy/search.html
@@ -1,4 +1,4 @@
-<form method="{{ method or 'POST' }}" action="{{ url_for('index') }}" id="search_form">
+<form method="{{ method or 'POST' }}" action="{{ url_for('search') }}" id="search_form">
     <div id="search_wrapper">
         <input type="text" autofocus placeholder="{{ _('Search for...') }}" id="q" class="q" name="q" tabindex="1" autocomplete="off" size="100" {% if q %}value="{{ q }}"{% endif %}/>
         <input type="submit" value="search" id="search_submit" />

--- a/searx/templates/oscar/results.html
+++ b/searx/templates/oscar/results.html
@@ -7,7 +7,7 @@
     <input type="hidden" name="language" value="{{ current_language }}" />{{- "" -}}
     {% if timeout_limit %}<input type="hidden" name="timeout_limit" value="{{ timeout_limit|e }}" />{% endif -%}
 {%- endmacro %}
-{%- macro search_url() %}{{ base_url }}?q={{ q|urlencode }}{% if selected_categories %}&amp;categories={{ selected_categories|join(",") | replace(' ','+') }}{% endif %}{% if pageno > 1 %}&amp;pageno={{ pageno }}{% endif %}{% if time_range %}&amp;time_range={{ time_range }}{% endif %}{% if current_language != 'all' %}&amp;language={{ current_language }}{% endif %}{% endmacro -%}
+{%- macro search_url() %}{{ url_for('search', _external=True) }}?q={{ q|urlencode }}{% if selected_categories %}&amp;categories={{ selected_categories|join(",") | replace(' ','+') }}{% endif %}{% if pageno > 1 %}&amp;pageno={{ pageno }}{% endif %}{% if time_range %}&amp;time_range={{ time_range }}{% endif %}{% if current_language != 'all' %}&amp;language={{ current_language }}{% endif %}{% endmacro -%}
 
 {% block title %}{{ q|e }} - {% endblock %}
 {% block meta %}{{"    "}}<link rel="alternate" type="application/rss+xml" title="Searx search: {{ q|e }}" href="{{ search_url() }}&amp;format=rss">{% endblock %}
@@ -42,7 +42,7 @@
                 </div>
                 <div class="panel-body">
                     {% for suggestion in suggestions %}
-                    <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}" role="navigation" class="form-inline pull-{% if rtl %}right{% else %}left{% endif %} suggestion_item">
+                    <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}" role="navigation" class="form-inline pull-{% if rtl %}right{% else %}left{% endif %} suggestion_item">
                         {% if current_language != 'all' %}
                         <input type="hidden" name="language" value="{{ current_language }}">
                         {% endif %}
@@ -71,7 +71,7 @@
                     <label>{{ _('Download results') }}</label>
                     <div class="clearfix"></div>
                     {% for output_type in ('csv', 'json', 'rss') %}
-                    <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}" class="form-inline pull-{% if rtl %}right{% else %}left{% endif %} result_download">
+                    <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}" class="form-inline pull-{% if rtl %}right{% else %}left{% endif %} result_download">
                         {{- search_form_attrs(pageno) -}}
                         <input type="hidden" name="format" value="{{ output_type }}">{{- "" -}}
                         <button type="submit" class="btn btn-default">{{ output_type }}</button>{{- "" -}}
@@ -92,7 +92,7 @@
                 <div class="clearfix">
                     <span class="result_header text-muted form-inline pull-left suggestion_item">{{ _('Try searching for:') }}</span>
                     {% for correction in corrections -%}
-                        <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}" role="navigation" class="form-inline pull-left suggestion_item">{{- "" -}}
+                        <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}" role="navigation" class="form-inline pull-left suggestion_item">{{- "" -}}
                             {% if current_language != 'all' %}
                             <input type="hidden" name="language" value="{{ current_language }}">
                             {% endif %}
@@ -140,13 +140,13 @@
             {% if rtl %}
             <div id="pagination">
                 <div class="pull-left">{{- "" -}}
-                  <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}" class="pull-left">
+                  <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}" class="pull-left">
                         {{- search_form_attrs(pageno+1) -}}
                         <button type="submit" class="btn btn-default"><span class="glyphicon glyphicon-backward"></span> {{ _('next page') }}</button>{{- "" -}}
                     </form>{{- "" -}}
                 </div>
                 <div class="pull-right">{{- "" -}}
-                    <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}"  class="pull-left">
+                    <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}"  class="pull-left">
                         {{- search_form_attrs(pageno-1) -}}
                         <button type="submit" class="btn btn-default" {% if pageno == 1 %}disabled{% endif %}><span class="glyphicon glyphicon-forward"></span> {{ _('previous page') }}</button>{{- "" -}}
                     </form>{{- "" -}}
@@ -156,13 +156,13 @@
             {% else %}
             <div id="pagination">
                 <div class="pull-left">{{- "" -}}
-                    <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}" class="pull-left">
+                    <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}" class="pull-left">
                         {{- search_form_attrs(pageno-1) -}}
                         <button type="submit" class="btn btn-default" {% if pageno == 1 %}disabled{% endif %}><span class="glyphicon glyphicon-backward"></span> {{ _('previous page') }}</button>{{- "" -}}
                     </form>{{- "" -}}
                 </div>
                 <div class="pull-right">{{- "" -}}
-                    <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}"  class="pull-left">
+                    <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}"  class="pull-left">
                         {{- search_form_attrs(pageno+1) -}}
                         <button type="submit" class="btn btn-default"><span class="glyphicon glyphicon-forward"></span> {{ _('next page') }}</button>{{- "" -}}
                     </form>{{- "" -}}

--- a/searx/templates/oscar/search.html
+++ b/searx/templates/oscar/search.html
@@ -1,5 +1,5 @@
 {% from 'oscar/macros.html' import icon %}
-<form method="{{ method or 'POST' }}" action="{{ url_for('index') }}" id="search_form" role="search">
+<form method="{{ method or 'POST' }}" action="{{ url_for('search') }}" id="search_form" role="search">
   <div class="row">
     <div class="col-xs-12 col-md-8">
       <div class="input-group search-margin">

--- a/searx/templates/oscar/search_full.html
+++ b/searx/templates/oscar/search_full.html
@@ -1,6 +1,6 @@
 {% from 'oscar/macros.html' import icon %}
 
-<form method="{{ method or 'POST' }}" action="{{ url_for('index') }}" id="search_form" role="search">
+<form method="{{ method or 'POST' }}" action="{{ url_for('search') }}" id="search_form" role="search">
     {% if rtl %}
     <div class="input-group">
     {% else %}

--- a/searx/templates/pix-art/search.html
+++ b/searx/templates/pix-art/search.html
@@ -1,4 +1,4 @@
-<form method="{{ method or 'POST' }}" action="{{ url_for('index') }}" id="search_form">
+<form method="{{ method or 'POST' }}" action="{{ url_for('search') }}" id="search_form">
     <div id="search_wrapper">
         <input type="text" autofocus placeholder="{{ _('Search for...') }}" id="q" class="q" name="q" tabindex="1" size="100" {% if q %}value="{{ q }}"{% endif %}/>
         <input type="submit" value="" id="search_submit" />

--- a/searx/templates/simple/infobox.html
+++ b/searx/templates/simple/infobox.html
@@ -33,7 +33,7 @@
     <div>
       <h3><bdi>{{ topic.name }}</bdi></h3>
       {% for suggestion in topic.suggestions %}
-      <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}">
+      <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}">
         <input type="hidden" name="q" value="{{ suggestion }}">
         <input type="hidden" name="time_range" value="{{ time_range }}">
         <input type="hidden" name="language" value="{{ current_language }}">

--- a/searx/templates/simple/results.html
+++ b/searx/templates/simple/results.html
@@ -1,7 +1,7 @@
 {% extends "simple/base.html" %}
 {% from 'simple/macros.html' import icon, icon_small %}
 {% block title %}{% if method == 'GET' %}{{- q|e -}} -{% endif %}{% endblock %}
-{% block meta %}<link rel="alternate" type="application/rss+xml" title="Searx search: {{ q|e }}" href="{{ url_for('index') }}?q={{ q|urlencode }}&amp;categories={{ selected_categories|join(",") | replace(' ','+') }}&amp;pageno={{ pageno }}&amp;time_range={{ time_range }}&amp;language={{ current_language }}&amp;safesearch={{ safesearch }}&amp;format=rss">{% endblock %}
+{% block meta %}<link rel="alternate" type="application/rss+xml" title="Searx search: {{ q|e }}" href="{{ url_for('search', _external=True) }}?q={{ q|urlencode }}&amp;categories={{ selected_categories|join(",") | replace(' ','+') }}&amp;pageno={{ pageno }}&amp;time_range={{ time_range }}&amp;language={{ current_language }}&amp;safesearch={{ safesearch }}&amp;format=rss">{% endblock %}
 {% block content %}
 <nav id="linkto_preferences"><a href="{{ url_for('preferences') }}">{{ icon('navicon-round') }}</a></nav>
 {% include 'simple/search.html' %}
@@ -55,7 +55,7 @@
 	  <h4 class="title">{{ _('Suggestions') }} : </h4>
 	  <div class="wrapper">
             {% for suggestion in suggestions %}
-            <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}">
+            <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}">
               <input type="hidden" name="q" value="{{ suggestion.url }}">
               <input type="hidden" name="time_range" value="{{ time_range }}">
               <input type="hidden" name="language" value="{{ current_language }}">
@@ -71,13 +71,13 @@
 
         <div id="search_url">
             <h4 class="title">{{ _('Search URL') }} :</h4>
-            <div class="selectable_url"><pre>{{ base_url }}?q={{ q|urlencode }}&amp;language={{ current_language }}&amp;time_range={{ time_range }}&amp;safesearch={{ safesearch }}{% if pageno > 1 %}&amp;pageno={{ pageno }}{% endif %}{% if selected_categories %}&amp;categories={{ selected_categories|join(",") | replace(' ','+') }}{% endif %}{% if timeout_limit %}&amp;timeout_limit={{ timeout_limit|urlencode }}{% endif %}</pre></div>
+            <div class="selectable_url"><pre>{{ url_for('search', _external=True) }}?q={{ q|urlencode }}&amp;language={{ current_language }}&amp;time_range={{ time_range }}&amp;safesearch={{ safesearch }}{% if pageno > 1 %}&amp;pageno={{ pageno }}{% endif %}{% if selected_categories %}&amp;categories={{ selected_categories|join(",") | replace(' ','+') }}{% endif %}{% if timeout_limit %}&amp;timeout_limit={{ timeout_limit|urlencode }}{% endif %}</pre></div>
         </div>
         <div id="apis">
           <h4 class="title">{{ _('Download results') }}</h4>
           {% for output_type in ('csv', 'json', 'rss') %}
 	  <div class="left">
-            <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}">
+            <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}">
               <input type="hidden" name="q" value="{{ q|e }}">
               {% for category in selected_categories %}
               <input type="hidden" name="category_{{ category }}" value="1">
@@ -100,7 +100,7 @@
       <h4>{{ _('Try searching for:') }}</h4>
       {% for correction in corrections %}
       <div class="left">
-	<form method="{{ method or 'POST' }}" action="{{ url_for('index') }}" role="navigation">
+	<form method="{{ method or 'POST' }}" action="{{ url_for('search') }}" role="navigation">
           <input type="hidden" name="q" value="{{ correction.url }}">
           <input type="hidden" name="time_range" value="{{ time_range }}">
           <input type="hidden" name="language" value="{{ current_language }}">
@@ -133,7 +133,7 @@
     {% if paging %}
     <nav id="pagination">
         {% if pageno > 1 %}
-            <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}">
+            <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}">
                 <div class="{% if rtl %}right{% else %}left{% endif %}">
                   <input type="hidden" name="q" value="{{ q|e }}" >
                   {% for category in selected_categories %}
@@ -149,7 +149,7 @@
                 </div>
             </form>
         {% endif %}
-        <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}">
+        <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}">
             <div class="{% if rtl %}left{% else %}right{% endif %}">
               <input type="hidden" name="q" value="{{ q|e }}" >
               {% for category in selected_categories %}

--- a/searx/templates/simple/search.html
+++ b/searx/templates/simple/search.html
@@ -1,4 +1,4 @@
-<form id="search" method="{{ method or 'POST' }}" action="{{ url_for('index') }}">
+<form id="search" method="{{ method or 'POST' }}" action="{{ url_for('search') }}">
   <div id="search_wrapper">
     <div class="search_box">
       <input id="q" autofocus name="q" type="text" placeholder="{{ _('Search for...') }}" tabindex="1" autocomplete="off" spellcheck="false" dir="auto" {% if q %}value="{{ q }}"{% endif %} >

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -531,10 +531,22 @@ def index_error(output_format, error_message):
         )
 
 
-@app.route('/search', methods=['GET', 'POST'])
 @app.route('/', methods=['GET', 'POST'])
 def index():
-    """Render index page.
+    """Render index page."""
+
+    # redirect to search if there's a query in the request
+    if request.form.get('q'):
+        return redirect(url_for('search'), 308)
+
+    return render(
+        'index.html',
+    )
+
+
+@app.route('/search', methods=['GET', 'POST'])
+def search():
+    """Search query in q and return results.
 
     Supported outputs: html, json, csv, rss.
     """

--- a/tests/unit/test_webapp.py
+++ b/tests/unit/test_webapp.py
@@ -77,6 +77,11 @@ class ViewsTestCase(SearxTestCase):
 
     def test_index_html(self):
         result = self.app.post('/', data={'q': 'test'})
+        self.assertEqual(result.status_code, 308)
+
+    def test_search_html(self):
+        result = self.app.post('/search', data={'q': 'test'})
+
         self.assertIn(
             b'<h3 class="result_title"><img width="14" height="14" class="favicon" src="/static/themes/legacy/img/icons/icon_youtube.ico" alt="youtube" /><a href="http://second.test.xyz" rel="noreferrer">Second <span class="highlight">Test</span></a></h3>',  # noqa
             result.data
@@ -88,7 +93,10 @@ class ViewsTestCase(SearxTestCase):
 
     def test_index_json(self):
         result = self.app.post('/', data={'q': 'test', 'format': 'json'})
+        self.assertEqual(result.status_code, 308)
 
+    def test_search_json(self):
+        result = self.app.post('/search', data={'q': 'test', 'format': 'json'})
         result_dict = json.loads(result.data.decode())
 
         self.assertEqual('test', result_dict['query'])
@@ -98,6 +106,10 @@ class ViewsTestCase(SearxTestCase):
 
     def test_index_csv(self):
         result = self.app.post('/', data={'q': 'test', 'format': 'csv'})
+        self.assertEqual(result.status_code, 308)
+
+    def test_search_csv(self):
+        result = self.app.post('/search', data={'q': 'test', 'format': 'csv'})
 
         self.assertEqual(
             b'title,url,content,host,engine,score,type\r\n'
@@ -108,6 +120,10 @@ class ViewsTestCase(SearxTestCase):
 
     def test_index_rss(self):
         result = self.app.post('/', data={'q': 'test', 'format': 'rss'})
+        self.assertEqual(result.status_code, 308)
+
+    def test_index_rss(self):
+        result = self.app.post('/search', data={'q': 'test', 'format': 'rss'})
 
         self.assertIn(
             b'<description>Search results for "test" - searx</description>',


### PR DESCRIPTION
This should make it easier to separately handle search and index requests from a web server or from a reverse proxy. Specifically, the problem right now is that both index and search requests look exactly the same to anything before searx itself, so it's hard to filter or rate-limit search queries without also targeting requests to index.

If a request to index contains a query, a permanent redirect HTTP response is returned. This should give some level of backwards compatibility for users that have set a searx instance in their browser's search bar. I would still recommend that users remove and add again searx in their browsers to avoid making double requests every time.

The search path in the URL is ``/search`` by default, but it can be customized in settings (this featured is inspired by [this comment](https://github.com/asciimoo/searx/issues/1584#issuecomment-493596451)). The search_path setting can even be empty. In that case, queries are run on index, just like they did before this pull request.