### PR TITLE
[Fix] and Update Gigablast.py

### DIFF
--- a/searx/engines/gigablast.py
+++ b/searx/engines/gigablast.py
@@ -28,11 +28,14 @@ safesearch = True
 # search-url
 base_url = 'https://gigablast.com/'
 search_string = 'search?{query}'\
-    '&n={number_of_results}'\
+    '&n=25'\
     '&c=main'\
     '&s={offset}'\
     '&format=json'\
-    '&langcountry={lang}'\
+    '&hacr=1'\
+    '&dr=1'\
+    '&qlangcountry=xx-zz'\
+    '&onlylang={lang}'\
     '&ff={safesearch}'\
     '&rand={rxikd}'
 # specific xpath variables
@@ -49,7 +52,7 @@ extra_param = ''  # gigablast requires a random extra parameter
 
 def parse_extra_param(text):
     global extra_param
-    param_lines = [x for x in text.splitlines() if x.startswith('var url=') or x.startswith('url=url+')]
+    param_lines = [x for x in text.splitlines() if x.startswith('var uxrl=') or x.startswith('uxrl=uxrl+')]
     extra_param = ''
     for l in param_lines:
         extra_param += l.split("'")[1]

--- a/searx/engines/yahoo.py
+++ b/searx/engines/yahoo.py
@@ -33,7 +33,7 @@ supported_languages_url = 'https://search.yahoo.com/web/advanced'
 results_xpath = "//div[contains(concat(' ', normalize-space(@class), ' '), ' Sr ')]"
 url_xpath = './/h3/a/@href'
 title_xpath = './/h3/a'
-content_xpath = './/div[@class="compText aAbs"]'
+content_xpath = ('.//div[@class="compText aAbs"/text()]')[0]
 suggestion_xpath = "//div[contains(concat(' ', normalize-space(@class), ' '), ' AlsoTry ')]//a"
 
 time_range_dict = {'day': ['1d', 'd'],
@@ -123,7 +123,7 @@ def response(resp):
         except:
             continue
 
-        content = extract_text(eval_xpath(result, content_xpath)[0])
+        content = extract_text(eval_xpath(result, content_xpath))
 
         # append result
         results.append({'url': url,


### PR DESCRIPTION
https://github.com/asciimoo/searx/issues/1960#issue-620276358

### In file "searx/engines/gigablast.py"
#### Replace:
```
def parse_extra_param(text):
    global extra_param
    param_lines = [x for x in text.splitlines() if x.startswith('var url=') or x.startswith('url=url+')]
```
and `&langcountry={lang}`

#### With:
```
def parse_extra_param(text):
    global extra_param
    param_lines = [x for x in text.splitlines() if x.startswith('var uxrl=') or x.startswith('uxrl=uxrl+')]
```
and `&qlangcountry={lang}`
#### According from: [view-source:https://www.gigablast.com/search?c=main&q=searx&qlangcountry=en-us](view-source:https://www.gigablast.com/search?c=main&q=searx&qlangcountry=en-us)
```
var uxrl='/search?c=main&q=searx&qlangcountry=en-us&rand=1589813557381&u';
uxrl=uxrl+'nch=3181505909';
client.open('GET', uxrl );
client.send();
```

### A question: is this setting useful ?
`&n={number_of_results}` => the default is 25 why don't let `&n=25`

> In my case when `& n = {number_of_results}` is set, I have no results from Gigablast.
> And when I delete it, Gigablast provides me with results.
> 


### Otherwise, i propose:
#### For localization improvement:
`&qlangcountry: xx-zz` => any contry
`&onlylang: fr` => All documents returned will be in this language.
#### Others (for results improvement):
`&hacr=1` => Only display at most one result per site.
`&dr=1` => Should similar search results be removed?
