### PR TITLE
Fix default locale and language issues

### DIFF
--- a/searx/preferences.py
+++ b/searx/preferences.py
@@ -4,6 +4,7 @@ from sys import version
 
 from searx import settings, autocomplete
 from searx.languages import language_codes as languages
+from searx.utils import match_language
 from searx.url_utils import parse_qs, urlencode
 
 if version[0] == '3':
@@ -11,7 +12,7 @@ if version[0] == '3':
 
 
 COOKIE_MAX_AGE = 60 * 60 * 24 * 365 * 5  # 5 years
-LANGUAGE_CODES = [l[0].split('-')[0] for l in languages]
+LANGUAGE_CODES = [l[0] for l in languages]
 LANGUAGE_CODES.append('all')
 DISABLED = 0
 ENABLED = 1
@@ -131,6 +132,10 @@ class SetSetting(Setting):
 
 class SearchLanguageSetting(EnumStringSetting):
     """Available choices may change, so user's value may not be in choices anymore"""
+
+    def _validate_selection(self, selection):
+        if not match_language(selection, self.choices, fallback=None) and selection != "":
+            raise ValidationException('Invalid language code: "{0}"'.format(selection))
 
     def parse(self, data):
         if data not in self.choices and data != self.value:
@@ -268,7 +273,7 @@ class Preferences(object):
         super(Preferences, self).__init__()
 
         self.key_value_settings = {'categories': MultipleChoiceSetting(['general'], choices=categories + ['none']),
-                                   'language': SearchLanguageSetting(settings['ui']['default_locale'],
+                                   'language': SearchLanguageSetting(settings['search']['default_lang'],
                                                                      choices=list(LANGUAGE_CODES) + ['']),
                                    'locale': EnumStringSetting(settings['ui']['default_locale'],
                                                                choices=list(settings['locales'].keys()) + ['']),

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -5,6 +5,7 @@ general:
 search:
     safe_search : 0 # Filter results. 0: None, 1: Moderate, 2: Strict
     autocomplete : "" # Existing autocomplete backends: "dbpedia", "duckduckgo", "google", "startpage", "wikipedia" - leave blank to turn it off by default
+    default_lang : "" # Default search language - leave blank to detect from browser information or use codes from 'languages.py'
     ban_time_on_fail : 5 # ban time in seconds after engine errors
     max_ban_time_on_fail : 120 # max ban time in seconds after engine errors
 


### PR DESCRIPTION
This fixes a couple of issues related to #1621. The problem is that that fix mixes interface language selection and search language selection, even though they're actually different things.

This causes issues when you try to select a language that is available in one list, but not the other.
For example:
1. In `settings.yml` set `default_locale` to a locale that has a translation but is not available in the search list, such as `bo`. 
2. Restart searx and clear cookies.
3. Try to use any view in searx.
Expected result: UI should be in Tibetan.
Actual result: 500 error.

And also the inverse:

1. Set `Accept-Language` header to a language that is in the search list but has no translation yet, such as `id-ID,id`.
2. Go to searx's index or preferences page.
Expected result: Indonesian should be selected in the search language selector.
Actual result: 500 error (or English if it was added in the `Accept-Language` header).

I also (re-)added a `default_lang` setting to allow instance owners to override the default language if they wish to do so. It works the exact same way as `default_locale` already does.