### PR TITLE
Configurable category order

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -24,6 +24,12 @@ ui:
     default_locale : "" # Default interface locale - leave blank to detect from browser information or use codes from the 'locales' config section
     theme_args :
         oscar_style : logicodev # default style of oscar
+#   categories_order :
+#     - general
+#     - files
+#     - map
+#     - it
+#     - science
 
 # searx supports result proxification using an external service: https://github.com/asciimoo/morty
 # uncomment below section if you have running morty proxy

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -355,17 +355,12 @@ def render(template_name, override_theme=None, **kwargs):
                              if (engine_name, category) not in disabled_engines)
 
     if 'categories' not in kwargs:
-        kwargs['categories'] = ['general']
-        kwargs['categories'].extend(x for x in
-                                    sorted(categories.keys())
-                                    if x != 'general'
-                                    and x in enabled_categories)
+        kwargs['categories'] = [x for x in
+                                _get_ordered_categories()
+                                if x in enabled_categories]
 
     if 'all_categories' not in kwargs:
-        kwargs['all_categories'] = ['general']
-        kwargs['all_categories'].extend(x for x in
-                                        sorted(categories.keys())
-                                        if x != 'general')
+        kwargs['all_categories'] = _get_ordered_categories()
 
     if 'selected_categories' not in kwargs:
         kwargs['selected_categories'] = []
@@ -441,6 +436,17 @@ def render(template_name, override_theme=None, **kwargs):
 
     return render_template(
         '{}/{}'.format(kwargs['theme'], template_name), **kwargs)
+
+
+def _get_ordered_categories():
+    ordered_categories = []
+    if 'categories_order' not in settings['ui']:
+        ordered_categories = ['general']
+        ordered_categories.extend(x for x in sorted(categories.keys()) if x != 'general')
+        return ordered_categories
+    ordered_categories = settings['ui']['categories_order']
+    ordered_categories.extend(x for x in sorted(categories.keys()) if x not in ordered_categories)
+    return ordered_categories
 
 
 @app.before_request


### PR DESCRIPTION
This PR introduces a new option named `category_order` under the section `ui`. As the name implies it lets administrators configure the order of the categories. If a category is not added to the ordered list, it is automatically concatenated to the end of the list.

For example the configuration below results in the following order: files, science, map, general, images, it, music, news, social media, videos.

```yaml
ui:
  categories_order:
    - files
    - science
    - map
```

Closes #573 