### PR TITLE
Split autocompleter into (browser)suggestions and API

### DIFF
--- a/searx/templates/__common__/opensearch.xml
+++ b/searx/templates/__common__/opensearch.xml
@@ -13,6 +13,6 @@
     </Url>
   {% endif %}
   {% if autocomplete %}
-    <Url rel="suggestions" type="application/json" template="{{ host }}autocompleter"/>
+    <Url rel="suggestions" type="application/json" template="{{ host }}autocompleter_suggestions?q={searchTerms}" method="get" />
   {% endif %}
 </OpenSearchDescription>

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -743,8 +743,7 @@ def about():
     )
 
 
-@app.route('/autocompleter', methods=['GET', 'POST'])
-def autocompleter():
+def _autocompleter(is_suggestion_query):
     """Return autocompleter results"""
 
     # set blocked engines
@@ -790,12 +789,24 @@ def autocompleter():
         results.append(raw_text_query.getFullQuery())
 
     # return autocompleter results
-    if request.form.get('format') == 'x-suggestions':
+    if is_suggestion_query:
         return Response(json.dumps([raw_text_query.query, results]),
                         mimetype='application/json')
 
     return Response(json.dumps(results),
                     mimetype='application/json')
+
+
+# TODO: It seems current browers only support suggestions via GET.
+# Re-evaluate opensearch-spec and browser behavior and add POST if possible!
+@app.route('/autocompleter_suggestions', methods=['GET'])
+def autocompleter_suggestions():
+    return _autocompleter(is_suggestion_query=True)
+
+
+@app.route('/autocompleter', methods=['GET', 'POST'])
+def autocompleter():
+    return _autocompleter(is_suggestion_query=False)
 
 
 @app.route('/preferences', methods=['GET', 'POST'])


### PR DESCRIPTION
## What does this PR do?
Since current browers do not seem to either POST requests at all, or
supplying a format-parameter as the current assumption is, the easiest
reasonably correct way seems to be to split the autocompleter endpoint
into:
- /autocompleter as used currently, continuing to work for the API-usage
  on the web-frondend
- /autocompleter_suggestions which is included in opensearch.xml defined
  for browser-suggestios-requests

While it is sad no get rid of POST for browser-autocompleter, it seems
neither chromium nor firefox currently support it — and opensearch
cannot reasonably specify it, as far as I understand. Thus removing it
seems fair for the time being.

Fixes: #2105

## Why is this change important?
For users, suggestions can be vitally important. It is a integrated part of todays searching workflow.

## How to test this PR locally?
- Start up searx using this branch
- Add it as search-engine via your browsers opensearch UI
- Enable it as a suggestion engine
- See it work or fail

## Author's checklist
- [ ] Do I understand opensearch.xml correct that POST suggestions do not work?
- [ ] Does this break any browsers I can’t try at the moment?
- [ ] Is having GET instead of POST a good idea?

## Related issues
Closes #2105