### PR TITLE
Update torrentz2 URL from .eu to .is

### DIFF
--- a/searx/engines/torrentz.py
+++ b/searx/engines/torrentz.py
@@ -1,13 +1,13 @@
 """
- Torrentz2.eu (BitTorrent meta-search engine)
+ Torrentz2.is (BitTorrent meta-search engine)
 
- @website      https://torrentz2.eu/
+ @website      https://torrentz2.is/
  @provide-api  no
 
  @using-api    no
  @results      HTML
  @stable       no (HTML can change, although unlikely,
-                   see https://torrentz.eu/torrentz.btsearch)
+                   see https://torrentz.is/torrentz.btsearch)
  @parse        url, title, publishedDate, seed, leech, filesize, magnetlink
 """
 
@@ -23,8 +23,8 @@ categories = ['files', 'videos', 'music']
 paging = True
 
 # search-url
-# https://torrentz2.eu/search?f=EXAMPLE&p=6
-base_url = 'https://torrentz2.eu/'
+# https://torrentz2.is/search?f=EXAMPLE&p=6
+base_url = 'https://torrentz2.is/'
 search_url = base_url + 'search?{query}'
 
 


### PR DESCRIPTION
## What does this PR do?
Updates the torrentz2 URL from now defunct https://torrentz.eu to the new https://torrentz2.is

The torrentz2.eu domain was suspended by the EURid registry; https://torrentfreak.com/torrentz2-eu-domain-suspended-by-registry-on-public-prosecutors-order-200628/
<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?
Torrentz2 is not working without this change
<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?
Tried searching for files before and after the change
<!-- commands to run the tests or instructions to test the changes-->
