### PR TITLE
Extract relative urls that do not start with / using xpath engine

### DIFF
--- a/searx/engines/xpath.py
+++ b/searx/engines/xpath.py
@@ -61,6 +61,10 @@ def extract_url(xpath_results, search_url):
         # fix relative url to the search engine
         url = urljoin(search_url, url)
 
+    # fix relative urls that fall through the crack
+    if '://' not in url:
+        url = urljoin(search_url, url)
+
     # normalize url
     url = normalize_url(url)
 


### PR DESCRIPTION
## What does this PR do?

This PR will modify the `xpath` engine to add the base domain to relative urls that do not start with `/`.

## Why is this change important?

Some relative urls in the `href` field do not start with `/`, which are omitted by the logic to perpend relative urls with the base domain.

One place to see such urls is when using [`zimply`](https://github.com/kimbauters/ZIMply/) to serve any zim file from [here](https://download.kiwix.org/zim/wikipedia/). Supporting such urls makes `searx` able to act as a search aggregator for multiple instances of locally hosted zim files, each running its own `zimply` server.

Here is a config entry for the `zimply` instance made usable by this PR:

```yml
engines:
  - name : offline wikipedia
    engine : xpath
    search_url : http://localhost:9454/search?q={query}
    url_xpath : (/html/body/a)/@href
    title_xpath : (/html/body/a)
    content_xpath : (/html/body/a)
    categories : local
    timeout : 7.0
    shortcut : lwp
```