### PR TITLE
[fix] Disable HTTP keep alive

### DIFF
--- a/dockerfiles/uwsgi.ini
+++ b/dockerfiles/uwsgi.ini
@@ -31,3 +31,7 @@ touch-logrotate = /run/uwsgi-logrotate
 unique-cron = 15 0 -1 -1 -1 { touch /run/uwsgi-logrotate  }
 log-backupname = /var/log/uwsgi/uwsgi.log.1
 logto = /var/log/uwsgi/uwsgi.log
+
+# No keep alive
+# See https://github.com/searx/searx-docker/issues/24
+add-header = Connection: close


### PR DESCRIPTION
Fix HTTP 429 response from filtron
See https://github.com/searx/searx-docker/issues/24