### PR TITLE
[Fix] oscar: no HTML escaping prior to output

### DIFF
--- a/searx/templates/oscar/infobox.html
+++ b/searx/templates/oscar/infobox.html
@@ -6,7 +6,7 @@
     <div class="panel-body">
         {% if infobox.img_src %}<img class="img-responsive center-block infobox_part" src="{{ image_proxify(infobox.img_src) }}" alt="{{ infobox.infobox }}" />{% endif %}
 
-        {% if infobox.content %}<bdi><p class="infobox_part">{{ infobox.content }}</p></bdi>{% endif %}
+        {% if infobox.content %}<bdi><p class="infobox_part">{{ infobox.content | safe }}</p></bdi>{% endif %}
 
         {% if infobox.attributes -%}
         <table class="table table-striped infobox_part">


### PR DESCRIPTION
#### Oscar: no HTML escaping prior to output #1649 
When results are fetched from any programming related documentation site
(like git-scm.com, docs.python.org etc), content in Info box is shown as
raw HTML code.

This change addresses the issue by using "safe" filter feature provided by
Django. See,
  - https://docs.djangoproject.com/en/3.0/ref/templates/builtins/#safe
  - Searx issue tracker (issue #1649), for more information.

Resolves: #1649

----------------------------------------------------------------------------------------------------------------------
After changes, it looks like this,

![no-raw-html](https://user-images.githubusercontent.com/28824347/71316242-81216380-2464-11ea-975e-6a4e6ed1df8e.png)