### PR TITLE
[fix] commit 2c6531b2 breaks the unit test, this is a hotfix

### DIFF
--- a/tests/unit/test_plugins.py
+++ b/tests/unit/test_plugins.py
@@ -7,7 +7,7 @@ from mock import Mock
 
 def get_search_mock(query, **kwargs):
     return Mock(search_query=Mock(query=query, **kwargs),
-                result_container=Mock(answers=set()))
+                result_container=Mock(answers=dict()))
 
 
 class PluginStoreTest(SearxTestCase):
@@ -50,11 +50,11 @@ class SelfIPTest(SearxTestCase):
         request.headers.getlist.return_value = []
         search = get_search_mock(query=b'ip', pageno=1)
         store.call(store.plugins, 'post_search', request, search)
-        self.assertTrue('127.0.0.1' in search.result_container.answers)
+        self.assertTrue('127.0.0.1' in search.result_container.answers["ip"]["answer"])
 
         search = get_search_mock(query=b'ip', pageno=2)
         store.call(store.plugins, 'post_search', request, search)
-        self.assertFalse('127.0.0.1' in search.result_container.answers)
+        self.assertFalse('ip' in search.result_container.answers)
 
         # User agent test
         request = Mock(user_agent='Mock')
@@ -62,24 +62,24 @@ class SelfIPTest(SearxTestCase):
 
         search = get_search_mock(query=b'user-agent', pageno=1)
         store.call(store.plugins, 'post_search', request, search)
-        self.assertTrue('Mock' in search.result_container.answers)
+        self.assertTrue('Mock' in search.result_container.answers["user-agent"]["answer"])
 
         search = get_search_mock(query=b'user-agent', pageno=2)
         store.call(store.plugins, 'post_search', request, search)
-        self.assertFalse('Mock' in search.result_container.answers)
+        self.assertFalse('user-agent' in search.result_container.answers)
 
         search = get_search_mock(query=b'user-agent', pageno=1)
         store.call(store.plugins, 'post_search', request, search)
-        self.assertTrue('Mock' in search.result_container.answers)
+        self.assertTrue('Mock' in search.result_container.answers["user-agent"]["answer"])
 
         search = get_search_mock(query=b'user-agent', pageno=2)
         store.call(store.plugins, 'post_search', request, search)
-        self.assertFalse('Mock' in search.result_container.answers)
+        self.assertFalse('user-agent' in search.result_container.answers)
 
         search = get_search_mock(query=b'What is my User-Agent?', pageno=1)
         store.call(store.plugins, 'post_search', request, search)
-        self.assertTrue('Mock' in search.result_container.answers)
+        self.assertTrue('Mock' in search.result_container.answers["user-agent"]["answer"])
 
         search = get_search_mock(query=b'What is my User-Agent?', pageno=2)
         store.call(store.plugins, 'post_search', request, search)
-        self.assertFalse('Mock' in search.result_container.answers)
+        self.assertFalse('user-agent' in search.result_container.answers)

--- a/tests/unit/test_webapp.py
+++ b/tests/unit/test_webapp.py
@@ -48,7 +48,7 @@ class ViewsTestCase(SearxTestCase):
 
         def search_mock(search_self, *args):
             search_self.result_container = Mock(get_ordered_results=lambda: test_results,
-                                                answers=set(),
+                                                answers=dict(),
                                                 corrections=set(),
                                                 suggestions=set(),
                                                 infoboxes=[],


### PR DESCRIPTION
commit 2c6531b2 does not only break the unit test, it is a significant change of the data model and the searx search-syntax model (UI) without any discussion nor documentation.

At the end, adding routes to instant answers is a nice feature but commit 2c6531b2 leaf some questions open.

In that sense, this patch is only a hotfix not a assessment.