### PR TITLE
[RFC ] Add multiple outgoing proxies

### DIFF
--- a/searx/poolrequests.py
+++ b/searx/poolrequests.py
@@ -87,7 +87,7 @@ def get_time_for_thread():
     return threadLocal.total_time
 
 
-def get_proxies():
+def get_proxy_cycles():
     proxy_settings = settings['outgoing'].get('proxies')
     if proxy_settings:
         # Backwards compatibility for single proxy in settings.yml
@@ -99,7 +99,15 @@ def get_proxies():
     return proxy_settings
 
 
-proxies = get_proxies()
+proxy_cycles = get_proxy_cycles()
+
+
+def get_proxies():
+    global proxy_cycles
+    proxy = {}
+    for protocol in proxy_cycles:
+        proxy[protocol] = next(proxy_cycles[protocol])
+    return proxy
 
 
 def request(method, url, **kwargs):
@@ -109,11 +117,8 @@ def request(method, url, **kwargs):
     # session start
     session = SessionSinglePool()
 
-    if proxies:
-        proxy = {}
-        for protocol in proxies:
-            proxy[protocol] = next(proxies[protocol])
-        kwargs['proxies'] = proxy
+    if proxy_cycles:
+        kwargs['proxies'] = get_proxies()
 
     # timeout
     if 'timeout' in kwargs:

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -40,11 +40,15 @@ outgoing: # communication with search engines
     pool_connections : 100 # Number of different hosts
     pool_maxsize : 10 # Number of simultaneous requests by host
 # uncomment below section if you want to use a proxy
-# see http://docs.python-requests.org/en/latest/user/advanced/#proxies
-# SOCKS proxies are also supported: see http://docs.python-requests.org/en/master/user/advanced/#socks
-#    proxies :
-#        http : http://127.0.0.1:8080
-#        https: http://127.0.0.1:8080
+# see https://2.python-requests.org/en/latest/user/advanced/#proxies
+# SOCKS proxies are also supported: see https://2.python-requests.org/en/latest/user/advanced/#socks
+#    proxies:
+#        http:
+#            - http://proxy1:8080
+#            - http://proxy2:8080
+#        https:
+#            - http://proxy1:8080
+#            - http://proxy2:8080
 # uncomment below section only if you have more than one network interface
 # which can be the source of outgoing search requests
 #    source_ips:

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -81,6 +81,7 @@ from searx.preferences import Preferences, ValidationException, LANGUAGE_CODES
 from searx.answerers import answerers
 from searx.url_utils import urlencode, urlparse, urljoin
 from searx.utils import new_hmac
+from searx.poolrequests import get_proxies
 
 # check if the pyopenssl package is installed.
 # It is needed for SSL connection without trouble, see #298
@@ -160,25 +161,6 @@ _category_names = (gettext('files'),
                    gettext('map'),
                    gettext('science'))
 
-
-def get_proxies():
-    proxy_settings = settings['outgoing'].get('proxies')
-    if proxy_settings:
-        # Backwards compatibility for single proxy in settings.yml
-        for protocol, proxy in proxy_settings.items():
-            if isinstance(proxy, str):
-                proxy_settings[protocol] = [proxy]
-        for protocol in proxy_settings:
-            proxy_settings[protocol] = cycle(proxy_settings[protocol])
-    return proxy_settings
-
-
-proxies = get_proxies()
-
-if proxies:
-    outgoing_proxies = {}
-    for protocol in proxies:
-        outgoing_proxies[protocol] = next(proxies[protocol])
 
 _flask_babel_get_translations = flask_babel.get_translations
 
@@ -892,7 +874,7 @@ def image_proxy():
                         stream=True,
                         timeout=settings['outgoing']['request_timeout'],
                         headers=headers,
-                        proxies=outgoing_proxies)
+                        proxies=get_proxies())
 
     if resp.status_code == 304:
         return '', resp.status_code


### PR DESCRIPTION
This is similar to source_ips as it makes it possible to use multiple proxies to do outgoing requests.
Fixes: #1899 and #1512

I'm not sure if this is the correct way to do it comments appreciated. Also `get_proxies()` is currently copy pasted in `searx/poolrequests.py` and `searx/webapp.py` i'm not sure where to put that function. Maybe `searx/utils.py`?