### PR TITLE
[fix] piratebay engine date and pep8 indentation

### DIFF
--- a/searx/engines/piratebay.py
+++ b/searx/engines/piratebay.py
@@ -62,8 +62,8 @@ def response(resp):
     # parse results
     for result in search_res:
         link = url + "description.php?id=" + result["id"]
-        magnetlink = "magnet:?xt=urn:btih:" + result["info_hash"] + "&dn=" + result["name"]
-        + "&tr=" + "&tr=".join(trackers)
+        magnetlink = "magnet:?xt=urn:btih:" + result["info_hash"] + \
+            "&dn=" + result["name"] + "&tr=" + "&tr=".join(trackers)
 
         params = {
             "url": link,
@@ -76,7 +76,7 @@ def response(resp):
 
         # extract and convert creation date
         try:
-            date = datetime.fromtimestamp(result.added)
+            date = datetime.fromtimestamp(float(result["added"]))
             params['publishedDate'] = date
         except:
             pass


### PR DESCRIPTION
## What does this PR do?

This PR fixes one error that I introduced in #2133 due to my pep8 linting and fix the date that wasn't displayed.

## Why is this change important?

This fixes an issue with the indentation of `magnetlink` and without that PR the piratebay engine doesn't work.

## How to test this PR locally?

1. Run Searx locally
2. Type `!tpb test` in the search bar.

## Related issues

#1935
