### PR TITLE
(minor fix) webapp - avoid "cgi.escape" warning errors

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -42,9 +42,9 @@ except:
     from sys import exit
     exit(1)
 try:
-    from cgi import escape
-except:
     from html import escape
+except:
+    from cgi import escape
 from six import next
 from datetime import datetime, timedelta
 from time import time


### PR DESCRIPTION
avoid warning `webapp.py:598: DeprecationWarning: cgi.escape is deprecated, use html.escape instead`