### PR TITLE
Scripts adapted to run on CentOS 7

### DIFF
--- a/utils/filtron.sh
+++ b/utils/filtron.sh
@@ -546,7 +546,7 @@ EOF
     eval "echo \"$(< "${TEMPLATES}/${SERVICE_SYSTEMD_UNIT}")\"" | prefix_stdout "         "
     echo -e "\n.. END install systemd unit"
 
-    # for DIST_NAME in ubuntu-20.04 arch fedora; do
+    # for DIST_NAME in ubuntu-20.04 arch fedora centos; do
     #     (
     #         DIST_ID=${DIST_NAME%-*}
     #         DIST_VERS=${DIST_NAME#*-}

--- a/utils/lxc.sh
+++ b/utils/lxc.sh
@@ -54,6 +54,13 @@ dnf install -y git curl wget hostname
 echo 'Set disable_coredump false' >> /etc/sudo.conf
 "
 
+# shellcheck disable=SC2034
+centos7_boilerplate="
+yum update -y
+yum install -y git curl wget hostname
+echo 'Set disable_coredump false' >> /etc/sudo.conf
+"
+
 REMOTE_IMAGES=()
 CONTAINERS=()
 LOCAL_IMAGES=()

--- a/utils/morty.sh
+++ b/utils/morty.sh
@@ -530,7 +530,7 @@ EOF
     eval "echo \"$(< "${TEMPLATES}/${SERVICE_SYSTEMD_UNIT}")\"" | prefix_stdout "         "
     echo -e "\n.. END install systemd unit"
 
-    # for DIST_NAME in ubuntu-20.04 arch fedora; do
+    # for DIST_NAME in ubuntu-20.04 arch fedora centos; do
     #     (
     #         DIST_ID=${DIST_NAME%-*}
     #         DIST_VERS=${DIST_NAME#*-}

--- a/utils/searx.sh
+++ b/utils/searx.sh
@@ -76,6 +76,19 @@ texlive-xetex-bin texlive-collection-fontsrecommended
 texlive-collection-latex dejavu-sans-fonts dejavu-serif-fonts
 dejavu-sans-mono-fonts"
 
+# yum packages
+SEARX_PACKAGES_centos="\
+python-virtualenv python python-pip python-lxml python-babel
+uwsgi uwsgi-plugin-python3
+git @development-tools libxml2
+ShellCheck"
+
+BUILD_PACKAGES_centos="\
+firefox graphviz graphviz-gd ImageMagick librsvg2-tools
+texlive-xetex-bin texlive-collection-fontsrecommended
+texlive-collection-latex dejavu-sans-fonts dejavu-serif-fonts
+dejavu-sans-mono-fonts"
+
 case $DIST_ID-$DIST_VERS in
     ubuntu-16.04|ubuntu-18.04)
         SEARX_PACKAGES="${SEARX_PACKAGES_debian}"
@@ -95,7 +108,7 @@ case $DIST_ID-$DIST_VERS in
         SEARX_PACKAGES="${SEARX_PACKAGES_arch}"
         BUILD_PACKAGES="${BUILD_PACKAGES_arch}"
         ;;
-    fedora-*)
+    fedora-*|centos-7)
         SEARX_PACKAGES="${SEARX_PACKAGES_fedora}"
         BUILD_PACKAGES="${BUILD_PACKAGES_fedora}"
         ;;
@@ -714,7 +727,7 @@ EOF
         arch-*)
             systemctl --no-pager -l status "uwsgi@${SERVICE_NAME%.*}"
             ;;
-        fedora-*)
+        fedora-*|centos-7)
             systemctl --no-pager -l status uwsgi
             ;;
     esac
@@ -729,7 +742,7 @@ EOF
         case $DIST_ID-$DIST_VERS in
             ubuntu-*|debian-*) tail -f /var/log/uwsgi/app/searx.log ;;
             arch-*)  journalctl -f -u "uwsgi@${SERVICE_NAME%.*}" ;;
-            fedora-*)  journalctl -f -u uwsgi ;;
+            fedora-*|centos-7)  journalctl -f -u uwsgi ;;
         esac
     done
 
@@ -790,22 +803,26 @@ rst-doc() {
     local debian="${SEARX_PACKAGES_debian}"
     local arch="${SEARX_PACKAGES_arch}"
     local fedora="${SEARX_PACKAGES_fedora}"
+    local centos="${SEARX_PACKAGES_centos}"
     local debian_build="${BUILD_PACKAGES_debian}"
     local arch_build="${BUILD_PACKAGES_arch}"
     local fedora_build="${BUILD_PACKAGES_fedora}"
+    local centos_build="${SEARX_PACKAGES_centos}"
     debian="$(echo "${debian}" | sed 's/.*/          & \\/' | sed '$ s/.$//')"
     arch="$(echo "${arch}"     | sed 's/.*/          & \\/' | sed '$ s/.$//')"
     fedora="$(echo "${fedora}" | sed 's/.*/          & \\/' | sed '$ s/.$//')"
+    centos="$(echo "${centos}" | sed 's/.*/          & \\/' | sed '$ s/.$//')"
     debian_build="$(echo "${debian_build}" | sed 's/.*/          & \\/' | sed '$ s/.$//')"
     arch_build="$(echo "${arch_build}"     | sed 's/.*/          & \\/' | sed '$ s/.$//')"
     fedora_build="$(echo "${fedora_build}" | sed 's/.*/          & \\/' | sed '$ s/.$//')"
+    centos_build="$(echo "${centos_build}" | sed 's/.*/          & \\/' | sed '$ s/.$//')"
 
     eval "echo \"$(< "${REPO_ROOT}/docs/build-templates/searx.rst")\""
 
     # I use ubuntu-20.04 here to demonstrate that versions are also suported,
     # normaly debian-* and ubuntu-* are most the same.
 
-    for DIST_NAME in ubuntu-20.04 arch fedora; do
+    for DIST_NAME in ubuntu-20.04 arch fedora centos; do
         (
             DIST_ID=${DIST_NAME%-*}
             DIST_VERS=${DIST_NAME#*-}
@@ -850,7 +867,7 @@ EOF
 
 EOF
                 ;;
-                fedora-*) cat <<EOF
+                fedora-*|centos-7) cat <<EOF
 
 .. code:: bash
 

--- a/utils/searx.sh
+++ b/utils/searx.sh
@@ -108,9 +108,13 @@ case $DIST_ID-$DIST_VERS in
         SEARX_PACKAGES="${SEARX_PACKAGES_arch}"
         BUILD_PACKAGES="${BUILD_PACKAGES_arch}"
         ;;
-    fedora-*|centos-7)
+    fedora-*)
         SEARX_PACKAGES="${SEARX_PACKAGES_fedora}"
         BUILD_PACKAGES="${BUILD_PACKAGES_fedora}"
+        ;;
+    centos-7)
+        SEARX_PACKAGES="${SEARX_PACKAGES_centos}"
+        BUILD_PACKAGES="${BUILD_PACKAGES_centos}"
         ;;
 esac
 

--- a/utils/searx.sh
+++ b/utils/searx.sh
@@ -78,7 +78,7 @@ dejavu-sans-mono-fonts"
 
 # yum packages
 SEARX_PACKAGES_centos="\
-python-virtualenv python python-pip python-lxml python-babel
+python36-virtualenv python36 python36-pip python36-lxml python-babel
 uwsgi uwsgi-plugin-python3
 git @development-tools libxml2
 ShellCheck"


### PR DESCRIPTION
## What does this PR do?

I've adapted the scripts to run on CentOS 7.

## Why is this change important?

Now it is possible to use scripts to install SearX on CentOS 7.

## How to test this PR locally?

searx.sh install all
searx.sh remove all
searx.sh apache install
searx.sh apache remove