### PR TITLE
Fix UI bug when search contain typo

### DIFF
--- a/searx/templates/oscar/results.html
+++ b/searx/templates/oscar/results.html
@@ -83,13 +83,15 @@
 
             {% if corrections -%}
             <div class="result">
-                <span class="result_header text-muted form-inline pull-left suggestion_item">{{ _('Try searching for:') }}</span>
-                {% for correction in corrections -%}
-                    <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}" role="navigation" class="form-inline pull-left suggestion_item">{{- "" -}}
-                        <input type="hidden" name="q" value="{{ correction.url }}">{{- "" -}}
-                        <button type="submit" class="btn btn-default btn-xs">{{ correction.title }}</button>{{- "" -}}
-                    </form>
-                {% endfor %}
+                <div class="clearfix">
+                    <span class="result_header text-muted form-inline pull-left suggestion_item">{{ _('Try searching for:') }}</span>
+                    {% for correction in corrections -%}
+                        <form method="{{ method or 'POST' }}" action="{{ url_for('index') }}" role="navigation" class="form-inline pull-left suggestion_item">{{- "" -}}
+                            <input type="hidden" name="q" value="{{ correction.url }}">{{- "" -}}
+                            <button type="submit" class="btn btn-default btn-xs">{{ correction.title }}</button>{{- "" -}}
+                        </form>
+                    {% endfor %}
+                </div>
             </div>
             {%- endif %}
 


### PR DESCRIPTION
## What does this PR do?

Fix UI bug with certain preferences as described on issue #2110.

## Why is this change important?

This change is important because bad UI may cause disgust. This change fixes bad UI.

## How to test this PR locally?

1. Go to /preferences page of Searx instance and set theme to Oscar and style to Pointhi.
2. Go to Plugins tab and enable "Vim-like hotkeys".
3. Save changes.
4. Search words with typographical error like "seach engine".
5. An issue must appear.

## Author's checklist

I nested children of `<div class="result">` into `<div class="clearfix">` at file `searx/templates/oscar/results.html`, line `86`. A bug appeared because when CSS stylesheet has rules about `float`, you need to use additional "clearfix" `div` to prevent such overflows.

## Related issues

Closes #2110
