### PR TITLE
[add] Additional Wikimedia projects

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -123,3 +123,4 @@ generally made searx better:
 - Vipul @finn0
 - @CaffeinatedTech
 - Robin Schneider @ypid
+- @splintah

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -694,7 +694,6 @@ engines:
     number_of_results : 5
     search_type : text
     disabled : True
-    query : "srsearch={query}"
 
   - name : wikinews
     engine : mediawiki
@@ -704,7 +703,6 @@ engines:
     number_of_results : 5
     search_type : text
     disabled : True
-    query : "srsearch={query}"
 
   - name : wikiquote
     engine : mediawiki
@@ -714,7 +712,6 @@ engines:
     number_of_results : 5
     search_type : text
     disabled : True
-    query : "srsearch={query}"
 
   - name : wikisource
     engine : mediawiki
@@ -724,7 +721,6 @@ engines:
     number_of_results : 5
     search_type : text
     disabled : True
-    query : "srsearch={query}"
 
   - name : wiktionary
     engine : mediawiki
@@ -734,7 +730,6 @@ engines:
     number_of_results : 5
     search_type : text
     disabled : True
-    query : "srsearch={query}"
 
   - name : wikiversity
     engine : mediawiki
@@ -744,7 +739,6 @@ engines:
     number_of_results : 5
     search_type : text
     disabled : True
-    query : "srsearch={query}"
 
   - name : wikivoyage
     engine : mediawiki
@@ -754,7 +748,6 @@ engines:
     number_of_results : 5
     search_type : text
     disabled : True
-    query : "srsearch={query}"
 
   - name : wolframalpha
     shortcut : wa

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -699,7 +699,7 @@ engines:
   - name : wikinews
     engine : mediawiki
     shortcut : wn
-    categories : general
+    categories : news
     base_url : "https://{language}.wikinews.org/"
     number_of_results : 5
     search_type : text

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -726,7 +726,7 @@ engines:
     disabled : True
     query : "srsearch={query}"
 
-  - name : wikitionary
+  - name : wiktionary
     engine : mediawiki
     shortcut : wt
     categories : general

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -686,6 +686,76 @@ engines:
     engine : vimeo
     shortcut : vm
 
+  - name : wikibooks
+    engine : mediawiki
+    shortcut : wb
+    categories : general
+    base_url : "https://{language}.wikibooks.org/"
+    number_of_results : 5
+    search_type : text
+    disabled : True
+    query : "srsearch={query}"
+
+  - name : wikinews
+    engine : mediawiki
+    shortcut : wn
+    categories : general
+    base_url : "https://{language}.wikinews.org/"
+    number_of_results : 5
+    search_type : text
+    disabled : True
+    query : "srsearch={query}"
+
+  - name : wikiquote
+    engine : mediawiki
+    shortcut : wq
+    categories : general
+    base_url : "https://{language}.wikiquote.org/"
+    number_of_results : 5
+    search_type : text
+    disabled : True
+    query : "srsearch={query}"
+
+  - name : wikisource
+    engine : mediawiki
+    shortcut : ws
+    categories : general
+    base_url : "https://{language}.wikisource.org/"
+    number_of_results : 5
+    search_type : text
+    disabled : True
+    query : "srsearch={query}"
+
+  - name : wikitionary
+    engine : mediawiki
+    shortcut : wt
+    categories : general
+    base_url : "https://{language}.wiktionary.org/"
+    number_of_results : 5
+    search_type : text
+    disabled : True
+    query : "srsearch={query}"
+
+  - name : wikiversity
+    engine : mediawiki
+    shortcut : wvs
+    categories : general
+    base_url : "https://{language}.wikiversity.org/"
+    number_of_results : 5
+    search_type : text
+    disabled : True
+    query : "srsearch={query}"
+
+  - name : wikivoyage
+    engine : mediawiki
+    shortcut : wvy
+    categories : general
+    base_url : "https://{language}.wikivoyage.org/"
+    number_of_results : 5
+    search_type : text
+    disabled : True
+    query : "srsearch={query}"
+
   - name : wolframalpha
     shortcut : wa
     # You can use the engine using the official stable API, but you need an API key

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -733,7 +733,7 @@ engines:
 
   - name : wikiversity
     engine : mediawiki
-    shortcut : wvs
+    shortcut : wv
     categories : general
     base_url : "https://{language}.wikiversity.org/"
     number_of_results : 5
@@ -742,7 +742,7 @@ engines:
 
   - name : wikivoyage
     engine : mediawiki
-    shortcut : wvy
+    shortcut : wy
     categories : general
     base_url : "https://{language}.wikivoyage.org/"
     number_of_results : 5


### PR DESCRIPTION
I've added some Wikimedia projects engines, using the generic Mediawiki engine. All projects mentioned in #1577 but WIkimedia Commons are added, as I think such an engine needs more features to support images and files.

The added projects:
- Wikibooks
- Wikinews
- Wikiquote
- Wikisource
- Wiktionary
- Wikiversity
- Wikivoyage

Some things that need to be done or discussed:
- [x] Are the shortcuts okay?
- [x] Is the number of results okay?
- [x] Should some or all be enabled by default?
- [x] Are the categories right?