### PR TITLE
Add access tokens to engines

### DIFF
--- a/searx/__init__.py
+++ b/searx/__init__.py
@@ -38,6 +38,7 @@ def check_settings_yml(file_name):
     else:
         return None
 
+
 # find location of settings.yml
 if 'SEARX_SETTINGS_PATH' in environ:
     # if possible set path to settings using the

--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -54,7 +54,8 @@ engine_default_args = {'paging': False,
                        'suspend_end_time': 0,
                        'continuous_errors': 0,
                        'time_range_support': False,
-                       'offline': False}
+                       'offline': False,
+                       'tokens': []}
 
 
 def load_engine(engine_data):
@@ -160,7 +161,7 @@ def to_percentage(stats, maxvalue):
     return stats
 
 
-def get_engines_stats():
+def get_engines_stats(preferences):
     # TODO refactor
     pageloads = []
     engine_times = []
@@ -171,8 +172,12 @@ def get_engines_stats():
 
     max_pageload = max_engine_times = max_results = max_score = max_errors = max_score_per_result = 0  # noqa
     for engine in engines.values():
+        if not preferences.validate_token(engine):
+            continue
+
         if engine.stats['search_count'] == 0:
             continue
+
         results_num = \
             engine.stats['result_count'] / float(engine.stats['search_count'])
 

--- a/searx/engines/dummy-offline.py
+++ b/searx/engines/dummy-offline.py
@@ -1,0 +1,12 @@
+"""
+ Dummy Offline
+
+ @results     one result
+ @stable      yes
+"""
+
+
+def search(query, request_params):
+    return [{
+        'result': 'this is what you get',
+    }]

--- a/searx/engines/genius.py
+++ b/searx/engines/genius.py
@@ -72,6 +72,7 @@ def parse_album(hit):
             result.update({'content': 'Released: {}'.format(year)})
     return result
 
+
 parse = {'lyric': parse_lyric, 'song': parse_lyric, 'artist': parse_artist, 'album': parse_album}
 
 

--- a/searx/query.py
+++ b/searx/query.py
@@ -177,7 +177,8 @@ class RawTextQuery(object):
 class SearchQuery(object):
     """container for all the search parameters (query, language, etc...)"""
 
-    def __init__(self, query, engines, categories, lang, safesearch, pageno, time_range, timeout_limit=None):
+    def __init__(self, query, engines, categories, lang, safesearch, pageno, time_range,
+                 timeout_limit=None, preferences=None):
         self.query = query.encode('utf-8')
         self.engines = engines
         self.categories = categories
@@ -186,6 +187,7 @@ class SearchQuery(object):
         self.pageno = pageno
         self.time_range = None if time_range in ('', 'None', None) else time_range
         self.timeout_limit = timeout_limit
+        self.preferences = preferences
 
     def __str__(self):
         return str(self.query) + ";" + str(self.engines)

--- a/searx/search.py
+++ b/searx/search.py
@@ -407,7 +407,7 @@ def get_search_query_from_webapp(preferences, form):
 
     return (SearchQuery(query, query_engines, query_categories,
                         query_lang, query_safesearch, query_pageno,
-                        query_time_range, query_timeout),
+                        query_time_range, query_timeout, preferences),
             raw_text_query)
 
 
@@ -458,6 +458,9 @@ class Search(object):
                 continue
 
             engine = engines[selected_engine['name']]
+
+            if not search_query.preferences.validate_token(engine):
+                continue
 
             # skip suspended engines
             if engine.suspend_end_time >= time():

--- a/searx/templates/oscar/preferences.html
+++ b/searx/templates/oscar/preferences.html
@@ -131,6 +131,12 @@
                              {% endfor %}
                          </select>
                     {{ preferences_item_footer(info, label, rtl) }}
+
+                    {% set label = _('Engine tokens') %}
+                    {% set info = _('Access tokens for private engines') %}
+                    {{ preferences_item_header(info, label, rtl) }}
+                        <input class="form-control" id='tokens' name='tokens' value='{{ preferences.tokens.get_value() }}'/>
+                    {{ preferences_item_footer(info, label, rtl) }}
                 </div>
                 </fieldset>
             </div>

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -1,60 +1,112 @@
 # -*- coding: utf-8 -*-
 
 from searx.testing import SearxTestCase
+from searx.preferences import Preferences
+from searx.engines import engines
 
-import searx.preferences
 import searx.search
-import searx.engines
+
+
+SAFESEARCH = 0
+PAGENO = 1
+PUBLIC_ENGINE_NAME = 'general dummy'
+PRIVATE_ENGINE_NAME = 'general private offline'
+TEST_ENGINES = [
+    {
+        'name': PUBLIC_ENGINE_NAME,
+        'engine': 'dummy',
+        'categories': 'general',
+        'shortcut': 'gd',
+        'timeout': 3.0,
+        'tokens': [],
+    },
+    {
+        'name': PRIVATE_ENGINE_NAME,
+        'engine': 'dummy-offline',
+        'categories': 'general',
+        'shortcut': 'do',
+        'timeout': 3.0,
+        'offline': True,
+        'tokens': ['my-token'],
+    },
+]
 
 
 class SearchTestCase(SearxTestCase):
 
     @classmethod
     def setUpClass(cls):
-        searx.engines.initialize_engines([{
-            'name': 'general dummy',
-            'engine': 'dummy',
-            'categories': 'general',
-            'shortcut': 'gd',
-            'timeout': 3.0
-        }])
+        searx.engines.initialize_engines(TEST_ENGINES)
 
     def test_timeout_simple(self):
         searx.search.max_request_timeout = None
-        search_query = searx.query.SearchQuery('test', [{'category': 'general', 'name': 'general dummy'}],
-                                               ['general'], 'en-US', 0, 1, None, None)
+        search_query = searx.query.SearchQuery('test', [{'category': 'general', 'name': PUBLIC_ENGINE_NAME}],
+                                               ['general'], 'en-US', SAFESEARCH, PAGENO, None, None,
+                                               preferences=Preferences(['oscar'], ['general'], engines, []))
         search = searx.search.Search(search_query)
         search.search()
         self.assertEquals(search.actual_timeout, 3.0)
 
     def test_timeout_query_above_default_nomax(self):
         searx.search.max_request_timeout = None
-        search_query = searx.query.SearchQuery('test', [{'category': 'general', 'name': 'general dummy'}],
-                                               ['general'], 'en-US', 0, 1, None, 5.0)
+        search_query = searx.query.SearchQuery('test', [{'category': 'general', 'name': PUBLIC_ENGINE_NAME}],
+                                               ['general'], 'en-US', SAFESEARCH, PAGENO, None, 5.0,
+                                               preferences=Preferences(['oscar'], ['general'], engines, []))
         search = searx.search.Search(search_query)
         search.search()
         self.assertEquals(search.actual_timeout, 3.0)
 
     def test_timeout_query_below_default_nomax(self):
         searx.search.max_request_timeout = None
-        search_query = searx.query.SearchQuery('test', [{'category': 'general', 'name': 'general dummy'}],
-                                               ['general'], 'en-US', 0, 1, None, 1.0)
+        search_query = searx.query.SearchQuery('test', [{'category': 'general', 'name': PUBLIC_ENGINE_NAME}],
+                                               ['general'], 'en-US', SAFESEARCH, PAGENO, None, 1.0,
+                                               preferences=Preferences(['oscar'], ['general'], engines, []))
         search = searx.search.Search(search_query)
         search.search()
         self.assertEquals(search.actual_timeout, 1.0)
 
     def test_timeout_query_below_max(self):
         searx.search.max_request_timeout = 10.0
-        search_query = searx.query.SearchQuery('test', [{'category': 'general', 'name': 'general dummy'}],
-                                               ['general'], 'en-US', 0, 1, None, 5.0)
+        search_query = searx.query.SearchQuery('test', [{'category': 'general', 'name': PUBLIC_ENGINE_NAME}],
+                                               ['general'], 'en-US', SAFESEARCH, PAGENO, None, 5.0,
+                                               preferences=Preferences(['oscar'], ['general'], engines, []))
         search = searx.search.Search(search_query)
         search.search()
         self.assertEquals(search.actual_timeout, 5.0)
 
     def test_timeout_query_above_max(self):
         searx.search.max_request_timeout = 10.0
-        search_query = searx.query.SearchQuery('test', [{'category': 'general', 'name': 'general dummy'}],
-                                               ['general'], 'en-US', 0, 1, None, 15.0)
+        search_query = searx.query.SearchQuery('test', [{'category': 'general', 'name': PUBLIC_ENGINE_NAME}],
+                                               ['general'], 'en-US', SAFESEARCH, PAGENO, None, 15.0,
+                                               preferences=Preferences(['oscar'], ['general'], engines, []))
         search = searx.search.Search(search_query)
         search.search()
         self.assertEquals(search.actual_timeout, 10.0)
+
+    def test_query_private_engine_without_token(self):
+        search_query = searx.query.SearchQuery('test', [{'category': 'general', 'name': PRIVATE_ENGINE_NAME}],
+                                               ['general'], 'en-US', SAFESEARCH, PAGENO, None, 2.0,
+                                               preferences=Preferences(['oscar'], ['general'], engines, []))
+        search = searx.search.Search(search_query)
+        results = search.search()
+        self.assertEquals(results.results_length(), 0)
+
+    def test_query_private_engine_with_incorrect_token(self):
+        preferences_with_tokens = Preferences(['oscar'], ['general'], engines, [])
+        preferences_with_tokens.parse_dict({'tokens': 'bad-token'})
+        search_query = searx.query.SearchQuery('test', [{'category': 'general', 'name': PRIVATE_ENGINE_NAME}],
+                                               ['general'], 'en-US', SAFESEARCH, PAGENO, None, 2.0,
+                                               preferences=preferences_with_tokens)
+        search = searx.search.Search(search_query)
+        results = search.search()
+        self.assertEquals(results.results_length(), 0)
+
+    def test_query_private_engine_with_correct_token(self):
+        preferences_with_tokens = Preferences(['oscar'], ['general'], engines, [])
+        preferences_with_tokens.parse_dict({'tokens': 'my-token'})
+        search_query = searx.query.SearchQuery('test', [{'category': 'general', 'name': PRIVATE_ENGINE_NAME}],
+                                               ['general'], 'en-US', SAFESEARCH, PAGENO, None, 2.0,
+                                               preferences=preferences_with_tokens)
+        search = searx.search.Search(search_query)
+        results = search.search()
+        self.assertEquals(results.results_length(), 1)


### PR DESCRIPTION
From now on it is possible to configure tokens for engines. This lets instance administrators limit the access to engines. Thus, making engines private.

A new setting is added to engines, named `tokens`. It expects a list of arbitrary strings. If a user presents one of the tokens when making a search request to searx, he/she is granted access to the engine.

Example configuration with the "well-known" Frinkiac engine:

```yaml
 - name : frinkiac
   engine : frinkiac
   shortcut : frk
   tokens : 
   - token1
   - token2
```

Users can add their tokens on the preferences page. The new setting expects a list of comma separated tokens.

![image](https://user-images.githubusercontent.com/3876218/73590174-b6978300-44df-11ea-981e-3f511e4a9cf3.png)

Important: At the moment, administrators are required to create tokens and distribute them to their users.
