### PR TITLE
[fix] travis: fix docker build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
       install: true
       script:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        - local/py3/bin/activate; ./manage.sh docker_build push
+        - make -e GIT_URL=$(git remote get-url origin) docker.push
       after_success: true
 
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,9 @@ PHONY += docker
 docker: buildenv
 	$(Q)./manage.sh docker_build
 
+docker.push: buildenv
+	$(Q)./manage.sh docker_build push
+
 # gecko
 # -----
 


### PR DESCRIPTION
Since #1900 docker images are published on asciimoo/searx name.
Searx docker image are published on searx/searx name: GIT_URL in Makefile need to be updated.

This PR:
* add a new Makefile target: ```docker.push```, a wrapper for ```./manage.sh docker_build push```
* call ```make -e GIT_URL=$(git remote get-url origin) docker.push``` so GIT_URL has the right value even in a fork.

You can see a successful build here:
* https://travis-ci.org/github/dalf/searx/jobs/669188184
* https://hub.docker.com/r/dalf/searx/tags

