### PR TITLE
Update settings.yml to put Wolfram|Alpha in the General category 

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -689,7 +689,7 @@ engines:
     # api_key: '' # required!
     engine : wolframalpha_noapi
     timeout: 6.0
-    categories : science
+    categories : general
 
   - name : dictzone
     engine : dictzone


### PR DESCRIPTION
Put Wolfram|Alpha in the general category, so it gives smart instant answers without cluttering results with scientific whitepapers.