### PR TITLE
Use query params for browser autocomplete

### DIFF
--- a/searx/templates/__common__/opensearch.xml
+++ b/searx/templates/__common__/opensearch.xml
@@ -13,6 +13,6 @@
     </Url>
   {% endif %}
   {% if autocomplete %}
-    <Url rel="suggestions" type="application/json" template="{{ host }}autocompleter"/>
+    <Url rel="suggestions" type="application/x-suggestions+json" template="{{ host }}autocompleter?q={searchTerms}"/>
   {% endif %}
 </OpenSearchDescription>

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -790,12 +790,12 @@ def autocompleter():
         results.append(raw_text_query.getFullQuery())
 
     # return autocompleter results
-    if request.form.get('format') == 'x-suggestions':
-        return Response(json.dumps([raw_text_query.query, results]),
+    if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
+        return Response(json.dumps(results),
                         mimetype='application/json')
 
-    return Response(json.dumps(results),
-                    mimetype='application/json')
+    return Response(json.dumps([raw_text_query.query, results]),
+                    mimetype='application/x-suggestions+json')
 
 
 @app.route('/preferences', methods=['GET', 'POST'])


### PR DESCRIPTION

## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

Sending query params over GET seems to be the only way to be able to
enable autocomplete in the browser. This commit adds the necessary URL
formatting to opensearch.xml. In order to identify queries coming from
the URL bar (rather than an AJAX request), which requires a different
JSON format and MIME type, the request headers are checked for
"X-Requested-With: XMLHttpRequest" which is added by jQuery request.

## Why is this change important?

Fixes autocomplete

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

Remove old Searx, make sure autocomplete is enabled, make sure to clear any cache (or force-load opensearch.xml), add engine, test suggestions.

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Fixes #2105
Closes #2125 
