### PR TITLE
Change isAlive() to is_alive() as isAlive() is unsupported in newer P…

### DIFF
--- a/searx/search.py
+++ b/searx/search.py
@@ -234,7 +234,7 @@ def search_multiple_requests(requests, result_container, start_time, timeout_lim
         if th.name == search_id:
             remaining_time = max(0.0, timeout_limit - (time() - start_time))
             th.join(remaining_time)
-            if th.isAlive():
+            if th.is_alive():
                 result_container.add_unresponsive_engine(th._engine_name, 'timeout')
                 logger.warning('engine timeout: {0}'.format(th._engine_name))
 


### PR DESCRIPTION
…ython versions

## What does this PR do?

As you can see [here](https://docs.python.org/3.10/library/threading.html#threading.Thread.is_alive), `Thread.isAlive() `is no longer supported and `Thread.is_alive()` should be used.

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
