### PR TITLE
Fix python 3.8 compatibility 

### DIFF
--- a/searx/engines/framalibre.py
+++ b/searx/engines/framalibre.py
@@ -10,7 +10,10 @@
  @parse       url, title, content, thumbnail, img_src
 """
 
-from cgi import escape
+try:
+    from cgi import escape
+except:
+    from html import escape
 from lxml import html
 from searx.engines.xpath import extract_text
 from searx.url_utils import urljoin, urlencode

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -41,7 +41,10 @@ except:
     logger.critical("cannot import dependency: pygments")
     from sys import exit
     exit(1)
-from cgi import escape
+try:
+    from cgi import escape
+except:
+    from html import escape
 from datetime import datetime, timedelta
 from time import time
 from werkzeug.contrib.fixers import ProxyFix


### PR DESCRIPTION
Archlinux has now python 3.8 and in pyhton 3.8 `escape` was removed from the `cgi` module, thus we need to import it from the `html` module.