### PR TITLE
[fix] Force Google old UI with a new user agent

### DIFF
--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -199,8 +199,9 @@ def request(query, params):
     params['headers']['Accept-Language'] = language + ',' + language + '-' + country
     params['headers']['Accept'] = 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
 
-    # Force Internet Explorer 12 user agent to avoid loading the new UI that Searx can't parse
-    params['headers']['User-Agent'] = "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)"
+    # Force Safari 3.1 on Mac OS X (Leopard) user agent to avoid loading the new UI that Searx can't parse
+    params['headers']['User-Agent'] = ("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_4)"
+                                       "AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.2 Safari/525.20.1")
 
     params['google_hostname'] = google_hostname
 


### PR DESCRIPTION
Google started to serve the new UI (that Searx can't parse) on Internet Explorer (all versions) so found out that by providing a very old version of Safari as a user agent Google let me load the old UI.

Why did I choose this very specific user agent? I wanted to use a quite common agent to avoid Google blocking it so picked this one which according to whatismybrowser.com is `very common`:
![2019-11-22_22-39](https://user-images.githubusercontent.com/4016501/69462327-99706680-0d70-11ea-8302-32012d9580dd.png)
https://developers.whatismybrowser.com/useragents/explore/software_name/safari/1

Fixes #1748 
Fixes #1704