### PR TITLE
Consider HTTP request when running search categories on select is ena…

### DIFF
--- a/searx/static/plugins/js/search_on_category_select.js
+++ b/searx/static/plugins/js/search_on_category_select.js
@@ -6,19 +6,37 @@ $(document).ready(function() {
             });
             $(document.getElementById($(this).attr("for"))).prop('checked', true);
             if($('#q').val()) {
+                if (getHttpRequest() == "GET") {
+                    $('#search_form').attr('action', $('#search_form').serialize());
+                }
                 $('#search_form').submit();
             }
             return false;
         });
         $('#time-range').change(function(e) {
             if($('#q').val()) {
+                if (getHttpRequest() == "GET") {
+                    $('#search_form').attr('action', $('#search_form').serialize());
+                }
                 $('#search_form').submit();
             }
         });
         $('#language').change(function(e) {
             if($('#q').val()) {
+                if (getHttpRequest() == "GET") {
+                    $('#search_form').attr('action', $('#search_form').serialize());
+                }
                 $('#search_form').submit();
             }
         });
     }
 });
+
+function getHttpRequest() {
+    httpRequest = "POST";
+    urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.has('method')) {
+        httpRequest = urlParams.get('method');
+    }
+    return httpRequest;
+}


### PR DESCRIPTION
Previously, if GET method was selected in the query URL, and you clicked on a category, the UI sent a POST request. Now if GET is selected, the URL is preserved.

Closes #1138