### PR TITLE
Add cloudron as installation method

### DIFF
--- a/docs/admin/index.rst
+++ b/docs/admin/index.rst
@@ -12,6 +12,7 @@ Administrator documentation
    installation-nginx
    installation-apache
    installation-docker
+   installation-cloudron
    update-searx
    settings
    api

--- a/docs/admin/installation-cloudron.rst
+++ b/docs/admin/installation-cloudron.rst
@@ -1,0 +1,23 @@
+.. _installation cloudron:
+
+====================
+Cloudron installation
+====================
+
+.. contents:: Contents
+   :depth: 2
+   :local:
+   :backlinks: entry
+
+Cloudron is a complete solution for running apps on your server and keeping them up-to-date and secure.
+searx is available as a 1-click install from the `Cloudron Appstore <https://cloudron.io/store.html>`_ .
+
+.. image:: https://cloudron.io/img/button.svg
+   :alt: Install on Cloudron
+   :target: https://cloudron.io/button.html?app=io.github.ascimoo.searx
+
+You can test it out in the `demo installation <https://my.demo.cloudron.io>`_ (username: cloudron password: cloudron).
+Just login and install searx on any subdomain.
+
+The source code for the package (MIT) is available `here <https://git.cloudron.io/cloudron/searx-app>`_.
+


### PR DESCRIPTION
Hi Searx team, we have been maintaining Searx package for Cloudron for a while now. Can it be added as an alternate install method for searx? The source code for the package is here - https://git.cloudron.io/cloudron/searx-app .  We also have some automated selenium tests which help us update searx easily - https://git.cloudron.io/cloudron/searx-app/-/tree/master/test . If anything in the manifest or listing (https://cloudron.io/store/io.github.ascimoo.searx.html) requires changes, please let me know.

Thanks!