### PR TITLE
Revise outdated URLs

### DIFF
--- a/docs/admin/settings.rst
+++ b/docs/admin/settings.rst
@@ -98,7 +98,7 @@ Global Settings
   specific instance of searx, a locale can be defined using an ISO language
   code, like ``fr``, ``en``, ``de``.
 
-.. _requests proxies: http://docs.python-requests.org/en/latest/user/advanced/#proxies
+.. _requests proxies: http://requests.readthedocs.io/en/latest/user/advanced/#proxies
 .. _PR SOCKS support: https://github.com/kennethreitz/requests/pull/478
 
 ``outgoing_proxies`` :

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -41,7 +41,7 @@ outgoing: # communication with search engines
     pool_maxsize : 10 # Number of simultaneous requests by host
 # uncomment below section if you want to use a proxy
 # see http://docs.python-requests.org/en/latest/user/advanced/#proxies
-# SOCKS proxies are also supported: see http://docs.python-requests.org/en/master/user/advanced/#socks
+# SOCKS proxies are also supported: see http://requests.readthedocs.io/en/master/user/advanced/#socks
 #    proxies :
 #        http : http://127.0.0.1:8080
 #        https: http://127.0.0.1:8080


### PR DESCRIPTION
Replace "docs.python-requests.org" with "requests.readthedocs.io".