### PR TITLE
Do not start a thread for an unacceptable request

### DIFF
--- a/searx/engines/currency_convert.py
+++ b/searx/engines/currency_convert.py
@@ -14,7 +14,7 @@ categories = []
 url = 'https://duckduckgo.com/js/spice/currency/1/{0}/{1}'
 weight = 100
 
-parser_re = re.compile(b'.*?(\\d+(?:\\.\\d+)?) ([^.0-9]+) (?:in|to) ([^.0-9]+)', re.I)
+parser_re = re.compile(b'.*?(\\d+(?:\\.\\d+)?) ([^.0-9]+) (?:in|to|en) ([^.0-9]+)', re.I)
 
 db = 1
 
@@ -39,11 +39,17 @@ def iso4217_to_name(iso4217, language):
     return db['iso4217'].get(iso4217, {}).get(language, iso4217)
 
 
-def request(query, params):
+def is_accepted(query, params):
     m = parser_re.match(query)
     if not m:
-        # wrong query
-        return params
+        return False
+
+    params['parsed_regex'] = m
+    return True
+
+
+def request(query, params):
+    m = params['parsed_regex']
     amount, from_currency, to_currency = m.groups()
     amount = float(amount)
     from_currency = name_to_iso4217(from_currency.strip())

--- a/searx/engines/translated.py
+++ b/searx/engines/translated.py
@@ -48,9 +48,8 @@ def request(query, params):
 
     params['url'] = url.format(from_lang=params['from_lang'][2],
                                to_lang=params['to_lang'][2],
-                               query=params['query'].decode('utf-8'))
+                               query=params['query'].decode('utf-8'),
                                key=key_form)
-
     return params
 
 
@@ -64,7 +63,7 @@ def response(resp):
         'title': '[{0}-{1}] {2}'.format(
             resp.search_params['from_lang'][1],
             resp.search_params['to_lang'][1],
-            resp.search_params['query']),
+            resp.search_params['query'])
         'content': resp.json()['responseData']['translatedText']
     })
     return results

--- a/searx/engines/translated.py
+++ b/searx/engines/translated.py
@@ -20,30 +20,36 @@ parser_re = re.compile(b'.*?([a-z]+)-([a-z]+) (.{2,})$', re.I)
 api_key = ''
 
 
-def request(query, params):
+def is_accepted(query, params):
     m = parser_re.match(query)
     if not m:
-        return params
+        return False
 
+    params['parsed_regex'] = m
     from_lang, to_lang, query = m.groups()
 
     from_lang = is_valid_lang(from_lang)
     to_lang = is_valid_lang(to_lang)
 
     if not from_lang or not to_lang:
-        return params
+        return False
 
-    if api_key:
-        key_form = '&key=' + api_key
-    else:
-        key_form = ''
-    params['url'] = url.format(from_lang=from_lang[1],
-                               to_lang=to_lang[1],
-                               query=query.decode('utf-8'),
-                               key=key_form)
-    params['query'] = query.decode('utf-8')
     params['from_lang'] = from_lang
     params['to_lang'] = to_lang
+    params['query'] = query
+
+    return True
+
+
+def request(query, params):
+    key_form = ''
+    if api_key:
+        key_form = '&key=' + api_key
+
+    params['url'] = url.format(from_lang=params['from_lang'][2],
+                               to_lang=params['to_lang'][2],
+                               query=params['query'].decode('utf-8'))
+                               key=key_form)
 
     return params
 

--- a/searx/search.py
+++ b/searx/search.py
@@ -498,6 +498,9 @@ class Search(object):
             request_params['category'] = selected_engine['category']
             request_params['pageno'] = search_query.pageno
 
+            if hasattr(engine, 'is_accepted') and not engine.is_accepted(search_query.query, request_params):
+                continue
+
             # append request to list
             requests.append((selected_engine['name'], search_query.query, request_params))
 


### PR DESCRIPTION
## What does this PR do?

This PR is the updated version of #992 created by @dalf . From now on engines can implement the function `is_accepted` to determine if the request submitted by the user can be executed. If not, the engine is never called.

## Why is this change important?

We can get rid of unnecessary threads which we know in advance won't retrieve any results.

## Related issues

Closes #992 
Closes #903
