### PR TITLE
Allow localization of "Self Informations"

### DIFF
--- a/searx/plugins/self_info.py
+++ b/searx/plugins/self_info.py
@@ -16,7 +16,7 @@ along with searx. If not, see < http://www.gnu.org/licenses/ >.
 '''
 from flask_babel import gettext
 import re
-name = "Self Informations"
+name = gettext('Self Informations')
 description = gettext('Displays your IP if the query is "ip" and your user agent if the query contains "user agent".')
 default_on = True
 


### PR DESCRIPTION
## What does this PR do?

Allows the string "Self Informations" in the plugin of the same name to be localized by wrapping it with gettext().

## Why is this change important?

Makes the translation consistent.

## How to test this PR locally?

Pull the PR.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
