### PR TITLE
[mod] external_bang.py: always read bangs.json with a UTF-8 file.

### DIFF
--- a/searx/external_bang.py
+++ b/searx/external_bang.py
@@ -9,7 +9,7 @@ from searx import searx_dir
 # NOTE only use the get_bang_url
 
 bangs_data = {}
-with open(join(searx_dir, 'data/bangs.json')) as json_file:
+with open(join(searx_dir, 'data/bangs.json'), encoding='utf-8') as json_file:
     for bang in json.load(json_file)['bang']:
         for trigger in bang["triggers"]:
             bangs_data[trigger] = {x: y for x, y in bang.items() if x != "triggers"}


### PR DESCRIPTION
## What does this PR do?

Make sure that ```searx/data/bangs.json``` is always read as an UTF-8 file.

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

The PR #2043 makes sure the locale is set to UTF-8 using the [installation scripts](https://asciimoo.github.io/searx/admin/installation.html#installation-scripts).

Unfortunately searx is not always install this way. 
We can either document the UTF-8 requirement: https://github.com/asciimoo/searx/pull/2043#issuecomment-653869595
However, the external files are read as UTF-8 files except bangs.json.

So this PR may not solve the locale setting requirement, it makes sure searx starts whatever the locale is (see the related issues).

## How to test this PR locally?

1. Set the locale something different than UTF-8 and C.
2. starts searx
3. check that searx doesn't crash.
4. check an external bang is working as expected.


## Author's checklist

N/A

## Related issues

Related to the PR #2043, and issues #2041, #2057