### PR TITLE
Allow !engine, !language, <timeout anywhere in query (#363).

### DIFF
--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -10,7 +10,8 @@ class TestQuery(SearxTestCase):
         query.parse_query()
 
         self.assertEquals(query.getFullQuery(), query_text)
-        self.assertEquals(len(query.query_parts), 1)
+        self.assertEquals(len(query.search_query_parts), 2)
+        self.assertEquals(len(query.special_query_parts), 0)
         self.assertEquals(len(query.languages), 0)
         self.assertFalse(query.specific)
 
@@ -22,7 +23,8 @@ class TestQuery(SearxTestCase):
         query.parse_query()
 
         self.assertEquals(query.getFullQuery(), full_query)
-        self.assertEquals(len(query.query_parts), 3)
+        self.assertEquals(len(query.search_query_parts), 2)
+        self.assertEquals(len(query.special_query_parts), 1)
         self.assertEquals(len(query.languages), 1)
         self.assertIn(language, query.languages)
         self.assertFalse(query.specific)
@@ -35,7 +37,8 @@ class TestQuery(SearxTestCase):
         query.parse_query()
 
         self.assertEquals(query.getFullQuery(), full_query)
-        self.assertEquals(len(query.query_parts), 3)
+        self.assertEquals(len(query.search_query_parts), 2)
+        self.assertEquals(len(query.special_query_parts), 1)
         self.assertIn('en', query.languages)
         self.assertFalse(query.specific)
 
@@ -47,7 +50,8 @@ class TestQuery(SearxTestCase):
         query.parse_query()
 
         self.assertEquals(query.getFullQuery(), full_query)
-        self.assertEquals(len(query.query_parts), 3)
+        self.assertEquals(len(query.search_query_parts), 2)
+        self.assertEquals(len(query.special_query_parts), 1)
         self.assertIn('all', query.languages)
         self.assertFalse(query.specific)
 
@@ -59,7 +63,8 @@ class TestQuery(SearxTestCase):
         query.parse_query()
 
         self.assertEquals(query.getFullQuery(), full_query)
-        self.assertEquals(len(query.query_parts), 1)
+        self.assertEquals(len(query.search_query_parts), 2)
+        self.assertEquals(len(query.special_query_parts), 1)
         self.assertEquals(len(query.languages), 0)
         self.assertFalse(query.specific)
 
@@ -69,7 +74,8 @@ class TestQuery(SearxTestCase):
         query.parse_query()
 
         self.assertEquals(query.getFullQuery(), query_text)
-        self.assertEquals(len(query.query_parts), 3)
+        self.assertEquals(len(query.search_query_parts), 2)
+        self.assertEquals(len(query.special_query_parts), 1)
         self.assertEquals(query.timeout_limit, 3)
         self.assertFalse(query.specific)
 
@@ -79,7 +85,8 @@ class TestQuery(SearxTestCase):
         query.parse_query()
 
         self.assertEquals(query.getFullQuery(), query_text)
-        self.assertEquals(len(query.query_parts), 3)
+        self.assertEquals(len(query.search_query_parts), 2)
+        self.assertEquals(len(query.special_query_parts), 1)
         self.assertEquals(query.timeout_limit, 0.35)
         self.assertFalse(query.specific)
 
@@ -89,7 +96,8 @@ class TestQuery(SearxTestCase):
         query.parse_query()
 
         self.assertEquals(query.getFullQuery(), query_text)
-        self.assertEquals(len(query.query_parts), 3)
+        self.assertEquals(len(query.search_query_parts), 2)
+        self.assertEquals(len(query.special_query_parts), 1)
         self.assertEquals(query.timeout_limit, 3.5)
         self.assertFalse(query.specific)
 
@@ -100,7 +108,7 @@ class TestQuery(SearxTestCase):
         query.parse_query()
 
         self.assertEquals(query.getFullQuery(), query_text)
-        self.assertEquals(len(query.query_parts), 1)
-        self.assertEquals(query.query_parts[0], query_text)
+        self.assertEquals(len(query.search_query_parts), 2)
+        self.assertEquals(len(query.special_query_parts), 1)
         self.assertEquals(query.timeout_limit, None)
         self.assertFalse(query.specific)


### PR DESCRIPTION
This pull request adds support for specifying engines, languages and timeouts anywhere in the query, as proposed in #363.

The changes work as follows: all raw query parts (separated by whitespace in the query) are divided into _search query parts_ (the query input for engines) and _special query parts_ (engines, languages, etc.). The query `'!go search :en engine'`, for example, contains the search query parts `['search', 'engine']` and the special query parts `['!go', ':en']`.

These changes do, however, change the query behaviour considerably (the tests are updated accordingly):
- Order of query parts is not fully preserved: after the query `'!go search :en engine'` is parsed, `getFullQuery()` returns `!go :en search engine`. I think this is only noticeable when applying suggestions. When searching for `'!go serch :en engine'` (note the misspelling of search), for example, the suggestion `'search engine'` is given, with a link to the query `!go :en search engine`.
- Whitespace is not preserved; this means that all whitespace will be changed into a single space when applying a suggestion: when searching for `'serch\tengine'` and applying the suggestion `'search engine'`, the new query becomes `'search engine'`, without the many spaces. This could be the same as the old behaviour, I'm not sure. (Fixing this would not be very hard, but maybe unnecessary.)
- Incorrect special parts are not removed. When applying the above mentioned suggestion to `'<xxx serch engine'`, the new query will be `'<xxx search engine'`. (This is very easy to fix, if necessary.)

So, the question is whether these behaviour changes are acceptable (and whether allowing bangs anywhere in the search is wanted, of course).