### PR TITLE
Make default query submission method configurable

### DIFF
--- a/searx/preferences.py
+++ b/searx/preferences.py
@@ -348,7 +348,7 @@ class Preferences(object):
                 }
             ),
             'method': EnumStringSetting(
-                'POST',
+                settings['server'].get('method', 'POST'),
                 choices=('GET', 'POST')
             ),
             'safesearch': MapSetting(

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -16,6 +16,7 @@ server:
     base_url : False # Set custom base_url. Possible values: False or "https://your.custom.host/location/"
     image_proxy : False # Proxying image results through searx
     http_protocol_version : "1.0"  # 1.0 and 1.1 are supported
+    method: "POST" # POST queries are more secure as they don't show up in history but may cause problems when using Firefox containers
 
 ui:
     static_path : "" # Custom static path - leave it blank if you didn't change


### PR DESCRIPTION
Very small PR :-)

## What does this PR do?

<!-- MANDATORY -->

This commit allows admins to modify the default method on their side so they can set it to GET if needed.

## Why is this change important?

<!-- MANDATORY -->

Sending queries through POST, while better for privacy, breaks functionality with certain extensions (e.g. Firefox containers). Since Firefox does not send cookies when requesting `/opensearch.xml`, users cannot easily switch to GET on the client side unless they make a custom search engine.

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

Change `method` in your `settings.yml` file to `GET`.

<!-- commands to run the tests or instructions to test the changes-->

<!-- additional notes for reviewiers -->

## Related issues

Closes #2129 
