### PR TITLE
[fix] ffox useragent: use Windows NT 10.0 and not Windows NT 10

### DIFF
--- a/utils/fetch_firefox_version.py
+++ b/utils/fetch_firefox_version.py
@@ -24,7 +24,7 @@ NORMAL_REGEX = re.compile('^[0-9]+\.[0-9](\.[0-9])?$')
 # 
 useragents = {
     "versions": (),
-    "os": ('Windows NT 10; WOW64',
+    "os": ('Windows NT 10.0; WOW64',
            'X11; Linux x86_64'),
     "ua": "Mozilla/5.0 ({os}; rv:{version}) Gecko/20100101 Firefox/{version}"
 }


### PR DESCRIPTION
This is an addittion to PR #1934:

  The .0 change really counts on some engines like Bing which seems to allow
  Windows NT 10.0 but not Windows NT 10.

Signed-off-by: Markus Heiser <markus.heiser@darmarit.de>