### PR TITLE
[enh] update documentation about docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -47,3 +47,10 @@ node_modules/
 */*/*/*/node_modules/
 
 .tx/
+
+#
+build/
+dist/
+local/
+gh-pages/
+searx.egg-info/

--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -1,14 +1,38 @@
 #!/bin/sh
 
-export SEARX_VERSION=$(su searx -c 'python3 -c "import six; import searx.version; six.print_(searx.version.VERSION_STRING)"')
-printf 'searx version %s\n\n' "${SEARX_VERSION}"
+help() {
+	printf "Command line:\n\n"
+	printf "  -h  Display this help\n"
+	printf "  -d  Dry run to update the configuration files.\n"
+	printf "  -f  Always update on the configuration files (existing files are renamed with the .old suffix)\n"
+	printf "      Without this option, the new configuration files are copied with the .new suffix\n"
+	printf "\nEnvironment variables:\n\n"
+	printf "  INSTANCE_NAME settings.yml : general.instance_name\n"
+	printf "  AUTOCOMPLETE  settings.yml : search.autocomplete\n"
+	printf "  BASE_URL      settings.yml : server.base_url\n"
+	printf "  MORTY_URL     settings.yml : result_proxy.url\n"
+	printf "  MORTY_KEY     settings.yml : result_proxy.key\n"
+	printf "  BIND_ADDRESS  uwsgi bind to the specified TCP socket using HTTP protocol. Default value: \"${DEFAULT_BIND_ADDRESS}\"\n"
+	printf "\nVolume:\n\n"
+	printf "  /etc/searx    the docker entry point copies settings.yml and uwsgi.ini in this directory (see the -f command line option)\n"
+	exit 0
+}
+
+export DEFAULT_BIND_ADDRESS="0.0.0.0:8080"
+if [ -z "${BIND_ADDRESS}" ]; then
+    export BIND_ADDRESS="${DEFAULT_BIND_ADDRESS}"
+fi
+
+export SEARX_VERSION=$(su searx -c 'python3 -c "import six; import searx.version; six.print_(searx.version.VERSION_STRING)"' 2>/dev/null)
+if [ -z "${SEARX_VERSION}" ]; then
+	# outside docker, display help
+	help
+else
+	printf 'searx version %s\n\n' "${SEARX_VERSION}"
+fi
 
 export UWSGI_SETTINGS_PATH=/etc/searx/uwsgi.ini
 export SEARX_SETTINGS_PATH=/etc/searx/settings.yml
-
-if [ -z "${BIND_ADDRESS}" ]; then
-    export BIND_ADDRESS=":8080"
-fi
 
 # Parse command line
 FORCE_CONF_UPDATE=0
@@ -23,19 +47,7 @@ do
 	    DRY_RUN=1
 	    ;;
 	h)
-	    printf "Command line:\n\n"
-	    printf "  -h  Display this help\n"
-	    printf "  -d  Dry run to update the configuration files.\n"
-	    printf "  -f  Always update on the configuration files (existing files are renamed with the .old suffix)\n"
-	    printf "      Without this option, new configuration files are copied with the .new suffix\n"
-	    printf "\nEnvironment variables:\n\n"
-	    printf "  INSTANCE_NAME settings.yml : general.instance_name\n"
-	    printf "  AUTOCOMPLETE  settings.yml : search.autocomplete\n"
-	    printf "  BASE_URL      settings.yml : server.base_url\n"
-	    printf "  MORTY_URL     settings.yml : result_proxy.url\n"
-	    printf "  MORTY_KEY     settings.yml : result_proxy.key\n"
-	    printf "  BIND_ADDRESS  where uwsgi will accept HTTP request (format : host:port)\n"
-	    exit 0
+		help
     esac
 done
 

--- a/docs/admin/installation-docker.rst
+++ b/docs/admin/installation-docker.rst
@@ -9,20 +9,52 @@ Docker installation
    :local:
    :backlinks: entry
 
-Make sure you have installed Docker.  For instance, you can deploy searx like this:
+----
+
+Docker image searx/searx
+========================
+
+
+The docker image is `searx/searx <https://hub.docker.com/r/searx/searx>`_ (based on `github.com/searx/searx <https://github.com/searx/searx>`_).
+
+Make sure you have `installed Docker <https://docs.docker.com/get-docker/>`_.  For instance, you can deploy a local instance:
 
 .. code:: sh
 
-    docker pull wonderfall/searx
-    docker run -d --name searx -p $PORT:8888 wonderfall/searx
+    export PORT=80
+    docker pull searx/searx
+    docker run --rm -d -v ${PWD}/searx:/etc/searx -p $PORT:8080 -e BASE_URL=http://localhost:$PORT/ searx/searx
 
 Go to ``http://localhost:$PORT``.
 
-See https://hub.docker.com/r/wonderfall/searx/ for more informations.  It's also
-possible to build searx from the embedded Dockerfile.
+Inside ``${PWD}/searx``, you will find ``settings.yml`` and ``uwsgi.ini``.
+You can modify these files according to your needs  and restart the Docker image.
+
+
+Command line
+------------
+
+
+.. code:: sh
+
+    docker run --rm -it searx/searx -h
+
+.. program-output:: ../dockerfiles/docker-entrypoint.sh -h
+
+
+Build the image
+---------------
+
+It's also possible to build searx from the embedded Dockerfile.
 
 .. code:: sh
 
    git clone https://github.com/asciimoo/searx.git
    cd searx
-   docker build -t whatever/searx .
+   make docker
+
+
+Public instance
+===============
+
+If you intend to create a public instance using Docker, see https://github.com/searx/searx-docker


### PR DESCRIPTION
## What does this PR do?

* update the documentation about docker: https://asciimoo.github.io/searx/admin/installation-docker.html
* update the  dockerfiles/docker-entrypoint.sh  (the documentation call the script to get the help output)

## Why is this change important?

* the [wonderfall/searx](https://hub.docker.com/r/wonderfall/searx) image haven't been updated for a long time (but it is the case now, see related issue bellow).

## How to test this PR locally?

* ```make docs```: check the changes (feel free to correct my broken English)
* ```make docker``` : check the docker image works as intended.

## Author's checklist


## Related issues

* https://github.com/asciimoo/searx/issues/1779
* https://github.com/asciimoo/searx/issues/1561
* https://github.com/asciimoo/searx/issues/1785