### PR TITLE
[fix] opensearch on chromium for android

### DIFF
--- a/searx/templates/__common__/opensearch.xml
+++ b/searx/templates/__common__/opensearch.xml
@@ -6,7 +6,7 @@
   <Image>{{ urljoin(host, url_for('static', filename='img/favicon.png')) }}</Image>
   <LongName>searx metasearch</LongName>
   {% if opensearch_method == 'get' %}
-    <Url rel="results" type="text/html" method="get" template="{{ host }}search?q={searchTerms}"/>
+    <Url rel="results" type="text/html" method="get" template="{{ host }}?q={searchTerms}"/>
   {% else %}
     <Url rel="results" type="text/html" method="post" template="{{ host }}">
         <Param name="q" value="{searchTerms}" />

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -463,6 +463,9 @@ def pre_request():
     request.errors = []
 
     preferences = Preferences(themes, list(categories.keys()), engines, plugins)
+    user_agent = request.headers.get('User-Agent', '').lower()
+    if 'webkit' in user_agent and 'android' in user_agent:
+        preferences.key_value_settings['method'].value = 'GET'
     request.preferences = preferences
     try:
         preferences.parse_dict(request.cookies)


### PR DESCRIPTION
## What does this PR do?

This PR set all the searches made by a Chrome/Chromium browser for Android to the "GET" method.

## Why is this change important?

In order to have Searx added a search engine on Chrome/Chromium for Android, the browser wants you to visit the correct specific URL `/?q=yourkeyword`.

## How to test this PR locally?

1. Run Searx locally
2. Install a chrome/chromium based browser on Android ([Bromite](https://www.bromite.org/) is a good choice).
3. Visit your Searx instance then make a search on it.
4. You should now see Searx in the "Recently visited" section of "Search engine" from the settings.
![Screenshot_20200810-174631_Chromium_1_1](https://user-images.githubusercontent.com/4016501/89802304-dfe53b80-db20-11ea-8f47-4d71b22b3cce.png)

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

- I don't know how to allow the ability for the user to switch back to POST requests in the preferences. Maybe a developer that is used to the Searx code base could help me about that.
- I tested this PR on most of the popular browser and it doesn't break their opensearch discovery nor their search ability.
	- Microsoft Edge 15: [proof](https://i.imgur.com/vhCAkPF.png)
	- Microsoft Edge 84: [proof](https://i.imgur.com/EQE5C5c.png)
	- Google Chrome 84: [proof](https://i.imgur.com/4Mp81tZ.png)
	- Safari 13.1: [proof](https://i.imgur.com/pBVu1t9.png)
	- Firefox 79: [proof](https://i.imgur.com/xdS9O60.png)

## Related issues

Closes #1666

--------------------------

This PR is still a draft because I want to see if the maintainers and the contributors agree with my solution or if there is a better one.