### PR TITLE
Hide error messages from users

### DIFF
--- a/docs/admin/engines.rst
+++ b/docs/admin/engines.rst
@@ -26,6 +26,8 @@ Safe search   **SS**
 Weigth        **W**
 ------------- ----------- ---------------------------------
 Disabled      **D**
+------------- ----------- ---------------------------------
+Show errors   **DE**
 ============= =========== =================================
 
 Configuration defaults (at built time):
@@ -51,6 +53,7 @@ Configuration defaults (at built time):
         - O
 	- W
 	- D
+	- DE
 
       {% for name, mod in engines.items() %}
 
@@ -67,5 +70,6 @@ Configuration defaults (at built time):
         - {{(mod.offline and "y") or ""}}
         - {{mod.weight or 1 }}
         - {{(mod.disabled and "y") or ""}}
+        - {{(mod.display_error_messages and "y") or ""}}
 
      {% endfor %}

--- a/docs/admin/settings.rst
+++ b/docs/admin/settings.rst
@@ -175,6 +175,9 @@ Engine settings
 ``weigth`` : default ``1``
   Weighting of the results of this engine.
 
+``display_error_messages`` : default ``True``
+  When an engine returns an error, the message is displayed on the user interface.
+
 .. note::
 
    A few more options are possible, but they are pretty specific to some

--- a/docs/dev/engine_overview.rst
+++ b/docs/dev/engine_overview.rst
@@ -57,6 +57,7 @@ engine                  string      name of searx-engine
                                     (filename without ``.py``)
 shortcut                string      shortcut of search-engine
 timeout                 string      specific timeout for search-engine
+display_error_messages  boolean     display error messages on the web UI
 ======================= =========== ===========================================
 
 

--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -55,6 +55,7 @@ engine_default_args = {'paging': False,
                        'continuous_errors': 0,
                        'time_range_support': False,
                        'offline': False,
+                       'display_error_messages': True,
                        'tokens': []}
 
 

--- a/searx/results.py
+++ b/searx/results.py
@@ -346,7 +346,8 @@ class ResultContainer(object):
         return resultnum_sum / len(self._number_of_results)
 
     def add_unresponsive_engine(self, engine_name, error_type, error_message=None):
-        self.unresponsive_engines.add((engine_name, error_type, error_message))
+        if engines[engine_name].display_error_messages:
+            self.unresponsive_engines.add((engine_name, error_type, error_message))
 
     def add_timing(self, engine_name, engine_time, page_load_time):
         self.timings.append({


### PR DESCRIPTION
A new option is added to engines to hide error messages from users. It is called `display_error_messages` and by default it is set to `True`. If it is set to `False` error messages do not show up on the UI.

Keep in mind that engines are still suspended if needed regardless of this setting.

Closes #1828 