### PR TITLE
Infobox fixes

### DIFF
--- a/searx/engines/wikipedia.py
+++ b/searx/engines/wikipedia.py
@@ -21,7 +21,8 @@ search_url = base_url + u'w/api.php?'\
     'action=query'\
     '&format=json'\
     '&{query}'\
-    '&prop=extracts|pageimages'\
+    '&prop=extracts|pageimages|pageprops'\
+    '&ppprop=disambiguation'\
     '&exintro'\
     '&explaintext'\
     '&pithumbsize=300'\
@@ -87,7 +88,7 @@ def response(resp):
         if int(article_id) > 0:
             break
 
-    if int(article_id) < 0:
+    if int(article_id) < 0 or 'disambiguation' in page.get('pageprops', {}):
         return []
 
     title = page.get('title')

--- a/searx/engines/wikipedia.py
+++ b/searx/engines/wikipedia.py
@@ -100,6 +100,7 @@ def response(resp):
     extract = page.get('extract')
 
     summary = extract_first_paragraph(extract, title, image)
+    summary = summary.replace('() ', '')
 
     # link to wikipedia article
     wikipedia_link = base_url.format(language=url_lang(resp.search_params['language'])) \

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -606,11 +606,11 @@ def index():
     # HTML output format
 
     # suggestions: use RawTextQuery to get the suggestion URLs with the same bang
-    suggestion_urls = map(lambda suggestion: {
-                          'url': raw_text_query.changeSearchQuery(suggestion).getFullQuery(),
-                          'title': suggestion
-                          },
-                          result_container.suggestions)
+    suggestion_urls = list(map(lambda suggestion: {
+                               'url': raw_text_query.changeSearchQuery(suggestion).getFullQuery(),
+                               'title': suggestion
+                               },
+                               result_container.suggestions))
 
     correction_urls = list(map(lambda correction: {
                                'url': raw_text_query.changeSearchQuery(correction).getFullQuery(),


### PR DESCRIPTION
Fixes issues in #1685 (or at least provides some workarounds) and also fixes another bug I found with the suggestions box.

1. The first issue happens because Wikipedia returns a disambiguation page. Since disambiguation pages do not return any meaningful information for now, I think it would be better to just remove them from the results.
Alternatively, we could later add a special case where disambiguation pages return a list of possible articles in an infobox or somewhere else.

2. About the second issue, it looks like Wikipedia's API [removes](https://www.mediawiki.org/wiki/Extension:TextExtracts#How_can_I_remove_content_from_a_page_preview/extract?) the IPA pronunciation for some reason. E.g. https://en.wikipedia.org/w/api.php?action=query&format=json&titles=git&prop=extracts|pageimages&explaintext&exintro
So as long as we can't retrieve the pronunciation, it would be better to at least remove the empty parenthesis as well.
There is a small risk that this removes a set of empty parenthesis that are actually meant to be in the article, but I haven't found any case yet. Luckily, this fix even works with the [( ) (album)](https://en.wikipedia.org/wiki/(_)_(album)) article.

3. Finally, there's also a python3 specific bug where the suggestion box is always shown even when it's empty. That's because in python3 map returns an iterator so we don't know whether it's empty or not until we iterate through it.