### PR TITLE
Fix YaCy text results returned as images

### DIFF
--- a/searx/engines/yacy.py
+++ b/searx/engines/yacy.py
@@ -75,7 +75,7 @@ def response(resp):
 
     for result in search_results[0].get('items', []):
         # parse image results
-        if result.get('image'):
+        if result.get('image') and result.get('width') and result.get('height'):
 
             result_url = ''
             if 'url' in result:


### PR DESCRIPTION
Even when searching for general results, YaCy still returns an image for results. Only actual image results have a width and a height set though.
This PR fixes the results display for YaCy results when searching for text.

Tested on my self hosted instances of both, YaCy version 1.922/9991 and Searx version 0.16.0-375-3d30a0be