### PR TITLE
[doc] add jinja template to document external bangs

### DIFF
--- a/docs/admin/external_bang.rst
+++ b/docs/admin/external_bang.rst
@@ -1,0 +1,30 @@
+.. _external bang:
+
+=============
+External bang
+=============
+
+*External Bangs* are shortcuts that quickly take you to search results on other
+sites.
+
+List of available *bangs*:
+
+.. _bang list:
+
+.. jinja:: external_bang
+
+   .. flat-table:: List of available *bangs*
+      :header-rows: 1
+      :stub-columns: 1
+
+      * - Name
+        - !!bang
+        - regions
+
+      {% for bang in bang_list %}
+
+      * - {{bang['name']}}
+        - !!{{', !!'.join(bang['triggers'])}}
+        - {{', '.join(bang['regions'])}}
+
+     {% endfor %}

--- a/docs/admin/index.rst
+++ b/docs/admin/index.rst
@@ -19,5 +19,6 @@ Administrator documentation
    filtron
    morty
    engines
+   external_bang
    plugins
    buildhosts

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import  sys, os
+import json
 from sphinx_build_tools import load_sphinx_config
 from searx.version import VERSION_STRING
 from pallets_sphinx_themes import ProjectLink
@@ -27,8 +28,12 @@ numfig = True
 exclude_patterns = ['build-templates/*.rst']
 
 from searx import webapp
+with open('../searx/data/bangs.json') as f:
+    bang_list = json.load(f)['bang']
+
 jinja_contexts = {
-    'webapp': dict(**webapp.__dict__)
+    'webapp': dict(**webapp.__dict__),
+    'external_bang': {'bang_list': bang_list},
 }
 
 # usage::   lorem :patch:`f373169` ipsum

--- a/docs/user/search_syntax.rst
+++ b/docs/user/search_syntax.rst
@@ -9,13 +9,17 @@ Searx allows you to modify the default categories, engines and search language
 via the search query.
 
 Prefix ``!``
-  to set Category/engine
+  to set category or :ref:`engine <configured engines>`
+
+Prefix: ``!!``
+  to take you to search results on other sites (also know as :ref:`bang <external bang>`)
 
 Prefix: ``:``
   to set language
 
 Prefix: ``?``
-  to add engines and categories to the currently selected categories
+  to add :ref:`engines <configured engines>` and categories to the
+  currently selected categories
 
 Abbrevations of the engines and languages are also accepted.  Engine/category
 modifiers are chainable and inclusive (e.g. with :search:`!it !ddg !wp qwer
@@ -27,6 +31,10 @@ categories and languages.
 
 Examples
 ========
+
+*Bang* take you to search results on Wikipedia:
+
+- :search:`!!w gallileo <?q=%21%21w%20gallileo>`
 
 Search in wikipedia for ``qwer``:
 


### PR DESCRIPTION
This PR adds documentation of the _external bangs_ from #2027.

Before we merge this PR we should [reduce the number of external bangs (issue 2045)](https://github.com/asciimoo/searx/issues/2045) 