### PR TITLE
Add Gitea engine with Codeberg backend

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -301,6 +301,19 @@ engines:
     engine : github
     shortcut : gh
 
+    # This a Gitea service. If you would like to use a different instance,
+    # change codeberg.org to URL of the desired Gitea host. Or you can create
+    # a new engine by copying this and changing the name, shortcut and search_url.
+  - name : codeberg
+    engine : json_engine
+    search_url : https://codeberg.org/api/v1/repos/search?q={query}&limit=10
+    url_query : html_url
+    title_query : name
+    content_query : description
+    categories : it
+    shortcut : cb
+    disabled : True
+
   - name : google
     engine : google
     shortcut : go


### PR DESCRIPTION
## What does this PR do?

This PR adds support for [Gitea](https://gitea.io), a self-hosted Git service. It is implemented as a JSON engine. By default it sends the requests to [codeberg](https://codeberg.org/).

## Why is this change important?

It is a new engine requested in various issues.

## How to test this PR locally?

Example query: `!gte python`

## Related issues

Closes #1448
Closes #1447