### PR TITLE
[fix] Preserve bangs in corrections

### DIFF
--- a/searx/templates/oscar/results.html
+++ b/searx/templates/oscar/results.html
@@ -22,8 +22,8 @@
                 <span class="result_header text-muted form-inline pull-left suggestion_item">{{ _('Try searching for:') }}</span>
                 {% for correction in corrections %}
                     <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}" role="navigation" class="form-inline pull-left suggestion_item">
-                        <input type="hidden" name="q" value="{{ query_prefix + correction }}">
-                        <button type="submit" class="btn btn-default btn-xs">{{ correction }}</button>
+                        <input type="hidden" name="q" value="{{ correction.url }}">
+                        <button type="submit" class="btn btn-default btn-xs">{{ correction.title }}</button>
                     </form>
                 {% endfor %}
             </div>

--- a/searx/templates/simple/results.html
+++ b/searx/templates/simple/results.html
@@ -95,13 +95,13 @@
       {% for correction in corrections %}
       <div class="left">
 	<form method="{{ method or 'POST' }}" action="{{ url_for('index') }}" role="navigation">
-          <input type="hidden" name="q" value="{{ correction }}">
+          <input type="hidden" name="q" value="{{ correction.url }}">
           <input type="hidden" name="time_range" value="{{ time_range }}">
           <input type="hidden" name="language" value="{{ current_language }}">
           <input type="hidden" name="safesearch" value="{{ safesearch }}">
           <input type="hidden" name="theme" value="{{ theme }}">
           {% if timeout_limit %}<input type="hidden" name="timeout_limit" value="{{ timeout_limit }}" >{% endif %}
-          <input type="submit" value="{{ correction }}">
+          <input type="submit" value="{{ correction.title }}">
 	</form>
       </div>
       {% endfor %}

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -610,6 +610,12 @@ def index():
                           'title': suggestion
                           },
                           result_container.suggestions)
+
+    correction_urls = list(map(lambda correction: {
+                               'url': raw_text_query.changeSearchQuery(correction).getFullQuery(),
+                               'title': correction
+                               },
+                               result_container.corrections))
     #
     return render(
         'results.html',
@@ -622,7 +628,7 @@ def index():
         advanced_search=advanced_search,
         suggestions=suggestion_urls,
         answers=result_container.answers,
-        corrections=result_container.corrections,
+        corrections=correction_urls,
         infoboxes=result_container.infoboxes,
         paging=result_container.paging,
         unresponsive_engines=result_container.unresponsive_engines,


### PR DESCRIPTION
Same as #1638, but with the spelling correction boxes.

The map is casted to a list because in python3 map returns an iterator which always evaluates to True in the templates, even if it's empty.