### PR TITLE
Only return one url per "type" in Wikidata

### DIFF
--- a/searx/engines/wikidata.py
+++ b/searx/engines/wikidata.py
@@ -382,7 +382,7 @@ def add_attribute(attributes, id_cache, property_id, default_label=None, date=Fa
 
 # requires property_id unless it's a wiki link (defined in link_type)
 def add_url(urls, result, id_cache, property_id=None, default_label=None, url_prefix=None, results=None,
-            link_type=None):
+            link_type=None, only_first=True):
     links = []
 
     # wiki links don't have property in wikidata page
@@ -421,6 +421,8 @@ def add_url(urls, result, id_cache, property_id=None, default_label=None, url_pr
             urls.append(u)
             if results is not None:
                 results.append(u)
+            if only_first:
+                break
 
 
 def get_imdblink(result, url_prefix):


### PR DESCRIPTION
## What does this PR do?

Change the Wikidata engine so by default only one url is returned per `add_url` call. This can still be overridden in the function's parameters.

## Why is this change important?

Wikidata often returns several "official websites" at once or many profiles of the same social media. This clutters the infobox with a lot of redundant buttons that look exactly the same.

The first match is always supposed to be the useful one since Wikidata already sorts their results internally that way. The other results are often secondary or outdated items.

## How to test this PR locally?

Try querying Wikidata with an item that has more than one official website or redundant social media profiles according to Wikidata, for example `!wd searx` or `!wd github`.