### PR TITLE
[engines|fix] flickr_noapi: Fix double-encode error (fixes #1799)

### DIFF
--- a/searx/engines/flickr_noapi.py
+++ b/searx/engines/flickr_noapi.py
@@ -118,9 +118,9 @@ def response(resp):
             'template': 'images.html'
         }
         try:
-            result['author'] = author.encode('utf-8')
-            result['title'] = title.encode('utf-8')
-            result['content'] = content.encode('utf-8')
+            result['author'] = author
+            result['title'] = title
+            result['content'] = content
         except:
             result['author'] = ''
             result['title'] = ''


### PR DESCRIPTION
See #1799 for the motivation for this PR