### PR TITLE
Respect "Results on new tabs" setting on oscar theme

### DIFF
--- a/searx/static/plugins/js/open_results_on_new_tab.js
+++ b/searx/static/plugins/js/open_results_on_new_tab.js
@@ -1,3 +1,10 @@
 $(document).ready(function() {
-    $('.result_header > a').attr('target', '_blank');
+    // Only add target=_blank when cookie is present (setting) and set to 1
+    let matchingCookies = document.cookie.split(' ').filter(e => e.startsWith('results_on_new_tab='));
+    if(matchingCookies.length == 1) {
+      let resultsOnNewTab = parseInt(matchingCookies[0].split('=')[1]);
+
+      if(resultsOnNewTab)
+        $('.result_header > a').attr('target', '_blank');
+    }
 });


### PR DESCRIPTION
Hi,

Installed your software onto my server and love it so far!

Though one annoying thing I encountered was that results opened in new tabs which conflicts with my "research" flow.  
I ensure that the setting "Results on new tabs" was set to "off", but that only effected the actual results, when:

- The theme wasn't oscar (default) including any style
- Javascript was turned off

I initially checked the [template file](https://github.com/asciimoo/searx/blob/master/searx/templates/oscar/result_templates/default.html) for that which seems to respect the results.  
Turned out that a javascript added the `target="_blank"` attribute later. It was always loaded and didn't have any conditions for doing that.

I'm not sure whether loading that script as js dependency for the plugin is supposed to be turned off. I simply added a check for that particular cookie to conditionally switch that behaviour instead.