### PR TITLE
Fix search error with query 'random sha256'

### DIFF
--- a/searx/answerers/random/answerer.py
+++ b/searx/answerers/random/answerer.py
@@ -37,7 +37,7 @@ def random_int():
 
 def random_sha256():
     m = hashlib.sha256()
-    m.update(b''.join(random_characters()))
+    m.update(''.join(random_characters()).encode())
     return unicode(m.hexdigest())
 
 


### PR DESCRIPTION
## What does this PR do?

This PR fix search error when search query is "random sha256". For example, on [searx.xyz](https://searx.xyz/search?q=random+sha256). There was this error in log file:
```
  File "/usr/local/searx/searx-src/searx/answerers/random/answerer.py", line 40, in random_sha256
    m.update(b''.join(random_characters()))
TypeError: sequence item 0: expected a bytes-like object, str found
```
This PR fix this error.
## Why is this change important?

This change is important for people who uses answerers frequently to generate random values. Now they can generate random sha256 hashes!

## How to test this PR locally?

Search in any Searx instance "random sha256" and you will see an error and redirect to homepage. Or won't see if you use branch `random-sha256-fix`.

## Author's checklist

Python can join string list only with string, not encoded `b''`, so i replaced it to `''` and `.encode`d that random string to prepare for hashing.
