### PR TITLE
Filtron sample: Add missing comma

### DIFF
--- a/docs/admin/filtron.rst
+++ b/docs/admin/filtron.rst
@@ -64,7 +64,7 @@ of:
                 "Param:q",
                 "Path=^(/|/search)$"
             ],
-            "interval": "<time-interval-in-sec (int)>"
+            "interval": "<time-interval-in-sec (int)>",
             "limit": "<max-request-number-in-interval (int)>",
             "subrules": [
                 {
@@ -91,7 +91,7 @@ of:
                 },
                 {
                     "name": "IP limit",
-                    "interval": "<time-interval-in-sec (int)>"
+                    "interval": "<time-interval-in-sec (int)>",
                     "limit": "<max-request-number-in-interval (int)>",
                     "stop": true,
                     "aggregations": [
@@ -111,7 +111,7 @@ of:
                     "filters": [
                         "Param:format=(csv|json|rss)"
                     ],
-                    "interval": "<time-interval-in-sec (int)>"
+                    "interval": "<time-interval-in-sec (int)>",
                     "limit": "<max-request-number-in-interval (int)>",
                     "stop": true,
                     "actions": [
@@ -125,7 +125,7 @@ of:
                 },
                 {
                     "name": "useragent limit",
-                    "interval": "<time-interval-in-sec (int)>"
+                    "interval": "<time-interval-in-sec (int)>",
                     "limit": "<max-request-number-in-interval (int)>",
                     "aggregations": [
                         "Header:User-Agent"


### PR DESCRIPTION
## What does this PR do?

Add missing commas in the filtron's sample configuration file.

## Why is this change important?

Based on this sample configuration, Filtron can't start :
```
Cannot parse rules: invalid character '"' after object key:value pair
```

## How to test this PR locally?

```
make docs-clean docs
```