### PR TITLE
Update default user agents

### DIFF
--- a/searx/data/useragents.json
+++ b/searx/data/useragents.json
@@ -1,11 +1,11 @@
 {
     "versions": [
-        "74.0",
-        "73.0.1",
-        "73.0"
+        "75.0",
+        "74.0.1",
+        "74.0"
     ],
     "os": [
-        "Windows NT 10; WOW64",
+        "Windows NT 10.0; WOW64",
         "X11; Linux x86_64"
     ],
     "ua": "Mozilla/5.0 ({os}; rv:{version}) Gecko/20100101 Firefox/{version}"


### PR DESCRIPTION
This PR update the default user agents with newer versions of Firefox.

About the `.0` change, it really counts on some engines like Bing which seems to allow `Windows NT 10.0` but not `Windows NT 10` (gotta love Microsoft).

Also, this page confirms that the official user agent use `Windows NT 10.0` and not `Windows NT 10`: https://www.whatismybrowser.com/guides/the-latest-user-agent/firefox