### PR TITLE
[FIX] yahoo.py crash list index out of range

### DIFF
--- a/searx/engines/gigablast.py
+++ b/searx/engines/gigablast.py
@@ -21,7 +21,7 @@ from searx.utils import eval_xpath
 # engine dependent config
 categories = ['general']
 paging = True
-number_of_results = 10
+number_of_results = 25
 language_support = True
 safesearch = True
 
@@ -32,8 +32,10 @@ search_string = 'search?{query}'\
     '&c=main'\
     '&s={offset}'\
     '&format=json'\
-    '&langcountry={lang}'\
+    '&qlangcountry=xx-zz&onlylang={lang}'\
     '&ff={safesearch}'\
+    '&hacr=1'\
+    '&dr=1'\
     '&rand={rxikd}'
 # specific xpath variables
 results_xpath = '//response//result'
@@ -49,7 +51,7 @@ extra_param = ''  # gigablast requires a random extra parameter
 
 def parse_extra_param(text):
     global extra_param
-    param_lines = [x for x in text.splitlines() if x.startswith('var url=') or x.startswith('url=url+')]
+    param_lines = [x for x in text.splitlines() if x.startswith('var uxrl=') or x.startswith('uxrl=uxrl+')]
     extra_param = ''
     for l in param_lines:
         extra_param += l.split("'")[1]

--- a/searx/engines/yahoo.py
+++ b/searx/engines/yahoo.py
@@ -33,7 +33,7 @@ supported_languages_url = 'https://search.yahoo.com/web/advanced'
 results_xpath = "//div[contains(concat(' ', normalize-space(@class), ' '), ' Sr ')]"
 url_xpath = './/h3/a/@href'
 title_xpath = './/h3/a'
-content_xpath = './/div[@class="compText aAbs"]'
+content_xpath = ('.//div[@class="compText aAbs"/text()]')[0]
 suggestion_xpath = "//div[contains(concat(' ', normalize-space(@class), ' '), ' AlsoTry ')]//a"
 
 time_range_dict = {'day': ['1d', 'd'],
@@ -123,7 +123,7 @@ def response(resp):
         except:
             continue
 
-        content = extract_text(eval_xpath(result, content_xpath)[0])
+        content = extract_text(eval_xpath(result, content_xpath))
 
         # append result
         results.append({'url': url,


### PR DESCRIPTION
#### @ search: yahoo (unexpected crash list index out of range)
``` 
ERROR:searx.search:engine yahoo : exception : list index out of range
 Traceback (most recent call last):
   File "/usr/local/searx/searx/search.py", line 156, in search_one_http_request_safe
     search_results = search_one_http_request(engine, query, request_params)
   File "/usr/local/searx/searx/search.py", line 97, in search_one_http_request
     return engine.response(response)
   File "/usr/local/searx/searx/engines/yahoo.py", line 166, in response
     content = extract_text(eval_xpath(result, content_xpath)[0])
 IndexError: list index out of range
```
#### I SUGGEST:
- @ line https://github.com/asciimoo/searx/blob/master/searx/engines/yahoo.py#L36
```content_xpath = ('.//div[@class="compText aAbs"]/text()')[0]```
or just ```content_xpath = './/div[@class="compText aAbs"]/text()'[0]```
#### AFTER:
pass search whitout errors with yahoo