### PR TITLE
pycurl instead of requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 cache:
   - pip
   - npm
@@ -9,6 +8,8 @@ cache:
 addons:
   firefox: "latest"
 
+before_install:
+  - sudo apt-get install -y libcurl4-openssl-dev libssl-dev
 install:
   - ./manage.sh install_geckodriver ~/drivers
   - export PATH=~/drivers:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN apk -U upgrade \
     libxslt-dev \
     libxml2-dev \
     openssl-dev \
+    curl-dev \
     tar \
     git \
  && apk add \
@@ -45,6 +46,8 @@ RUN apk -U upgrade \
     libxml2 \
     libxslt \
     openssl \
+    libcurl \
+    libstdc++ \
     tini \
     uwsgi \
     uwsgi-python3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,8 +58,7 @@ RUN apk -U upgrade \
 
 COPY --chown=searx:searx . .
 
-RUN su searx -c "/usr/bin/python3 -m compileall -q searx"; \
-    touch -c --date=@${TIMESTAMP_SETTINGS} searx/settings.yml; \
+RUN touch -c --date=@${TIMESTAMP_SETTINGS} searx/settings.yml; \
     touch -c --date=@${TIMESTAMP_UWSGI} dockerfiles/uwsgi.ini; \
     if [ ! -z $VERSION_GITCOMMIT ]; then\
       echo "VERSION_STRING = VERSION_STRING + \"-$VERSION_GITCOMMIT\"" >> /usr/local/searx/searx/version.py; \

--- a/misc/httpclient_bench.py
+++ b/misc/httpclient_bench.py
@@ -1,0 +1,163 @@
+from sys import path
+from os.path import realpath, dirname
+path.append(realpath(dirname(realpath(__file__)) + '/../'))
+
+import sys
+import gc
+import aiohttp
+import asyncio
+import time
+import uvloop
+from statistics import mean, stdev
+import searx.httpclient
+import searx.httpclient.requests
+import concurrent.futures
+import logging
+from searx import settings, logger
+
+urls1 = [
+    'https://a.searx.space/0',
+    'https://a.searx.space/1',
+    'https://a.searx.space/2',
+    'https://a.searx.space/3',
+    'https://a.searx.space/4',
+    'https://a.searx.space/5',
+    'https://a.searx.space/6',
+    'https://a.searx.space/7',
+    'https://a.searx.space/8',
+    'https://a.searx.space/9',
+    # 'https://github.com',
+    'https://en.wikipedia.org/wiki/List_of_Unicode_characters',
+    'https://en.wikipedia.org/wiki/Windows-1252'
+    # 'https://google.com',
+]
+
+urls2 = [
+    # 'https://yandex.com/search/?text=test&p=0',
+    'https://www.wikidata.org/w/index.php?search=test&ns0=1',
+    'https://duckduckgo.com/html?q=test&kl=us-en&s=0&dc=0',
+    'https://en.wikipedia.org/w/api.php?action=query&format=json&titles=test%7CTest'\
+    + '&prop=extracts%7Cpageimages&exintro&explaintext&pithumbsize=300&redirects',
+    'https://www.bing.com/search?q=language%3AEN+test&first=1',
+    'https://api.duckduckgo.com/?q=test&format=json&pretty=0&no_redirect=1&d=1'
+]
+
+urls3 = [
+    'https://a.searx.space/9'
+]
+
+user_agent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:69.0) Gecko/20100101 Firefox/69.0'
+
+
+def timed(func):
+    async def wrapper(*args):
+        print('<', end='')
+        sys.stdout.flush()
+        start = time.time()
+        await func(*args)
+        t = round(time.time() - start, 4)
+        await asyncio.sleep(0.125)
+        print('>', end='')
+        sys.stdout.flush()
+        return t
+    return wrapper
+
+
+def timed_sync(func):
+    def wrapper(*args):
+        start = time.time()
+        func(*args)
+        return round(time.time() - start, 4)
+    return wrapper
+
+
+async def fetch_aiohttp(session, url):
+    async with session.get(url) as response:
+        return await response.text()
+
+
+@timed
+async def main_aiohttp(urls, client_session):
+    coroutines = [fetch_aiohttp(client_session, url) for url in urls]
+    await asyncio.gather(*coroutines)
+
+
+async def fetch_curl(async_multi_request, url):
+    # print('.', end='')
+    response = await async_multi_request.async_request(method='GET', url=url, timeout=3)
+    # print(':', end='')
+    return response.text
+
+
+@timed
+async def main_curl(urls, async_multi_request):
+    coroutines = [fetch_curl(async_multi_request, url) for url in urls]
+    await asyncio.gather(*coroutines)
+    # futures = [ async_multi_request.async_request(method='GET', url=url) for url in urls ]
+    # responses = await asyncio.gather(futures, return_exceptions=True)
+    # print(responses)
+    # texts = [response.text() for response in responses]
+    # print(futures[0].result())
+
+
+async def bench_aiohttp(bench_urls):
+    client_session = aiohttp.ClientSession()
+    try:
+        print('== aiohttp ==')
+        r = [await main_aiohttp(bench_urls, client_session) for i in range(10)]
+        # await asyncio.sleep(30)
+        r = r + [await main_aiohttp(bench_urls, client_session) for i in range(10)]
+        print(f'\n--> avg={mean(r)} s. stdev={stdev(r)} s.')
+        print(r)
+    finally:
+        await client_session.close()
+
+
+async def bench_curl(bench_urls):
+    print('== curl ==')
+    async_multi_request = searx.httpclient.AsyncioSession()
+    async_multi_request.start()
+    try:
+        r = [await main_curl(bench_urls, async_multi_request) for i in range(10)]
+        # await asyncio.sleep(30)
+        r = r + [await main_curl(bench_urls, async_multi_request) for i in range(10)]
+        print(f'\n--> avg={mean(r)} s. stdev={stdev(r)} s.')
+        print(r)
+    finally:
+        async_multi_request.close()
+
+
+def main(coroutine, prof_filename):
+    import yappi
+    import cProfile
+
+    profiling = False
+
+    logging.basicConfig(level=logging.DEBUG)
+    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+    loop = asyncio.get_event_loop()
+
+    if profiling:
+        yappi.start(builtins=True)
+        yappi.set_clock_type("cpu")
+
+    try:
+        searx.httpclient.requests.SESSION.stop()
+        loop.run_until_complete(coroutine)
+
+        gc.collect()
+    finally:
+        if profiling:
+            yappi.stop()
+            pr = yappi.convert2pstats(yappi.get_func_stats())
+            pr.dump_stats(prof_filename)
+            yappi.clear_stats()
+
+if __name__ == '__main__':
+    import pycurl
+    print(pycurl.version)
+
+    bench_urls = urls1 + urls2 + urls3
+
+    main(bench_aiohttp(bench_urls), 'aiohttp.prof')
+    # main(bench_curl(bench_urls), 'curl.prof')

--- a/misc/httpclient_main.py
+++ b/misc/httpclient_main.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+if __name__ == '__main__':
+    from sys import path
+    from os.path import realpath, dirname
+    path.append(realpath(dirname(realpath(__file__)) + '/../../'))
+
+    import concurrent.futures
+    from searx.httpclient import Sessions, logger
+
+    import yappi
+    import cProfile
+    import time
+
+    yappi.start(builtins=True)
+
+    r = Sessions()
+    # time.sleep(10)
+
+    start_time = time.time()
+    a = time.time()
+    allresponses = []
+
+    # r1 = r.request('GET', 'https://httpbin.org/delay/0', headers={'User-Agent': 'x'})
+    allresponses.append(r.async_request('GET', 'https://a.searx.space/404',
+                                        timeout=5.1, params={'q': 'test'}, debug=False))
+    allresponses.append(r.async_request('GET', 'https://a-v2.sndcdn.com/assets/app-55ad8b3-d95005d-3.js',
+                                        timeout=20, debug=True))
+    # r2 = r.request('GET', 'https://a.searx.space/config', cookies={'as': 'sa', 'bb': 'cc'})
+    # r3 = r.request('GET', 'https://a.searx.space', timeout=1.0, headers={'User-Agent': 'x'})
+    # for i in range(1, 100):
+    #    allresponses.append(r.async_request('GET', 'https://a.searx.space/dummmy/' + str(i), timeout=5.0))
+
+    for async_response in concurrent.futures.as_completed(allresponses):
+        try:
+            response = async_response.result()
+            print(response.request)
+            print(response)
+            print(response.request.url, response.status_code, response.reason, response.headers, response.cookies)
+        except Exception as e:
+            logger.exception(e)
+        # print(v.text)
+        # print(v.headers)
+
+    print(time.time() - start_time)
+
+    r.close()
+    yappi.stop()
+    pr = yappi.convert2pstats(yappi.get_func_stats())
+    pr.dump_stats('curl.prof')

--- a/misc/httpclient_stream.py
+++ b/misc/httpclient_stream.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+
+
+urls1 = [
+    'https://a.searx.space/0',
+    'https://a.searx.space/1',
+    'https://a.searx.space/2',
+    'https://a.searx.space/3',
+    'https://a.searx.space/4',
+    'https://a.searx.space/5',
+    'https://a.searx.space/6',
+    'https://a.searx.space/7',
+    'https://a.searx.space/8',
+    'https://a.searx.space/9',
+    # 'https://github.com',
+    'https://en.wikipedia.org/wiki/List_of_Unicode_characters',
+    'https://en.wikipedia.org/wiki/Windows-1252'
+    # 'https://google.com',
+]
+
+urls2 = [
+    # 'https://yandex.com/search/?text=test&p=0',
+    'https://www.wikidata.org/w/index.php?search=test&ns0=1',
+    'https://duckduckgo.com/html?q=test&kl=us-en&s=0&dc=0',
+    'https://en.wikipedia.org/w/api.php?action=query&format=json&titles=test%7CTest'\
+    + '&prop=extracts%7Cpageimages&exintro&explaintext&pithumbsize=300&redirects',
+    'https://www.bing.com/search?q=language%3AEN+test&first=1',
+    'https://api.duckduckgo.com/?q=test&format=json&pretty=0&no_redirect=1&d=1'
+]
+
+urls3 = [
+    'https://a.searx.space/9'
+]
+
+urls4 = [
+    'https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Parque_Eagle_River%2C_Anchorage%2C_Alaska%2C_Estados_Unidos%2C_2017-09-01%2C_DD_21.jpg/800px-Parque_Eagle_River%2C_Anchorage%2C_Alaska%2C_Estados_Unidos%2C_2017-09-01%2C_DD_21.jpg'  # noqa
+]
+
+urls = urls1 + urls2 + urls3 + urls4
+
+if __name__ == '__main__':
+    from sys import path
+    import gc
+    # from guppy import hpy; h=hpy()
+    from os.path import realpath, dirname
+    path.append(realpath(dirname(realpath(__file__)) + '/../'))
+
+    import searx.httpclient
+    import requests
+
+    # import yappi
+    # import cProfile
+    import time
+    import linecache
+    import os
+    # import tracemalloc
+
+    def mean(t):
+        total = 0
+        count = 0
+        for i in t:
+            total = total + i
+            count = count + 1
+        if count > 0:
+            return total / count
+        else:
+            return 0
+
+    def stdev(t):
+        return 0
+
+    try:
+        from statistics import mean, stdev
+    except:
+        pass
+
+    def memory_dump():
+        # Add to leaky code within python_script_being_profiled.py
+        from pympler import muppy, summary
+        all_objects = muppy.get_objects()
+        sum1 = summary.summarize(all_objects)# Prints out a summary of the large objects
+        summary.print_(sum1)# Get references to certain types of objects such as dataframe
+
+
+    def display_top(snapshot, key_type='lineno', limit=10):
+        #snapshot = snapshot.filter_traces((
+        #    tracemalloc.Filter(False, "<frozen importlib._bootstrap>"),
+        #    tracemalloc.Filter(False, "<unknown>"),
+        #))
+        top_stats = snapshot.statistics(key_type)
+
+        print("Top %s lines" % limit)
+        for index, stat in enumerate(top_stats[:limit], 1):
+            frame = stat.traceback[0]
+            # replace "/path/to/module/file.py" with "module/file.py"
+            filename = os.sep.join(frame.filename.split(os.sep)[-2:])
+            print("#%s: %s:%s: %.1f KiB"
+                % (index, filename, frame.lineno, stat.size / 1024))
+            line = linecache.getline(frame.filename, frame.lineno).strip()
+            if line:
+                print('    %s' % line)
+
+        other = top_stats[limit:]
+        if other:
+            size = sum(stat.size for stat in other)
+            print("%s other: %.1f KiB" % (len(other), size / 1024))
+        total = sum(stat.size for stat in top_stats)
+        print("Total allocated size: %.1f KiB" % (total / 1024))
+
+
+    def fetch_url(r, u):
+        start_time = time.time()
+        response = r.request('GET', u, timeout=5.1, stream=False)
+        # print(response.request)
+        # print(response)
+        # print(response.request.url, response.status_code, response.reason, response.headers, response.cookies)
+        return time.time() - start_time 
+
+    @profile
+    def test():
+        print('start')
+        # with requests.Session() as r:
+        with searx.httpclient.Session() as r:
+            t = []
+            for u in urls:
+                t.append(fetch_url(r, u))
+            time.sleep(30)
+            for u in urls:
+                t.append(fetch_url(r, u))
+        gc.collect()
+        print('end\n--> avg={0} s. stdev={1} s.'.format(mean(t), stdev(t)))
+
+    # yappi.start(builtins=True)
+    
+    tmalloc = False
+
+    if tmalloc:
+        tracemalloc.start(100)
+        snapshot1 = tracemalloc.take_snapshot()
+
+    test()
+
+    if tmalloc:
+        snapshot2 = tracemalloc.take_snapshot()
+        top_stats = snapshot2.compare_to(snapshot1, 'lineno')
+        print("[ Top 10 ]")
+        for stat in top_stats[:10]:
+            print(stat)
+
+        display_top(snapshot2, key_type='lineno')
+    # memory_dump()
+    # print(h.heap())
+    # yappi.stop()
+    # pr = yappi.convert2pstats(yappi.get_func_stats())
+    # pr.dump_stats('curl.prof')

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pyyaml==5.1
 pycurl==7.43.0.3
 cchardet==2.1.4
 distro==1.4.0
+futures==3.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,11 @@ certifi==2019.3.9
 babel==2.7.0
 flask-babel==0.12.2
 flask==1.0.2
-idna==2.8
 jinja2==2.10.1
 lxml==4.3.3
 pygments==2.1.3
-pyopenssl==19.0.0
 python-dateutil==2.8.0
 pyyaml==5.1
-requests[socks]==2.22.0
+pycurl==7.43.0.3
+cchardet==2.1.4
+distro==1.4.0

--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -24,7 +24,7 @@ from searx.languages import language_codes
 from searx.engines import (
     categories, engines, engine_shortcuts
 )
-from searx.poolrequests import get as http_get
+from searx.httpclient import get as http_get
 from searx.url_utils import urlencode
 
 if sys.version_info[0] == 3:

--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -24,7 +24,7 @@ from babel.localedata import locale_identifiers
 from flask_babel import gettext
 from operator import itemgetter
 from json import loads
-from requests import get
+from searx.httpclient.requests import get
 from searx import settings
 from searx import logger
 from searx.utils import load_module, match_language, get_engine_from_settings

--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -16,7 +16,7 @@
 from lxml.html import fromstring
 from json import loads
 from searx.engines.xpath import extract_text
-from searx.poolrequests import get
+from searx.httpclient import get
 from searx.url_utils import urlencode
 from searx.utils import match_language
 

--- a/searx/engines/duckduckgo_images.py
+++ b/searx/engines/duckduckgo_images.py
@@ -19,7 +19,7 @@ from searx.engines.duckduckgo import (
     _fetch_supported_languages, supported_languages_url,
     get_region_code, language_aliases
 )
-from searx.poolrequests import get
+from searx.httpclient.requests import get
 from searx.url_utils import urlencode
 
 # engine dependent config

--- a/searx/engines/pubmed.py
+++ b/searx/engines/pubmed.py
@@ -15,7 +15,7 @@ from flask_babel import gettext
 from lxml import etree
 from datetime import datetime
 from searx.url_utils import urlencode
-from searx.poolrequests import get
+from searx.httpclient import get
 
 
 categories = ['science']

--- a/searx/engines/soundcloud.py
+++ b/searx/engines/soundcloud.py
@@ -15,7 +15,7 @@ from json import loads
 from lxml import html
 from dateutil import parser
 from searx import logger
-from searx.poolrequests import get as http_get
+from searx.httpclient import get as http_get
 from searx.url_utils import quote_plus, urlencode
 
 try:

--- a/searx/engines/wikidata.py
+++ b/searx/engines/wikidata.py
@@ -12,7 +12,7 @@
 """
 
 from searx import logger
-from searx.poolrequests import get
+from searx.httpclient import get
 from searx.engines.xpath import extract_text
 from searx.engines.wikipedia import _fetch_supported_languages, supported_languages_url
 from searx.url_utils import urlencode

--- a/searx/engines/wolframalpha_noapi.py
+++ b/searx/engines/wolframalpha_noapi.py
@@ -11,7 +11,7 @@
 from json import loads
 from time import time
 
-from searx.poolrequests import get as http_get
+from searx.httpclient import get as http_get
 from searx.url_utils import urlencode
 
 # search-url
@@ -48,7 +48,7 @@ def obtain_token():
     update_time = time() - (time() % 3600)
     try:
         token_response = http_get('https://www.wolframalpha.com/input/api/v1/code?ts=9999999999999999999', timeout=2.0)
-        token['value'] = loads(token_response.text)['code']
+        token['value'] = token_response.json()['code']
         token['last_updated'] = update_time
     except:
         pass

--- a/searx/httpclient/__init__.py
+++ b/searx/httpclient/__init__.py
@@ -17,5 +17,5 @@ from searx.httpclient.requests import (set_timeout_for_thread, reset_time_for_th
 from searx.httpclient.models import (Request, Response)
 
 from searx.httpclient.sessions import Session
-if sys.version_info[0] == 3 and sys.version_info[1] >= 6:
+if sys.version_info[0] == 3 and sys.version_info[1] >= 5:
     from searx.httpclient.asynciosessions import AsyncioSession

--- a/searx/httpclient/__init__.py
+++ b/searx/httpclient/__init__.py
@@ -17,5 +17,5 @@ from searx.httpclient.requests import (set_timeout_for_thread, reset_time_for_th
 from searx.httpclient.models import (Request, Response)
 
 from searx.httpclient.sessions import Session
-if sys.version_info[0] == 3:
+if sys.version_info[0] == 3 and sys.version_info[1] >= 6:
     from searx.httpclient.asynciosessions import AsyncioSession

--- a/searx/httpclient/__init__.py
+++ b/searx/httpclient/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# pycurl with the requests API
+# borrow code from https://github.com/psf/requests
+# borrow code from https://github.com/Lispython/human_curl/blob/master/human_curl/core.py ( Alexandr Lispython )
+import sys
+import searx.httpclient.misc
+
+from searx.httpclient.exceptions import (HTTPError, RequestError, InvalidURLError,
+                                         MissingSchemaError, InvalidMethodError,
+                                         TimeoutError, ConnectionError, CurlError,
+                                         SSLError, TooManyRedirects, ProxyError)
+
+from searx.httpclient.requests import (set_timeout_for_thread, reset_time_for_thread,
+                                       get_time_for_thread, request, get, post, head,
+                                       options, delete, patch, put)
+
+from searx.httpclient.models import (Request, Response)
+
+from searx.httpclient.sessions import Session
+if sys.version_info[0] == 3:
+    from searx.httpclient.asynciosessions import AsyncioSession

--- a/searx/httpclient/asynciosessions.py
+++ b/searx/httpclient/asynciosessions.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+import asyncio
+import pycurl
+from searx.httpclient.sessions import Session
+from searx.httpclient.models import PreparedResponse
+
+
+class AsyncioFutureResponse(object):
+
+    def __init__(self, request, curl_handler, loop):
+        self.request = request
+        self.curl_handler = curl_handler
+        self._loop = loop
+        self._future = loop.create_future()
+        self._prepare_response = PreparedResponse(request, curl_handler)
+
+    def _finish(self, err_code=None, err_string=None):
+        (result, exception) = self._prepare_response.finish(err_code, err_string)
+        if exception:
+            self._loop.call_soon_threadsafe(self._future.set_exception, exception)
+        if result:
+            self._loop.call_soon_threadsafe(self._future.set_result, result)
+
+    def _get_user_object(self):
+        return self._future
+
+
+class AsyncioSession(Session):
+
+    def __init__(self, loop=None, **kwargs):
+        super(AsyncioSession, self).__init__(**kwargs)
+        if loop is None:
+            loop = asyncio.get_event_loop()
+        self._loop = loop
+
+    def _new_async_response(self, request, handle):
+        return AsyncioFutureResponse(request, handle, self._loop)
+
+    async def request(self, method, url, **kwargs):
+        async_response = self.async_request(method, url, **kwargs)
+        return await async_response.result()

--- a/searx/httpclient/exceptions.py
+++ b/searx/httpclient/exceptions.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+import pycurl
+
+
+class HTTPError(Exception):
+    "Base exception used by this module."
+    pass
+
+
+class RequestError(IOError):
+    """There was an ambiguous exception that occurred while handling your
+    request.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Initialize RequestException with `request` and `response` objects."""
+        response = kwargs.pop('response', None)
+        self.response = response
+        self.request = kwargs.pop('request', None)
+        if (response is not None and not self.request and
+                hasattr(response, 'request')):
+            self.request = self.response.request
+        self.err_code = kwargs.pop('err_code', None)
+        self.err_string = kwargs.pop('err_string', None)
+        self.message = self.__repr__()
+        super(RequestError, self).__init__(*args)
+
+    def __repr__(self):
+        if hasattr(self, 'request'):
+            req = 'request({0} "{1}")'.format(self.request.method, self.request.url)
+        else:
+            req = None
+        if hasattr(self, 'response') and hasattr(self.response, 'status_code'):
+            res = 'response({0})'.format(self.response.status_code)
+        else:
+            res = None
+        if hasattr(self, 'err_code') and hasattr(self, 'err_string') and self.err_code is not None:
+            err = 'cURL error({0}): {1}'.format(self.err_code, self.err_string)
+        else:
+            err = None
+        return ', '.join(filter(None, (req, res, err)))
+
+    def __str__(self):
+        return self.__repr__()
+
+
+class InvalidURLError(RequestError, ValueError):
+    """The URL provided was somehow invalid."""
+
+
+class MissingSchemaError(RequestError, ValueError):
+    """The URL schema (e.g. http or https) is missing."""
+
+
+class InvalidMethodError(RequestError, ValueError):
+    """The method is invalid"""
+
+
+class TimeoutError(RequestError):
+    """Timeout exception"""
+
+
+class ConnectionError(RequestError):
+    """A Connection error occurred."""
+
+
+class CurlError(RequestError):
+    """Curl error"""
+    def __init__(self, *args, **kwargs):
+        super(CurlError, self).__init__(*args, **kwargs)
+
+
+class SSLError(RequestError):
+    pass
+
+
+class TooManyRedirects(RequestError):
+    pass
+
+
+class ProxyError(RequestError):
+    pass
+
+
+CURL_ERROR_CODE_TO_EXCEPTION = {
+    pycurl.E_UNSUPPORTED_PROTOCOL: InvalidURLError,
+    pycurl.E_URL_MALFORMAT: InvalidURLError,
+    pycurl.E_COULDNT_RESOLVE_HOST: ConnectionError,
+    pycurl.E_COULDNT_CONNECT: ConnectionError,
+    pycurl.E_OPERATION_TIMEDOUT: TimeoutError,
+    pycurl.E_SSL_CONNECT_ERROR: SSLError,
+    pycurl.E_TOO_MANY_REDIRECTS: TooManyRedirects,
+    pycurl.E_SSL_CERTPROBLEM: SSLError,
+    pycurl.E_SSL_CIPHER: SSLError,
+    pycurl.E_SSL_ISSUER_ERROR: SSLError,
+    pycurl.E_COULDNT_RESOLVE_PROXY: ProxyError
+}

--- a/searx/httpclient/misc.py
+++ b/searx/httpclient/misc.py
@@ -1,0 +1,50 @@
+import distro
+import pycurl
+from searx.httpclient.utils import logger
+
+try:
+    import platform
+    if platform.system().lower() != 'windows':
+        import signal
+        from threading import current_thread
+        if current_thread().name == 'MainThread':
+            signal.signal(signal.SIGPIPE, signal.SIG_IGN)
+except ImportError:
+    pass
+
+
+def enable_http2():
+    d = distro.linux_distribution(full_distribution_name=False)
+    if d[0] == 'ubuntu' and d[1] == '18.04':
+        """
+        libcurl from Ubuntu 18.04.3 LTS segfaults on heavy load when HTTP/2 is used:
+        #0  Curl_add_buffer (in=0x0, inptr=inptr@entry=0x7f7d7023c108, size=size@entry=7) at http.c:1227
+        #1  0x00007f7d7021d67e in on_header (session=<optimized out>, frame=0x7f7d64512c68, name=<optimized out>, namelen=7, value=0x7f7d6ffc53bd "404", valuelen=3, flags=0 '\000', userp=0x7f7d642169d0) at http2.c:951
+        #2  0x00007f7d6ffbbc62 in nghttp2_session_mem_recv () from /usr/lib/x86_64-linux-gnu/libnghttp2.so.14
+        #3  0x00007f7d7021f186 in http2_recv (conn=0x7f7d642169d0, sockindex=<optimized out>, mem=0x3728060 "", len=<optimized out>, err=0x7f7d68e241c4) at http2.c:1581
+        #4  0x00007f7d701e932d in Curl_read (conn=conn@entry=0x7f7d642169d0, sockfd=17, buf=0x3728060 "", sizerequested=16384, n=n@entry=0x7f7d68e24270) at sendf.c:741
+        #5  0x00007f7d701fb619 in readwrite_data (comeback=0x7f7d68e242fb, done=0x7f7d68e242f9, didwhat=<synthetic pointer>, k=0x3722e30, conn=0x7f7d642169d0, data=0x3722d70) at transfer.c:475
+        #6  Curl_readwrite (conn=0x7f7d642169d0, data=data@entry=0x3722d70, done=done@entry=0x7f7d68e242f9, comeback=comeback@entry=0x7f7d68e242fb) at transfer.c:1118
+        #7  0x00007f7d70205e8b in multi_runsingle (multi=multi@entry=0x110c7c0, now=..., data=data@entry=0x3722d70) at multi.c:1871
+        #8  0x00007f7d702073e4 in curl_multi_perform (multi=0x110c7c0, running_handles=running_handles@entry=0x7f7d68e24474) at multi.c:2136
+
+        may be this code misuses libcurl, maybe there is a real in libcurl 7.58.0
+        doesn't happen with Alpine linux 3.10
+        """  # noqa
+        logger.warn('HTTP/2 disabled because of a bug in libcurl')
+        return False
+
+    features = PYCURL_VERSION[4]
+    # hardcoded value to fail safe: pycurl.VERSION_HTTP2 == 65536
+    return features & 65536 != 0
+
+
+def curl_version_ge(major, minor, patch):
+    v = (major << 16) & (minor << 8) & patch
+    return v >= PYCURL_VERSION[2]
+
+
+PYCURL_VERSION = pycurl.version_info()
+HAS_HTTP2 = enable_http2()
+
+pycurl.global_init(pycurl.GLOBAL_ALL)

--- a/searx/httpclient/misc.py
+++ b/searx/httpclient/misc.py
@@ -40,8 +40,8 @@ def enable_http2():
 
 
 def curl_version_ge(major, minor, patch):
-    v = (major << 16) & (minor << 8) & patch
-    return v >= PYCURL_VERSION[2]
+    v = (major << 16) | (minor << 8) | patch
+    return PYCURL_VERSION[2] >= v
 
 
 PYCURL_VERSION = pycurl.version_info()

--- a/searx/httpclient/models.py
+++ b/searx/httpclient/models.py
@@ -9,8 +9,8 @@ import cchardet as chardet
 from itertools import chain
 from re import compile as re_compile
 from searx.url_utils import urlencode, urljoin, urlparse, urlunparse, quote
-from searx.utils import basestring, to_key_val_list, IS_PY2
-from searx.httpclient.utils import logger, unquote_unreserved, to_native_string, CaseInsensitiveDict
+from searx.utils import basestring, IS_PY2
+from searx.httpclient.utils import logger, unquote_unreserved, to_native_string, to_key_val_list, CaseInsensitiveDict
 from searx.httpclient.misc import curl_version_ge, HAS_HTTP2
 from searx.httpclient import exceptions
 

--- a/searx/httpclient/models.py
+++ b/searx/httpclient/models.py
@@ -1,0 +1,701 @@
+# -*- coding: utf-8 -*-
+import sys
+import pycurl
+import certifi
+import cgi
+import time
+import logging
+import cchardet as chardet
+from itertools import chain
+from re import compile as re_compile
+from searx.url_utils import urlencode, urljoin, urlparse, urlunparse, quote
+from searx.utils import unicode, basestring, to_key_val_list, IS_PY2
+from searx.httpclient.utils import logger, unquote_unreserved, to_native_string, CaseInsensitiveDict
+from searx.httpclient.misc import curl_version_ge, HAS_HTTP2
+from searx.httpclient import exceptions
+
+if sys.version_info[0] == 3:
+    unicode = str
+
+try:
+    from io import BytesIO
+except ImportError:
+    from cStringIO import StringIO as BytesIO
+
+try:
+    import simplejson as json
+except ImportError:
+    import json
+
+try:
+    from http.cookies import SimpleCookie, CookieError
+except ImportError:
+    from Cookie import SimpleCookie, CookieError
+
+
+# from https://github.com/psf/requests/blob/428f7a275914f60a8f1e76a7d69516d617433d30/requests/models.py#L55
+DEFAULT_REDIRECT_LIMIT = 30
+CERTIFI_PATH = certifi.where()
+# from https://github.com/Lispython/human_curl/blob/1bdda958c4bb57f73f2332bfef5026a44270b3c3/human_curl/core.py#L61
+HTTP_GENERAL_RESPONSE_HEADER = re_compile(r"(?P<version>HTTP\/.*?)\s+(?P<code>\d{3})\s+(?P<message>.*)")
+
+TO_CURL_HTTP_METHOD = {
+    "GET": pycurl.HTTPGET,
+    "POST": pycurl.POST,
+    # "PUT": pycurl.UPLOAD,
+    "PUT": pycurl.PUT,
+    "HEAD": pycurl.NOBODY
+}
+SUPPORTED_METHODS = ("GET", "HEAD", "POST", "DELETE", "PUT", "OPTIONS")
+
+# FULL LIST OF GETINFO OPTIONS
+CURL_INFO_MAP = {
+    # timers
+    # An overview of the six time values available from curl_easy_getinfo()
+    # perform() --> NAMELOOKUP --> CONNECT --> APPCONNECT
+    # --> PRETRANSFER --> STARTTRANSFER --> TOTAL --> REDIRECT
+    "TOTAL_TIME": pycurl.TOTAL_TIME,
+    "NAMELOOKUP_TIME": pycurl.NAMELOOKUP_TIME,
+    "CONNECT_TIME": pycurl.CONNECT_TIME,
+    "APPCONNECT_TIME": pycurl.APPCONNECT_TIME,
+    "PRETRANSFER_TIME": pycurl.PRETRANSFER_TIME,
+    "STARTTRANSFER_TIME": pycurl.STARTTRANSFER_TIME,
+    "REDIRECT_TIME": pycurl.REDIRECT_TIME,
+}
+
+# PROXY
+PROXIES_TYPES_MAP = {
+    'socks5-hostname': pycurl.PROXYTYPE_SOCKS5_HOSTNAME,
+    'socks5': pycurl.PROXYTYPE_SOCKS5,
+    'socks4': pycurl.PROXYTYPE_SOCKS4,
+    'socks4a': pycurl.PROXYTYPE_SOCKS4A,
+    'http': pycurl.PROXYTYPE_HTTP,
+    'https': pycurl.PROXYTYPE_HTTP
+}
+
+# HTTPVERSION
+CURL_HTTPVERSION_MAP = {
+    pycurl.CURL_HTTP_VERSION_1_0: "HTTP/1.0",
+    pycurl.CURL_HTTP_VERSION_1_1: "HTTP/1.1",
+}
+
+if HAS_HTTP2:
+    CURL_HTTPVERSION_MAP[pycurl.CURL_HTTP_VERSION_2_0] = "HTTP/2"
+
+
+class PreparedResponse(object):
+
+    __slots__ = 'request', 'curl_handler', 'start_time', '_response_buffer', '_response_headers'
+
+    def __init__(self, request, curl_handler):
+        if request.stream:
+            raise NotImplementedError()
+        PrepareCurlHandler.prepare_curl_handler(request, curl_handler)
+        self.request = request
+        self.curl_handler = curl_handler
+        self.start_time = time.time()
+        self._response_headers = BytesIO()
+        curl_handler.setopt(pycurl.WRITEHEADER, self._response_headers)
+        self._response_buffer = BytesIO()
+        curl_handler.setopt(pycurl.WRITEDATA, self._response_buffer)
+
+    def get_remaining_time(self):
+        return max(0.0, self.request.timeout - (time.time() - self.start_time)) / 1000.0
+
+    # from https://github.com/Lispython/human_curl/blob/1bdda958c4bb57f73f2332bfef5026a44270b3c3/human_curl/core.py#L695
+    def _get_curl_info(self):
+        curl_handler = self.curl_handler
+        response_info = {}
+        for field, value in CURL_INFO_MAP.items():
+            try:
+                field_data = curl_handler.getinfo(value)
+            except Exception as e:
+                logger.warn("getinfo({0}) error".format(field), e)
+                continue
+            else:
+                response_info[field] = field_data
+        return response_info
+
+    def finish(self, err_code=None, err_string=None):
+        response = None
+        exception = None
+        curl_handler = self.curl_handler
+        try:
+            content_type = curl_handler.getinfo(pycurl.CONTENT_TYPE)
+        except:
+            content_type = None
+        try:
+            url = curl_handler.getinfo(pycurl.EFFECTIVE_URL)
+            content = self._response_buffer.getvalue()
+            headers_raw = self._response_headers.getvalue()
+            status_code = curl_handler.getinfo(pycurl.HTTP_CODE)
+            info = self._get_curl_info()
+            elapsed = time.time() - self.start_time
+            response = Response(self.request, url, content, status_code, headers_raw, content_type, info, elapsed)
+            if logger.isEnabledFor(logging.DEBUG):
+                http_version = CURL_HTTPVERSION_MAP.get(curl_handler.getinfo(pycurl.INFO_HTTP_VERSION), "HTTP?")
+                download_size = int(curl_handler.getinfo(pycurl.SIZE_DOWNLOAD))
+                logger.debug("\"{12} {0} {10}\" {9} {11}\n  total: {1:.3f}s, pycurl: {2:.3f}s, namelookup: {3:.3f}s, "
+                             "connect: {4:.3f}s, appconnect: {5:.3f}s, pretransfer: {6:.3f}s, "
+                             "starttransfer: {7:.3f}s, redirect: {8:.3f}s".format(
+                                 url, elapsed, info["TOTAL_TIME"],
+                                 info["NAMELOOKUP_TIME"], info["CONNECT_TIME"], info["APPCONNECT_TIME"],
+                                 info["PRETRANSFER_TIME"], info["STARTTRANSFER_TIME"], info["REDIRECT_TIME"],
+                                 status_code, http_version, download_size, self.request.method.upper()))
+            if err_code is not None:
+                logger.error("cURL error ({0}): {1} {2}".format(err_code, err_string, curl_handler.errstr()))
+                error = exceptions.CURL_ERROR_CODE_TO_EXCEPTION.get(err_code, exceptions.CurlError)
+                exception = error(response=response, request=self.request,
+                                  err_code=err_code, err_string=err_string)
+        except Exception as e:
+            logger.error(e)
+            exception = e
+        finally:
+            self._response_buffer.close()
+            self._response_headers.close()
+        return (response, exception)
+
+
+class PrepareCurlHandler(object):
+
+    @staticmethod
+    def prepare_curl_handler(request, curl_handler):
+        # no SIGNAL (seems to slow down request by about 100ms ?)
+        curl_handler.setopt(pycurl.NOSIGNAL, 1)
+
+        # wait for pipe connection to confirm
+        curl_handler.setopt(pycurl.PIPEWAIT, True)
+
+        # consistently use ipv4
+        curl_handler.setopt(pycurl.IPRESOLVE, pycurl.IPRESOLVE_V4)
+
+        # TCP FastOpen
+        curl_handler.setopt(pycurl.TCP_FASTOPEN, True)
+
+        # TCP KeepAlive
+        curl_handler.setopt(pycurl.TCP_KEEPALIVE, True)
+        curl_handler.setopt(pycurl.TCP_KEEPIDLE, 30)
+        curl_handler.setopt(pycurl.TCP_KEEPINTVL, 15)
+
+        # use TLS1.3 if possible
+        # curl_handler.setopt(pycurl.SSLVERSION, pycurl.SSLVERSION_MAX_TLSv1_3)
+
+        # see https://curl.haxx.se/docs/http2.html
+        if request.http2:
+            curl_handler.setopt(pycurl.HTTP_VERSION, pycurl.CURL_HTTP_VERSION_2TLS)
+        else:
+            curl_handler.setopt(pycurl.HTTP_VERSION, pycurl.CURL_HTTP_VERSION_1_1)
+
+        # use certifi
+        curl_handler.setopt(pycurl.CAINFO, CERTIFI_PATH)
+
+        # verify certificate ?
+        if request.verify:
+            curl_handler.setopt(pycurl.SSL_VERIFYPEER, 1)
+            curl_handler.setopt(pycurl.SSL_VERIFYHOST, 2)
+        else:
+            curl_handler.setopt(pycurl.SSL_VERIFYPEER, 0)
+            curl_handler.setopt(pycurl.SSL_VERIFYHOST, 0)
+
+        # set debug
+        curl_handler.setopt(pycurl.VERBOSE, request.debug)
+
+        # xferinfo function
+        if request.xferinfo_function is not None:
+            curl_handler.setopt(pycurl.NOPROGRESS, False)
+            curl_handler.setopt(pycurl.XFERINFOFUNCTION, request.xferinfo_function)
+        else:
+            curl_handler.setopt(pycurl.NOPROGRESS, True)
+
+        # set url
+        url, scheme, hostname = PrepareCurlHandler._prepare_url(request.url, request.params)
+        curl_handler.setopt(curl_handler.URL, url)
+
+        # Follow redirects
+        if request.allow_redirects:
+            curl_handler.setopt(pycurl.FOLLOWLOCATION, True)
+            curl_handler.setopt(pycurl.MAXREDIRS, DEFAULT_REDIRECT_LIMIT)
+        else:
+            curl_handler.setopt(pycurl.FOLLOWLOCATION, False)
+
+        # cURL automaticaly add supported encoding
+        curl_handler.setopt(curl_handler.ACCEPT_ENCODING, '')
+
+        # set timeout
+        curl_handler.setopt(curl_handler.CONNECTTIMEOUT_MS, int(request.timeout))
+        curl_handler.setopt(curl_handler.TIMEOUT_MS, int(request.timeout))
+
+        # set data
+        if request.data is not None:
+            curl_handler.setopt(curl_handler.POSTFIELDS, urlencode(request.data))
+
+        # Method
+        method = request.method.upper()
+        if method in TO_CURL_HTTP_METHOD.values():
+            curl_handler.setopt(TO_CURL_HTTP_METHOD[method], True)
+        elif method in SUPPORTED_METHODS:
+            curl_handler.setopt(pycurl.CUSTOMREQUEST, method)
+        else:
+            raise exceptions.InvalidMethodError("cURL request do not support %s" % method)
+
+        # Method: Responses without body
+        if method in ("OPTIONS", "HEAD", "DELETE"):
+            curl_handler.setopt(pycurl.NOBODY, True)
+
+        # Headers
+        curl_handler.setopt(pycurl.HTTPHEADER,
+                            ['{0}: {1}'.format(k, v)
+                             for k, v in request.headers.items()])
+
+        # Cookies
+        if request.cookies:
+            curl_handler.setopt(pycurl.COOKIE, '; '.join('{0}={1}'.format(k, v)
+                                for k, v in request.cookies.items()))
+        else:
+            curl_handler.unsetopt(pycurl.COOKIE)
+
+        # Proxy
+        if request.proxies:
+            proxy = PrepareCurlHandler.select_proxy(scheme, hostname, request.proxies)
+            if proxy is not None:
+                pscheme, pnetloc = proxy.split('://')
+                ptype = PROXIES_TYPES_MAP.get(pscheme.lower())
+                if ptype is not None:
+                    curl_handler.setopt(pycurl.PROXYTYPE, ptype)
+                    curl_handler.setopt(pycurl.PROXY, pnetloc)
+                else:
+                    raise exceptions.ProxyError(request=request)
+            else:
+                curl_handler.unsetopt(pycurl.PROXYTYPE)
+                curl_handler.unsetopt(pycurl.PROXY)
+
+    # modified version of https://github.com/psf/requests/blob/428f7a275914f60a8f1e76a7d69516d617433d30/requests/models.py#L356 # noqa
+    @staticmethod
+    def _prepare_url(url, params):
+        """Prepares the given HTTP URL."""
+        #: Accept objects that have string representations.
+        #: We're unable to blindly call unicode/str functions
+        #: as this will include the bytestring indicator (b'')
+        #: on python 3.x.
+        #: https://github.com/psf/requests/pull/2238
+        if isinstance(url, bytes):
+            url = url.decode('utf8')
+        else:
+            url = unicode(url)
+
+        # Remove leading whitespaces from url
+        url = url.lstrip()
+
+        # Don't do any URL preparation for non-HTTP schemes like `mailto`,
+        # `data` etc to work around exceptions from `url_parse`, which
+        # handles RFC 3986 only.
+        if ':' in url and not url.lower().startswith('http'):
+            return url
+
+        # Support for unicode domain names and paths.
+        try:
+            r = urlparse(url)
+            scheme, netloc, path, query, fragment, hostname = \
+                r.scheme, r.netloc, r.path, r.query, r.fragment, r.hostname
+        except ValueError as e:
+            raise exceptions.InvalidURLError(*e.args)
+
+        if not scheme:
+            error = "Invalid URL {0!r}: No schema supplied. Perhaps you meant http://{0}?"
+            error = error.format(to_native_string(url, 'utf8'))
+            raise exceptions.MissingSchemaError(error)
+
+        # check if there is a netloc
+        if not netloc:
+            raise exceptions.InvalidURLError("Invalid URL %r: No host supplied" % url)
+
+        # Bare domains aren't valid URLs.
+        if not path:
+            path = '/'
+
+        if IS_PY2:
+            if isinstance(scheme, str):
+                scheme = scheme.encode('utf-8')
+            if isinstance(netloc, str):
+                netloc = netloc.encode('utf-8')
+            if isinstance(path, str):
+                path = path.encode('utf-8')
+            if isinstance(query, str):
+                query = query.encode('utf-8')
+            if isinstance(fragment, str):
+                fragment = fragment.encode('utf-8')
+
+        if isinstance(params, (str, bytes)):
+            params = to_native_string(params)
+
+        enc_params = PrepareCurlHandler._encode_params(params)
+        if enc_params:
+            if query:
+                query = '%s&%s' % (query, enc_params)
+            else:
+                query = enc_params
+
+        return (PrepareCurlHandler.requote_uri(
+                urlunparse([scheme, netloc, path, None, query, fragment])),
+                scheme,
+                hostname)
+
+    # from https://github.com/psf/requests/blob/428f7a275914f60a8f1e76a7d69516d617433d30/requests/models.py#L83
+    @staticmethod
+    def _encode_params(data):
+        """Encode parameters in a piece of data.
+        Will successfully encode parameters when passed as a dict or a list of
+        2-tuples. Order is retained if data is a list of 2-tuples but arbitrary
+        if parameters are supplied as a dict.
+        """
+
+        if isinstance(data, (str, bytes)):
+            return data
+        elif hasattr(data, 'read'):
+            return data
+        elif hasattr(data, '__iter__'):
+            # speed optimization
+            if len(data) == 0:
+                return ''
+            result = []
+            for k, vs in to_key_val_list(data):
+                if isinstance(vs, basestring) or not hasattr(vs, '__iter__'):
+                    vs = [vs]
+                for v in vs:
+                    if v is not None:
+                        result.append(
+                            (k.encode('utf-8') if isinstance(k, str) else k,
+                             v.encode('utf-8') if isinstance(v, str) else v))
+            return urlencode(result, doseq=True)
+        else:
+            return data
+
+    # from https://github.com/psf/requests/blob/3e7d0a873f838e0001f7ac69b1987147128a7b5f/requests/utils.py#L594
+    @staticmethod
+    def requote_uri(uri):
+        """Re-quote the given URI.
+        This function passes the given URI through an unquote/quote cycle to
+        ensure that it is fully and consistently quoted.
+        :rtype: str
+        """
+        safe_with_percent = "!#$%&'()*+,/:;=?@[]~"
+        safe_without_percent = "!#$&'()*+,/:;=?@[]~"
+        try:
+            # Unquote only the unreserved characters
+            # Then quote only illegal characters (do not quote reserved,
+            # unreserved, or '%')
+            return quote(unquote_unreserved(uri), safe=safe_with_percent)
+        except exceptions.InvalidURLError:
+            # We couldn't unquote the given URI, so let's try quoting it, but
+            # there may be unquoted '%'s in the URI. We need to make sure they're
+            # properly quoted so they do not cause issues elsewhere.
+            return quote(uri, safe=safe_without_percent)
+
+    # from https://github.com/psf/requests/blob/3e7d0a873f838e0001f7ac69b1987147128a7b5f/requests/utils.py
+    @staticmethod
+    def select_proxy(scheme, hostname, proxies):
+        """Select a proxy for the url, if applicable.
+        :param url: The url being for the request
+        :param proxies: A dictionary of schemes or schemes and hosts to proxy URLs
+        """
+        if hostname is None:
+            return proxies.get(scheme, proxies.get('all'))
+
+        proxy_keys = [
+            scheme + '://' + hostname,
+            scheme,
+            'all://' + hostname,
+            'all',
+        ]
+        proxy = None
+        for proxy_key in proxy_keys:
+            if proxy_key in proxies:
+                proxy = proxies[proxy_key]
+                break
+
+        return proxy
+
+
+class Request(object):
+
+    def __init__(self,
+                 method=None,
+                 url=None,
+                 headers=None,
+                 data=None,
+                 params=None,
+                 cookies=None,
+                 stream=False,
+                 allow_redirects=True,
+                 max_redirects=0,
+                 http2=True,
+                 timeout=2.0,
+                 verify=True,
+                 proxies=None,
+                 debug=False,
+                 xferinfo_function=None):
+        if headers is None:
+            headers = {}
+        if params is None:
+            params = {}
+        if cookies is None:
+            cookies = {}
+        self.method = method
+        self.url = url
+        self.headers = headers
+        self.data = data
+        self.params = params
+        self.cookies = cookies
+        self.stream = stream
+        self.allow_redirects = allow_redirects
+        self.max_redirects = max_redirects
+        self.http2 = http2
+        self.timeout = int(timeout * 1000)  # in milisecs
+        self.verify = verify
+        self.proxies = proxies
+        self.debug = debug
+        self.xferinfo_function = xferinfo_function
+
+    def __repr__(self):
+        return '<Request [%s]>' % (self.method)
+
+
+# no __bool__ / __nonzero__ : https://github.com/psf/requests/issues/2002
+class Response(object):
+
+    def __init__(self, request, url, content, status_code, headers_raw, content_type, info, elapsed):
+        self.request = request
+        self.url = url
+        self.content = content
+        self._content_type = content_type
+        self._headers_raw = headers_raw
+        self.status_code = status_code
+        self.info = info
+        self.elapsed = elapsed
+        self._reason = None
+        self.encoding = self._encoding_from_content_type()
+        # list of parsed headers blocks
+        self._headers_history = []
+        # Redirects history
+        self._history = []
+        # Headers
+        self._headers = CaseInsensitiveDict()
+        # Cookies
+        self._cookies = {}
+
+    # from https://github.com/Lispython/human_curl/blob/1bdda958c4bb57f73f2332bfef5026a44270b3c3/human_curl/core.py#L761
+    @staticmethod
+    def _split_headers_blocks(raw_headers):
+        i = 0
+        blocks = []
+        for item in raw_headers.strip().split("\r\n"):
+            if item.startswith("HTTP"):
+                blocks.append([item])
+                i = len(blocks) - 1
+            elif item:
+                blocks[i].append(item)
+        return blocks
+
+    def _encoding_from_content_type(self):
+        if self._content_type:
+            _, params = cgi.parse_header(self._content_type)
+            charset = params.get('charset', None)
+            if charset:
+                return charset.lower()
+            else:
+                return None
+        else:
+            return None
+
+    # modify version of https://github.com/Lispython/human_curl/blob/1bdda958c4bb57f73f2332bfef5026a44270b3c3/human_curl/core.py#L772 # noqa
+    def _parse_headers_raw(self):
+        """Parse response headers and save as instance vars
+        """
+        def parse_header_block(raw_block):
+            r"""Parse headers block
+            Arguments:
+            - `block`: raw header block
+            Returns:
+            - `headers_list`:
+            """
+            block_headers = []
+            for header in raw_block:
+                if not header:
+                    continue
+                elif not header.startswith("HTTP"):
+                    field, value = map(lambda u: u.strip(), header.split(":", 1))
+                    if field.startswith("Location"):
+                        # maybe not good
+                        if not value.startswith("http"):
+                            value = urljoin(self.url, value)
+                        self._history.append(value)
+                    if value[:1] == value[-1:] == '"':
+                        value = value[1:-1]  # strip "
+                    block_headers.append((field, value.strip()))
+                elif header.startswith("HTTP"):
+                    # extract version, code, message from first header
+                    try:
+                        version, code, message = HTTP_GENERAL_RESPONSE_HEADER.findall(header)[0]
+                    except Exception as e:
+                        # logger.warn(e)
+                        continue
+                    else:
+                        block_headers.append((version, code, message))
+                else:
+                    # raise ValueError("Wrong header field")
+                    pass
+            return block_headers
+
+        for raw_block in self._split_headers_blocks(self._headers_raw.decode('utf-8')):
+            block = parse_header_block(raw_block)
+            self._headers_history.append(block)
+
+        last_header = self._headers_history[-1]
+        self._reason = last_header[0][2]
+        self._headers = CaseInsensitiveDict(last_header[1:])
+
+        if not self._history:
+            self._history.append(self.url)
+
+        if not self.encoding:
+            self.encoding = self._encoding_from_content_type()
+
+    # from https://github.com/Lispython/human_curl/blob/1bdda958c4bb57f73f2332bfef5026a44270b3c3/human_curl/core.py#L825
+    def _parse_cookies(self):
+        if not self._headers_history:
+            self._parse_headers_raw()
+
+        # Get cookies from endpoint
+        cookies = []
+        for header in chain(*self._headers_history):
+            if len(header) > 2:
+                continue
+            key, value = header[0], header[1]
+            if key.lower().startswith("set-cookie"):
+                try:
+                    cookie = SimpleCookie()
+                    cookie.load(value)
+                    cookies.extend(cookie.values())
+                except CookieError as e:
+                    logger.warn("_parse_cookies error", e)
+        self._cookies = dict([(cookie.key, cookie.value) for cookie in cookies])
+        return self._cookies
+
+    # from https://github.com/psf/requests/blob/428f7a275914f60a8f1e76a7d69516d617433d30/requests/models.py#L730
+    @property
+    def apparent_encoding(self):
+        return chardet.detect(self.content)['encoding']
+
+    # from https://github.com/psf/requests/blob/428f7a275914f60a8f1e76a7d69516d617433d30/requests/models.py#L854
+    @property
+    def text(self):
+        if not self.content:
+            return str('')
+        encoding = self.encoding
+        if encoding is None:
+            encoding = self.apparent_encoding
+        if encoding.lower() == 'utf-8':
+            encoding = 'utf-8-sig'
+
+        text = None
+        try:
+            text = str(self.content, encoding=encoding, errors='replace')
+        except (LookupError, TypeError):
+            text = str(self.content, errors='replace')
+        return text
+
+    # modified version from https://github.com/psf/requests/blob/428f7a275914f60a8f1e76a7d69516d617433d30/requests/models.py#L894 # noqa
+    # no fast utf?? decoding, rely on cchardet
+    def json(self):
+        """Returns the json-encoded content of a response"""
+        return json.loads(self.text)
+
+    @property
+    def reason(self):
+        """Returns response headers"""
+        if not self._headers:
+            self._parse_headers_raw()
+        return self._reason
+
+    @property
+    def headers(self):
+        """Returns response headers"""
+        if not self._headers:
+            self._parse_headers_raw()
+        return self._headers
+
+    # from https://github.com/Lispython/human_curl/blob/1bdda958c4bb57f73f2332bfef5026a44270b3c3/human_curl/core.py#L864
+    @property
+    def cookies(self):
+        """Returns list of BaseCookie object
+        All cookies in list are ``Cookie.Morsel`` instance
+        :return self._cookies: cookies list
+        """
+        if not self._cookies:
+            self._parse_cookies()
+        return self._cookies
+
+    # from https://github.com/Lispython/human_curl/blob/1bdda958c4bb57f73f2332bfef5026a44270b3c3/human_curl/core.py#L876
+    @property
+    def history(self):
+        """Returns redirects history list
+        :return: list of `Response` objects
+        """
+        if not self._history:
+            self._parse_headers_raw()
+        return self._history
+
+    # from https://github.com/psf/requests/blob/428f7a275914f60a8f1e76a7d69516d617433d30/requests/models.py#L698
+    @property
+    def ok(self):
+        """Returns True if :attr:`status_code` is less than 400, False if not.
+        This attribute checks if the status code of the response is between
+        400 and 600 to see if there was a client error or a server error. If
+        the status code is between 200 and 400, this will return True. This
+        is **not** a check to see if the response code is ``200 OK``.
+        """
+        try:
+            self.raise_for_status()
+        except exceptions.HTTPError:
+            return False
+        return True
+
+    # from https://github.com/psf/requests/blob/428f7a275914f60a8f1e76a7d69516d617433d30/requests/models.py#L938
+    def raise_for_status(self):
+        """Raises stored :class:`HTTPError`, if one occurred."""
+
+        http_error_msg = ''
+        if isinstance(self.reason, bytes):
+            # We attempt to decode utf-8 first because some servers
+            # choose to localize their reason strings. If the string
+            # isn't utf-8, we fall back to iso-8859-1 for all other
+            # encodings. (See PR #3538)
+            try:
+                reason = self.reason.decode('utf-8')
+            except UnicodeDecodeError:
+                reason = self.reason.decode('iso-8859-1')
+        else:
+            reason = self.reason
+
+        if 400 <= self.status_code < 500:
+            http_error_msg = u'%s Client Error: %s for url: %s' % (self.status_code, reason, self.url)
+
+        elif 500 <= self.status_code < 600:
+            http_error_msg = u'%s Server Error: %s for url: %s' % (self.status_code, reason, self.url)
+
+        if http_error_msg:
+            raise exceptions.HTTPError(http_error_msg)
+
+        return self
+
+    def __repr__(self):
+        return '<Response [%s]>' % (self.status_code)
+
+    def close(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()

--- a/searx/httpclient/requests.py
+++ b/searx/httpclient/requests.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+import threading
+import time
+from searx.httpclient.sessions import Session
+from searx import settings, logger
+
+THREADLOCAL = threading.local()
+
+max_host_connections = settings['outgoing'].get('pool_maxsize', 10)
+max_total_connections = max_host_connections * settings['outgoing'].get('pool_connections', 100)
+SESSION = Session(share_cookies=False,
+                  http2=True,
+                  max_total_connections=max_total_connections,
+                  max_host_connections=max_host_connections)
+
+
+def set_timeout_for_thread(timeout, start_time=None):
+    THREADLOCAL.timeout = timeout
+    THREADLOCAL.start_time = start_time
+
+
+def reset_time_for_thread():
+    THREADLOCAL.total_time = 0
+
+
+def get_time_for_thread():
+    return THREADLOCAL.total_time
+
+
+def request(method, url, **kwargs):
+    """same as requests/requests/api.py request(...)"""
+    time_before_request = time.time()
+
+    # proxies
+    kwargs['proxies'] = settings['outgoing'].get('proxies') or None
+
+    # timeout
+    if 'timeout' in kwargs:
+        timeout = kwargs['timeout']
+    else:
+        timeout = getattr(THREADLOCAL, 'timeout', None)
+        if timeout is not None:
+            kwargs['timeout'] = timeout
+
+    # do request
+    response = SESSION.request(method, url, **kwargs)
+
+    time_after_request = time.time()
+
+    # is there a timeout for this engine ?
+    if timeout is not None:
+        timeout_overhead = 0.2  # seconds
+        # start_time = when the user request started
+        start_time = getattr(THREADLOCAL, 'start_time', time_before_request)
+        search_duration = time_after_request - start_time
+        if search_duration > timeout + timeout_overhead:
+            raise TimeoutError(response=response)
+
+    if hasattr(THREADLOCAL, 'total_time'):
+        THREADLOCAL.total_time += time_after_request - time_before_request
+
+    return response
+
+
+def get(url, **kwargs):
+    kwargs.setdefault('allow_redirects', True)
+    return request('get', url, **kwargs)
+
+
+def options(url, **kwargs):
+    kwargs.setdefault('allow_redirects', True)
+    return request('options', url, **kwargs)
+
+
+def head(url, **kwargs):
+    kwargs.setdefault('allow_redirects', False)
+    return request('head', url, **kwargs)
+
+
+def post(url, data=None, **kwargs):
+    return request('post', url, data=data, **kwargs)
+
+
+def put(url, data=None, **kwargs):
+    return request('put', url, data=data, **kwargs)
+
+
+def patch(url, data=None, **kwargs):
+    return request('patch', url, data=data, **kwargs)
+
+
+def delete(url, **kwargs):
+    return request('delete', url, **kwargs)

--- a/searx/httpclient/sessions.py
+++ b/searx/httpclient/sessions.py
@@ -1,0 +1,218 @@
+# -*- coding: utf-8 -*-
+import pycurl
+import threading
+import concurrent.futures
+from uuid import uuid4
+from itertools import cycle, chain
+from searx.httpclient.misc import HAS_HTTP2
+from searx.httpclient.utils import logger
+from searx.httpclient.models import PreparedResponse, Request, DEFAULT_REDIRECT_LIMIT
+
+
+class FutureResponse(concurrent.futures.Future):
+
+    __slots__ = 'request', 'curl_handler'
+
+    def __init__(self, request, curl_handler):
+        super(FutureResponse, self).__init__()
+        self.request = request
+        self.curl_handler = curl_handler
+        self._prepare_response = PreparedResponse(request, curl_handler)
+
+    def _finish(self, err_code=None, err_string=None):
+        (result, exception) = self._prepare_response.finish(err_code, err_string)
+        if exception:
+            self.set_exception(exception)
+        if result:
+            self.set_result(result)
+
+    def _get_user_object(self):
+        return self
+
+    def result(self, timeout=None):
+        if timeout is None:
+            timeout = self._prepare_response.get_remaining_time()
+        try:
+            return super(FutureResponse, self).result(timeout)
+        except concurrent.futures.TimeoutError:
+            raise TimeoutError(request=self.request)
+
+    def exception(self, timeout=None):
+        if timeout is None:
+            timeout = self._prepare_response.get_remaining_time()
+        try:
+            return super(FutureResponse, self).exception(timeout)
+        except concurrent.futures.TimeoutError:
+            raise TimeoutError(request=self.request)
+
+
+class ConnectionPool(object):
+
+    __slots__ = 'curl_share', 'max_connections', 'connections'
+
+    def __init__(self, curl_share, max_connections):
+        self.curl_share = curl_share
+        self.max_connections = max_connections or 100  # Magic number from previous versions
+        self.connections = []
+        for i in range(max(100, self.max_connections)):
+            h = self._new_connection()
+            # add to the pool
+            self.connections.append(h)
+
+    def _new_connection(self):
+        h = pycurl.Curl()
+        h.setopt(pycurl.SHARE, self.curl_share)
+        return h
+
+    def borrowConnection(self, source_address=None):
+        try:
+            h = self.connections.pop()
+        except:
+            h = self._new_connection()
+        # use source_addresses
+        if source_address:
+            h.setopt(pycurl.INTERFACE, source_address)
+        return h
+
+    def returnConnection(self, connection):
+        connection.reset()
+        self.connections.append(connection)
+
+
+class Session(object):
+
+    def __init__(self, start=True, share_cookies=True, source_ips=None, http2=True,
+                 max_total_connections=None, max_host_connections=None):
+        self.source_ips = cycle(source_ips) if source_ips else cycle([None])
+        self.stream = False
+        self.verify = True
+        self.proxies = {}
+        self.max_redirects = DEFAULT_REDIRECT_LIMIT
+        # Ignore http2 parameter if curl doesn't support HTTP2
+        self.http2 = http2 & HAS_HTTP2
+
+        self.run = False
+        self._future_responses = {}
+        self._new_future_responses = []
+        self._mutex = threading.Lock()
+        self._no_new_future_response = threading.Condition(self._mutex)
+
+        self.curl_share = pycurl.CurlShare()
+        self.curl_share.setopt(pycurl.SH_SHARE, pycurl.LOCK_DATA_DNS)
+        self.curl_share.setopt(pycurl.SH_SHARE, pycurl.LOCK_DATA_SSL_SESSION)
+        if share_cookies:
+            self.curl_share.setopt(pycurl.SH_SHARE, pycurl.LOCK_DATA_DNS)
+
+        self._curl_multi_handler = pycurl.CurlMulti()
+        if http2:
+            # PIPE_MULTIPLEX: libcurl will attempt to re-use existing HTTP/2 connections
+            # and just add a new stream over that when doing subsequent parallel requests.
+            self._curl_multi_handler.setopt(pycurl.M_PIPELINING, pycurl.PIPE_MULTIPLEX)
+        elif curl_version_ge(7, 62, 0):
+            # https://daniel.haxx.se/blog/2019/04/06/curl-says-bye-bye-to-pipelining/
+            self._curl_multi_handler.setopt(pycurl.M_PIPELINING, pycurl.PIPE_NOTHING)
+        else:
+            self._curl_multi_handler.setopt(pycurl.M_PIPELINING, pycurl.PIPE_HTTP1)
+        if max_host_connections is not None:
+            self._curl_multi_handler.setopt(pycurl.M_MAX_HOST_CONNECTIONS, max_host_connections)
+        if max_total_connections is not None:
+            self._curl_multi_handler.setopt(pycurl.M_MAX_TOTAL_CONNECTIONS, max_total_connections)
+        self._connections = ConnectionPool(self.curl_share, max_total_connections)
+        if start:
+            self.start()
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+    def start(self):
+        if not self.run:
+            main_thread_name = 'httpclient-' + uuid4().__str__()
+            self.run = True
+            self.main_thread = threading.Thread(target=self.loop, name=main_thread_name)
+            self.main_thread.daemon = True
+            self.main_thread.start()
+
+    def stop(self):
+        if hasattr(self, 'run') and self.run:
+            self.run = False
+            with self._no_new_future_response:
+                self._no_new_future_response.notify()
+            self.main_thread.join(10.0)
+
+    def close(self):
+        self.stop()
+        if hasattr(self, '_curl_multi_handler'):
+            self._curl_multi_handler.close()
+
+    def __del__(self):
+        self.close()
+
+    def _new_async_response(self, request, handle):
+        return FutureResponse(request, handle)
+
+    def async_request(self, method, url, **kwargs):
+        kwargs.setdefault('stream', self.stream)
+        kwargs.setdefault('verify', self.verify)
+        kwargs.setdefault('proxies', self.proxies)
+        kwargs.setdefault('max_redirects', self.max_redirects)
+        kwargs.setdefault('http2', self.http2)
+        request = Request(method=method, url=url, **kwargs)
+        handle = self._connections.borrowConnection(next(self.source_ips))
+        future_response = self._new_async_response(request, handle)
+        with self._no_new_future_response:
+            self._new_future_responses.append(future_response)
+            self._no_new_future_response.notify()
+        return future_response._get_user_object()
+
+    def request(self, method, url, **kwargs):
+        async_response = self.async_request(method, url, **kwargs)
+        return async_response.result()
+
+    def loop(self):
+        handle_count = 0
+        while self.run:
+            # add new requests
+            if handle_count == 0:
+                with self._no_new_future_response:
+                    self._no_new_future_response.wait()
+            while len(self._new_future_responses) > 0:
+                future_response = self._new_future_responses.pop()
+                try:
+                    self._curl_multi_handler.add_handle(future_response.curl_handler)
+                    self._future_responses[future_response.curl_handler] = future_response
+                except Exception as e:
+                    logger.exception("Error adding request", e)
+                    future_response._finish(-1, "Error adding request")
+                    # safety net (?): do not reuse curl handle
+                    future_response.curl_handler.close()
+
+            # select
+            self._curl_multi_handler.select(1)
+
+            # perform
+            while True:
+                ret, handle_count = self._curl_multi_handler.perform()
+                if ret != pycurl.E_CALL_MULTI_PERFORM:
+                    break
+
+            # parse
+            while True:
+                num_q, success_list, error_list = self._curl_multi_handler.info_read()
+                for handle in success_list:
+                    future_response = self._future_responses[handle]
+                    future_response._finish(None, None)
+                    del self._future_responses[handle]
+                    self._connections.returnConnection(handle)
+                    self._curl_multi_handler.remove_handle(handle)
+                for handle, err_code, err_string in error_list:
+                    future_response = self._future_responses[handle]
+                    future_response._finish(err_code, err_string)
+                    del self._future_responses[handle]
+                    self._connections.returnConnection(handle)
+                    self._curl_multi_handler.remove_handle(handle)
+                if num_q == 0:
+                    break

--- a/searx/httpclient/sessions.py
+++ b/searx/httpclient/sessions.py
@@ -7,6 +7,7 @@ from itertools import cycle, chain
 from searx.httpclient.misc import HAS_HTTP2
 from searx.httpclient.utils import logger
 from searx.httpclient.models import PreparedResponse, Request, DEFAULT_REDIRECT_LIMIT
+from searx.httpclient import exceptions
 
 
 class FutureResponse(concurrent.futures.Future):
@@ -35,7 +36,7 @@ class FutureResponse(concurrent.futures.Future):
         try:
             return super(FutureResponse, self).result(timeout)
         except concurrent.futures.TimeoutError:
-            raise TimeoutError(request=self.request)
+            raise exceptions.TimeoutError(request=self.request)
 
     def exception(self, timeout=None):
         if timeout is None:
@@ -101,7 +102,8 @@ class Session(object):
         self.curl_share.setopt(pycurl.SH_SHARE, pycurl.LOCK_DATA_DNS)
         self.curl_share.setopt(pycurl.SH_SHARE, pycurl.LOCK_DATA_SSL_SESSION)
         if share_cookies:
-            self.curl_share.setopt(pycurl.SH_SHARE, pycurl.LOCK_DATA_DNS)
+            # FIXME: not tested
+            self.curl_share.setopt(pycurl.SH_SHARE, pycurl.LOCK_DATA_COOKIE)
 
         self._curl_multi_handler = pycurl.CurlMulti()
         if http2:

--- a/searx/httpclient/utils.py
+++ b/searx/httpclient/utils.py
@@ -61,6 +61,33 @@ def to_native_string(string, encoding='ascii'):
     return out
 
 
+# https://github.com/psf/requests/blob/0357b0724bd01cc89169fd40ca0132cf3248aff3/requests/utils.py#L287
+def to_key_val_list(value):
+    """Take an object and test to see if it can be represented as a
+    dictionary. If it can be, return a list of tuples, e.g.,
+    ::
+        >>> to_key_val_list([('key', 'val')])
+        [('key', 'val')]
+        >>> to_key_val_list({'key': 'val'})
+        [('key', 'val')]
+        >>> to_key_val_list('string')
+        Traceback (most recent call last):
+        ...
+        ValueError: cannot encode objects that are not 2-tuples
+    :rtype: list
+    """
+    if value is None:
+        return None
+
+    if isinstance(value, (str, bytes, bool, int)):
+        raise ValueError('cannot encode objects that are not 2-tuples')
+
+    if isinstance(value, Mapping):
+        value = value.items()
+
+    return list(value)
+
+
 # from https://github.com/psf/requests/blob/0357b0724bd01cc89169fd40ca0132cf3248aff3/requests/structures.py#L15
 class CaseInsensitiveDict(MutableMapping):
     """A case-insensitive ``dict``-like object.

--- a/searx/httpclient/utils.py
+++ b/searx/httpclient/utils.py
@@ -1,0 +1,131 @@
+# -*- coding: utf-8 -*-
+import logging
+import pycurl
+from searx import logger
+from searx.utils import IS_PY2
+from searx.httpclient.exceptions import InvalidURLError
+
+from collections import OrderedDict
+if IS_PY2:
+    from collections import MutableMapping
+else:
+    from collections.abc import MutableMapping
+
+logger = logger.getChild('httpclient')
+
+
+# https://github.com/psf/requests/blob/3e7d0a873f838e0001f7ac69b1987147128a7b5f/requests/utils.py#L566
+# The unreserved URI characters (RFC 3986)
+UNRESERVED_SET = frozenset(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" + "0123456789-._~")
+
+
+# from https://github.com/psf/requests/blob/3e7d0a873f838e0001f7ac69b1987147128a7b5f/requests/utils.py#L570
+def unquote_unreserved(uri):
+    """Un-escape any percent-escape sequences in a URI that are unreserved
+    characters. This leaves all reserved, illegal and non-ASCII bytes encoded.
+    :rtype: str
+    """
+    parts = uri.split('%')
+    for i in range(1, len(parts)):
+        h = parts[i][0:2]
+        if len(h) == 2 and h.isalnum():
+            try:
+                c = chr(int(h, 16))
+            except ValueError:
+                raise InvalidURLError("Invalid percent-escape sequence: '%s'" % h)
+
+            if c in UNRESERVED_SET:
+                parts[i] = c + parts[i][2:]
+            else:
+                parts[i] = '%' + parts[i]
+        else:
+            parts[i] = '%' + parts[i]
+    return ''.join(parts)
+
+
+# https://github.com/psf/requests/blob/0357b0724bd01cc89169fd40ca0132cf3248aff3/requests/_internal_utils.py#L14
+def to_native_string(string, encoding='ascii'):
+    """Given a string object, regardless of type, returns a representation of
+    that string in the native string type, encoding and decoding where
+    necessary. This assumes ASCII unless told otherwise.
+    """
+    if isinstance(string, str):
+        out = string
+    else:
+        if IS_PY2:
+            out = string.encode(encoding)
+        else:
+            out = string.decode(encoding)
+
+    return out
+
+
+# from https://github.com/psf/requests/blob/0357b0724bd01cc89169fd40ca0132cf3248aff3/requests/structures.py#L15
+class CaseInsensitiveDict(MutableMapping):
+    """A case-insensitive ``dict``-like object.
+    Implements all methods and operations of
+    ``MutableMapping`` as well as dict's ``copy``. Also
+    provides ``lower_items``.
+    All keys are expected to be strings. The structure remembers the
+    case of the last key to be set, and ``iter(instance)``,
+    ``keys()``, ``items()``, ``iterkeys()``, and ``iteritems()``
+    will contain case-sensitive keys. However, querying and contains
+    testing is case insensitive::
+        cid = CaseInsensitiveDict()
+        cid['Accept'] = 'application/json'
+        cid['aCCEPT'] == 'application/json'  # True
+        list(cid) == ['Accept']  # True
+    For example, ``headers['content-encoding']`` will return the
+-Encoding'`` response header, regardless
+    of how the header name was originally stored.
+    If the constructor, ``.update``, or equality comparison
+    operations are given keys that have equal ``.lower()``s, the
+    behavior is undefined.
+    """
+
+    def __init__(self, data=None, **kwargs):
+        self._store = OrderedDict()
+        if data is None:
+            data = {}
+        self.update(data, **kwargs)
+
+    def __setitem__(self, key, value):
+        # Use the lowercased key for lookups, but store the actual
+        # key alongside the value.
+        self._store[key.lower()] = (key, value)
+
+    def __getitem__(self, key):
+        return self._store[key.lower()][1]
+
+    def __delitem__(self, key):
+        del self._store[key.lower()]
+
+    def __iter__(self):
+        return (casedkey for casedkey, mappedvalue in self._store.values())
+
+    def __len__(self):
+        return len(self._store)
+
+    def lower_items(self):
+        """Like iteritems(), but with all lowercase keys."""
+        return (
+            (lowerkey, keyval[1])
+            for (lowerkey, keyval)
+            in self._store.items()
+        )
+
+    def __eq__(self, other):
+        if isinstance(other, Mapping):
+            other = CaseInsensitiveDict(other)
+        else:
+            return NotImplemented
+        # Compare insensitively
+        return dict(self.lower_items()) == dict(other.lower_items())
+
+    # Copy is required
+    def copy(self):
+        return CaseInsensitiveDict(self._store.values())
+
+    def __repr__(self):
+        return str(dict(self.items()))

--- a/searx/search.py
+++ b/searx/search.py
@@ -21,8 +21,6 @@ import threading
 from time import time
 from uuid import uuid4
 from flask_babel import gettext
-# import requests.exceptions
-# import searx.poolrequests as requests_lib
 import searx.httpclient as requests_lib
 from searx.engines import (
     categories, engines, settings

--- a/searx/search.py
+++ b/searx/search.py
@@ -21,8 +21,9 @@ import threading
 from time import time
 from uuid import uuid4
 from flask_babel import gettext
-import requests.exceptions
-import searx.poolrequests as requests_lib
+# import requests.exceptions
+# import searx.poolrequests as requests_lib
+import searx.httpclient as requests_lib
 from searx.engines import (
     categories, engines, settings
 )
@@ -185,14 +186,14 @@ def search_one_http_request_safe(engine_name, query, request_params, result_cont
         with threading.RLock():
             engine.stats['errors'] += 1
 
-        if (issubclass(e.__class__, requests.exceptions.Timeout)):
+        if (issubclass(e.__class__, requests_lib.TimeoutError)):
             result_container.add_unresponsive_engine((engine_name, gettext('timeout')))
             # requests timeout (connect or read)
             logger.error("engine {0} : HTTP requests timeout"
                          "(search duration : {1} s, timeout: {2} s) : {3}"
                          .format(engine_name, engine_time, timeout_limit, e.__class__.__name__))
             requests_exception = True
-        elif (issubclass(e.__class__, requests.exceptions.RequestException)):
+        elif (issubclass(e.__class__, requests_lib.RequestError)):
             result_container.add_unresponsive_engine((engine_name, gettext('request exception')))
             # other requests exception
             logger.exception("engine {0} : requests exception"

--- a/searx/url_utils.py
+++ b/searx/url_utils.py
@@ -2,7 +2,7 @@ from sys import version_info
 
 if version_info[0] == 2:
     from urllib import quote, quote_plus, unquote, urlencode
-    from urlparse import parse_qs, parse_qsl, urljoin, urlparse, urlunparse, ParseResult
+    from urlparse import parse_qs, parse_qsl, urljoin, urlsplit, urlparse, urlunparse, ParseResult
 else:
     from urllib.parse import (
         parse_qs,
@@ -12,6 +12,7 @@ else:
         unquote,
         urlencode,
         urljoin,
+        urlsplit,
         urlparse,
         urlunparse,
         ParseResult
@@ -25,6 +26,7 @@ __export__ = (parse_qs,
               unquote,
               urlencode,
               urljoin,
+              urlsplit,
               urlparse,
               urlunparse,
               ParseResult)

--- a/searx/utils.py
+++ b/searx/utils.py
@@ -457,29 +457,3 @@ def get_engine_from_settings(name):
             return engine
 
     return {}
-
-
-def to_key_val_list(value):
-    """Take an object and test to see if it can be represented as a
-    dictionary. If it can be, return a list of tuples, e.g.,
-    ::
-        >>> to_key_val_list([('key', 'val')])
-        [('key', 'val')]
-        >>> to_key_val_list({'key': 'val'})
-        [('key', 'val')]
-        >>> to_key_val_list('string')
-        Traceback (most recent call last):
-        ...
-        ValueError: cannot encode objects that are not 2-tuples
-    :rtype: list
-    """
-    if value is None:
-        return None
-
-    if isinstance(value, (str, bytes, bool, int)):
-        raise ValueError('cannot encode objects that are not 2-tuples')
-
-    if isinstance(value, Mapping):
-        value = value.items()
-
-    return list(value)

--- a/searx/utils.py
+++ b/searx/utils.py
@@ -32,12 +32,19 @@ try:
 except:
     from html.parser import HTMLParser
 
+try:
+    from collections import Callable, Mapping, MutableMapping
+except:
+    from collections.abc import Callable, Mapping, MutableMapping
+
 if sys.version_info[0] == 3:
     unichr = chr
     unicode = str
-    IS_PY2 = False
     basestring = str
+    IS_PY2 = False
 else:
+    unicode = unicode
+    basestring = basestring
     IS_PY2 = True
 
 logger = logger.getChild('utils')
@@ -450,3 +457,29 @@ def get_engine_from_settings(name):
             return engine
 
     return {}
+
+
+def to_key_val_list(value):
+    """Take an object and test to see if it can be represented as a
+    dictionary. If it can be, return a list of tuples, e.g.,
+    ::
+        >>> to_key_val_list([('key', 'val')])
+        [('key', 'val')]
+        >>> to_key_val_list({'key': 'val'})
+        [('key', 'val')]
+        >>> to_key_val_list('string')
+        Traceback (most recent call last):
+        ...
+        ValueError: cannot encode objects that are not 2-tuples
+    :rtype: list
+    """
+    if value is None:
+        return None
+
+    if isinstance(value, (str, bytes, bool, int)):
+        raise ValueError('cannot encode objects that are not 2-tuples')
+
+    if isinstance(value, Mapping):
+        value = value.items()
+
+    return list(value)

--- a/tests/unit/engines/test_wolframalpha_api.py
+++ b/tests/unit/engines/test_wolframalpha_api.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from collections import defaultdict
 import mock
-from requests import Request
+from searx.httpclient import Request
 from searx.engines import wolframalpha_api
 from searx.testing import SearxTestCase
 

--- a/tests/unit/engines/test_wolframalpha_noapi.py
+++ b/tests/unit/engines/test_wolframalpha_noapi.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from collections import defaultdict
 import mock
-from requests import Request
+from searx.httpclient import Request
 from searx.engines import wolframalpha_noapi
 from searx.testing import SearxTestCase
 


### PR DESCRIPTION
Implement #503

The requests API has been partially implemented: requests package can be replaced by searx.httpclient
Noticable exceptions:
* stream=True parameter.
* PreparedRequest object.

Speed:
* Seems as fast as aiohttp when HTTP2 is used.
* Faster than requests especially on slow server.

Use more memory than aiohttp and a little more than requests.
Compatible with python 2 and 3.

It is possible to make asynchronous HTTP Requests:
* either with a concurrent.futures.Future ( searx.httpclient.Session )
* or asyncio.Future ( searx.httpclient.AsyncioSession )

Implementation details:
* one thread is created per Session/AsyncioSession
* curl_multi is used to execute requests
* use HTTP/2 when possible, but is disabled on Ubuntu 18.04 (segfault, see comment in searx/httpclient/misc.py )

Debug information example:
```
DEBUG:searx.httpclient:"GET https://www.wikidata.org/w/index.php?search=searx&ns0=1 HTTP/1.1" 200 15025
  total: 0.656s, pycurl: 0.647s, namelookup: 0.108s, connect: 0.174s, appconnect: 0.295s, pretransfer: 0.296s, starttransfer: 0.595s, redirect: 0.000s
```

Notes:
* a lot of code have been borrowed from requests, and some from human_curl (see comments in the code).
* lack of tests.
* memory leak not checked.
* most probably should be a separate package.
* curl comes with a lot of different flavors: so your mileage may vary.
* it has helped to create full a quick & dirty asyncio prototype: see PR #1724
* this PR is a bookmark (rather code to be merged in the master branch).
