### PR TITLE
[enh] use httpx instead of requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ stages:
 
 jobs:
   include:
-    - python: "3.5"
     - python: "3.6"
     - python: "3.7"
     - python: "3.8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,6 @@ pygments==2.1.3
 pyopenssl==19.1.0
 python-dateutil==2.8.0
 pyyaml==5.3.1
-requests[socks]==2.24.0
+httpx[http2]==0.16.1
+brotlipy==0.7.0
+uvloop==0.14.0

--- a/searx/engines/dictzone.py
+++ b/searx/engines/dictzone.py
@@ -60,7 +60,7 @@ def response(resp):
                 to_results.append(to_result.text_content())
 
         results.append({
-            'url': urljoin(resp.url, '?%d' % k),
+            'url': urljoin(str(resp.url), '?%d' % k),
             'title': from_result.text_content(),
             'content': '; '.join(to_results)
         })

--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -208,8 +208,8 @@ def response(resp):
     results = []
 
     # detect google sorry
-    resp_url = urlparse(resp.url)
-    if resp_url.netloc == 'sorry.google.com' or resp_url.path == '/sorry/IndexRedirect':
+    resp_url = urlparse(str(resp.url))
+    if resp.url == 'sorry.google.com' or resp_url.path == '/sorry/IndexRedirect':
         raise RuntimeWarning('sorry.google.com')
 
     if resp_url.path.startswith('/sorry'):

--- a/searx/engines/spotify.py
+++ b/searx/engines/spotify.py
@@ -12,7 +12,7 @@
 
 from json import loads
 from urllib.parse import urlencode
-import requests
+import searx.poolrequests as requests
 import base64
 
 # engine dependent config

--- a/searx/poolrequests.py
+++ b/searx/poolrequests.py
@@ -1,13 +1,16 @@
-import sys
 from time import time
 from itertools import cycle
-from threading import RLock, local
+import threading
+import concurrent.futures
+import asyncio
+import logging
 
-import requests
+import uvloop
+import httpcore
+import httpx
 
 from searx import settings
 from searx import logger
-
 
 logger = logger.getChild('poolrequests')
 
@@ -30,93 +33,85 @@ if not getattr(ssl, "HAS_SNI", False):
         sys.exit(1)
 
 
-class HTTPAdapterWithConnParams(requests.adapters.HTTPAdapter):
+LOOP = None
+CLIENTS = dict()
+THREADLOCAL = threading.local()
+POOL_CONNECTIONS = settings['outgoing'].get('pool_connections', 100)  # Magic number kept from previous code
+POOL_MAXSIZE = settings['outgoing'].get('pool_maxsize', 10)  # Picked from constructor
 
-    def __init__(self, pool_connections=requests.adapters.DEFAULT_POOLSIZE,
-                 pool_maxsize=requests.adapters.DEFAULT_POOLSIZE,
-                 max_retries=requests.adapters.DEFAULT_RETRIES,
-                 pool_block=requests.adapters.DEFAULT_POOLBLOCK,
-                 **conn_params):
-        if max_retries == requests.adapters.DEFAULT_RETRIES:
-            self.max_retries = requests.adapters.Retry(0, read=False)
-        else:
-            self.max_retries = requests.adapters.Retry.from_int(max_retries)
-        self.config = {}
-        self.proxy_manager = {}
-
-        super().__init__()
-
-        self._pool_connections = pool_connections
-        self._pool_maxsize = pool_maxsize
-        self._pool_block = pool_block
-        self._conn_params = conn_params
-
-        self.init_poolmanager(pool_connections, pool_maxsize, block=pool_block, **conn_params)
-
-    def __setstate__(self, state):
-        # Can't handle by adding 'proxy_manager' to self.__attrs__ because
-        # because self.poolmanager uses a lambda function, which isn't pickleable.
-        self.proxy_manager = {}
-        self.config = {}
-
-        for attr, value in state.items():
-            setattr(self, attr, value)
-
-        self.init_poolmanager(self._pool_connections, self._pool_maxsize,
-                              block=self._pool_block, **self._conn_params)
-
-
-threadLocal = local()
-connect = settings['outgoing'].get('pool_connections', 100)  # Magic number kept from previous code
-maxsize = settings['outgoing'].get('pool_maxsize', requests.adapters.DEFAULT_POOLSIZE)  # Picked from constructor
 if settings['outgoing'].get('source_ips'):
-    http_adapters = cycle(HTTPAdapterWithConnParams(pool_connections=connect, pool_maxsize=maxsize,
-                                                    source_address=(source_ip, 0))
-                          for source_ip in settings['outgoing']['source_ips'])
-    https_adapters = cycle(HTTPAdapterWithConnParams(pool_connections=connect, pool_maxsize=maxsize,
-                                                     source_address=(source_ip, 0))
-                           for source_ip in settings['outgoing']['source_ips'])
+    LOCAL_ADDRESS_CYCLE = cycle(settings['outgoing'].get('source_ips'))
 else:
-    http_adapters = cycle((HTTPAdapterWithConnParams(pool_connections=connect, pool_maxsize=maxsize), ))
-    https_adapters = cycle((HTTPAdapterWithConnParams(pool_connections=connect, pool_maxsize=maxsize), ))
-
-
-class SessionSinglePool(requests.Session):
-
-    def __init__(self):
-        super().__init__()
-
-        # reuse the same adapters
-        with RLock():
-            self.adapters.clear()
-            self.mount('https://', next(https_adapters))
-            self.mount('http://', next(http_adapters))
-
-    def close(self):
-        """Call super, but clear adapters since there are managed globaly"""
-        self.adapters.clear()
-        super().close()
+    LOCAL_ADDRESS_CYCLE = cycle((None, ))
 
 
 def set_timeout_for_thread(timeout, start_time=None):
-    threadLocal.timeout = timeout
-    threadLocal.start_time = start_time
+    THREADLOCAL.timeout = timeout
+    THREADLOCAL.start_time = start_time
 
 
 def reset_time_for_thread():
-    threadLocal.total_time = 0
+    THREADLOCAL.total_time = 0
 
 
 def get_time_for_thread():
-    return threadLocal.total_time
+    return THREADLOCAL.total_time
+
+
+async def get_client(verify, proxies):
+    global CLIENTS, POOL_CONNECTIONS, POOL_MAXSIZE
+
+    if proxies is None:
+        local_address = next(LOCAL_ADDRESS_CYCLE)
+        key = (verify, local_address, None)
+    else:
+        local_address = None
+        key = (verify, local_address, str(proxies))
+
+    if key not in CLIENTS:
+        ssl_context = httpx.create_ssl_context() if verify else None
+        transport = httpcore.AsyncConnectionPool(ssl_context=ssl_context,
+                                                 max_connections=POOL_CONNECTIONS,
+                                                 max_keepalive_connections=POOL_MAXSIZE,
+                                                 local_address=local_address,
+                                                 http2=True)
+        client = httpx.AsyncClient(transport=transport, proxies=proxies)
+        CLIENTS[key] = client
+    else:
+        client = CLIENTS[key]
+    return client
+
+
+async def send_request(method, url, kwargs):
+    if isinstance(url, bytes):
+        url = url.decode()
+
+    client = await get_client(kwargs.get('verify', True), kwargs.get('proxies', None))
+    if 'verify' in kwargs:
+        del kwargs['verify']
+    if 'proxies' in kwargs:
+        del kwargs['proxies']
+    if 'stream' in kwargs:
+        del kwargs['stream']
+        raise NotImplementedError('stream not supported')
+
+    response = await client.request(method.upper(), url, **kwargs)
+
+    # requests compatibility
+    try:
+        response.raise_for_status()
+        response.ok = True
+    except httpx.HTTPError:
+        response.ok = False
+
+    return response
 
 
 def request(method, url, **kwargs):
+    global LOOP
+
     """same as requests/requests/api.py request(...)"""
     time_before_request = time()
-
-    # session start
-    session = SessionSinglePool()
 
     # proxies
     if kwargs.get('proxies') is None:
@@ -126,12 +121,13 @@ def request(method, url, **kwargs):
     if 'timeout' in kwargs:
         timeout = kwargs['timeout']
     else:
-        timeout = getattr(threadLocal, 'timeout', None)
+        timeout = getattr(THREADLOCAL, 'timeout', None)
         if timeout is not None:
             kwargs['timeout'] = timeout
 
     # do request
-    response = session.request(method=method, url=url, **kwargs)
+    future = asyncio.run_coroutine_threadsafe(send_request(method, url, kwargs), LOOP)
+    response = future.result()
 
     time_after_request = time()
 
@@ -139,16 +135,14 @@ def request(method, url, **kwargs):
     if timeout is not None:
         timeout_overhead = 0.2  # seconds
         # start_time = when the user request started
-        start_time = getattr(threadLocal, 'start_time', time_before_request)
+        start_time = getattr(THREADLOCAL, 'start_time', time_before_request)
         search_duration = time_after_request - start_time
         if search_duration > timeout + timeout_overhead:
-            raise requests.exceptions.Timeout(response=response)
+            # FIXME: should not be request=None
+            raise httpx.ReadTimeout(message='Timeout', request=None)
 
-    # session end
-    session.close()
-
-    if hasattr(threadLocal, 'total_time'):
-        threadLocal.total_time += time_after_request - time_before_request
+    if hasattr(THREADLOCAL, 'total_time'):
+        THREADLOCAL.total_time += time_after_request - time_before_request
 
     return response
 
@@ -182,3 +176,24 @@ def patch(url, data=None, **kwargs):
 
 def delete(url, **kwargs):
     return request('delete', url, **kwargs)
+
+
+def init():
+    # log
+    for logger_name in ('hpack.hpack', 'hpack.table'):
+        logging.getLogger(logger_name).setLevel(logging.WARNING)
+
+    # loop
+    def loop_thread():
+        global LOOP
+        LOOP = uvloop.new_event_loop()
+        LOOP.run_forever()
+
+    th = threading.Thread(
+        target=loop_thread,
+        name='asyncio_loop',
+        daemon=True,
+    )
+    th.start()
+
+init()

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -31,7 +31,7 @@ import hmac
 import json
 import os
 
-import requests
+import searx.poolrequests
 
 from searx import logger
 logger = logger.getChild('webapp')
@@ -892,11 +892,10 @@ def image_proxy():
     headers = dict_subset(request.headers, {'If-Modified-Since', 'If-None-Match'})
     headers['User-Agent'] = gen_useragent()
 
-    resp = requests.get(url,
-                        stream=True,
-                        timeout=settings['outgoing']['request_timeout'],
-                        headers=headers,
-                        proxies=outgoing_proxies)
+    resp = searx.poolrequests.get(url,
+                                  timeout=settings['outgoing']['request_timeout'],
+                                  headers=headers,
+                                  proxies=outgoing_proxies)
 
     if resp.status_code == 304:
         return '', resp.status_code
@@ -911,18 +910,8 @@ def image_proxy():
         logger.debug('image-proxy: wrong content-type: {0}'.format(resp.headers.get('content-type')))
         return '', 400
 
-    img = b''
-    chunk_counter = 0
-
-    for chunk in resp.iter_content(1024 * 1024):
-        chunk_counter += 1
-        if chunk_counter > 5:
-            return '', 502  # Bad gateway - file is too big (>5M)
-        img += chunk
-
     headers = dict_subset(resp.headers, {'Content-Length', 'Length', 'Date', 'Last-Modified', 'Expires', 'Etag'})
-
-    return Response(img, mimetype=resp.headers['content-type'], headers=headers)
+    return Response(resp.content, mimetype=resp.headers['content-type'], headers=headers)
 
 
 @app.route('/stats', methods=['GET'])


### PR DESCRIPTION
Demo implementation of https://github.com/asciimoo/searx/issues/899#issuecomment-589593476
* All code is sync expect the httpx calls.
* Require Python 3.6 (Python 3.5 end of life: 13 Sep 2020)
* Support HTTP/2 and brotli. (require the ```httpx[http2]``` package, see https://www.python-httpx.org/http2/#enabling-http2 )
* ~~There is a bug: ... TypeError: '_asyncio.Task' object is not callable~~
* Stream is not supported ( https://github.com/asciimoo/searx/blob/master/searx/webapp.py#L822 ) (1)
* ~Multiple source IP are ignored (2). But httpcore [supports source IP](https://github.com/encode/httpcore/blob/master/CHANGELOG.md#0100-august-7th-2020). See https://github.com/encode/httpx/pull/1165~
* ~~The settings pool_connections and pool_maxsize doesn't exist in HTTPX.~~ (see https://www.python-httpx.org/advanced/#pool-limit-configuration )

Except (1) and (2), poolrequests.py API is compatible with the existing implementation, so theoretically, the choice between requests and httpx can be done at runtime.

httpx supports socks proxy using an external package: https://github.com/romis2012/httpx-socks also see https://github.com/encode/httpcore/pull/186

But frankly speaking, it would be better to first drop Python 2 support, then switch to an async architecture (*) and use httpx.

(*) modulo available packages in the different distros, but that's another topic.

Note: see https://github.com/dalf/pyhttp-benchmark/blob/master/results/output.md to have benchmarks.
