### PR TITLE
[enh] test: load each engine to check for syntax errors

### DIFF
--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -72,11 +72,8 @@ def load_engine(engine_data):
 
     engine_module = engine_data['engine']
 
-    try:
-        engine = load_module(engine_module + '.py', engine_dir)
-    except:
-        logger.exception('Cannot load engine "{}"'.format(engine_module))
-        return None
+    # can raise an exception
+    engine = load_module(engine_module + '.py', engine_dir)
 
     for param_name in engine_data:
         if param_name == 'engine':
@@ -254,9 +251,11 @@ def load_engines(engine_list):
     global engines
     engines.clear()
     for engine_data in engine_list:
-        engine = load_engine(engine_data)
-        if engine is not None:
+        try:
+            engine = load_engine(engine_data)
             engines[engine.name] = engine
+        except:
+            logger.exception('Cannot load engine "{}"'.format(engine_data['engine']))
     return engines
 
 

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -136,11 +136,6 @@ app.jinja_env.lstrip_blocks = True
 app.jinja_env.add_extension('jinja2.ext.loopcontrols')
 app.secret_key = settings['server']['secret_key']
 
-if not searx_debug \
-   or os.environ.get("WERKZEUG_RUN_MAIN") == "true" \
-   or os.environ.get('UWSGI_ORIGINAL_PROC_NAME') is not None:
-    initialize_engines(settings['engines'])
-
 babel = Babel(app)
 
 rtl_locales = ['ar', 'arc', 'bcc', 'bqi', 'ckb', 'dv', 'fa', 'fa_IR', 'glk', 'he',
@@ -1051,6 +1046,10 @@ def page_not_found(e):
 
 
 def run():
+    if not searx_debug \
+       or os.environ.get("WERKZEUG_RUN_MAIN") == "true" \
+       or os.environ.get('UWSGI_ORIGINAL_PROC_NAME') is not None:
+        initialize_engines(settings['engines'])
     logger.debug('starting webserver on %s:%s', settings['server']['bind_address'], settings['server']['port'])
     app.run(
         debug=searx_debug,

--- a/tests/unit/test_engines.py
+++ b/tests/unit/test_engines.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+import unittest2 as unittest
+from unittest2.util import strclass
+from searx.engines import load_engine
+from searx import settings
+
+
+class TestEngine(unittest.TestCase):
+
+    def test_engines(self):
+        for engine_data in settings['engines']:
+            load_engine(engine_data)


### PR DESCRIPTION
## What does this PR do?

In the tests (```make test```), all the engines are loaded to check for syntax errors.

## Why is this change important?

In the https://github.com/asciimoo/searx/pull/2159 , Travis, ```make test``` are ok despite a syntax error: https://travis-ci.org/github/asciimoo/searx/jobs/721829981#L938

## How to test this PR locally?

Note:
* Before this PR, the engines are loaded as soon as searx.webapp is imported.
* After this PR, the engines are loaded inside searx.webapp.run()
* Before and after this PR, searx starts even if some engines can't start.

Call 
* ```make test```
* ```make run```

## Author's checklist


## Related issues

Possible enhancement, later:
* call ```is_accepted(...)```
* call ```request(...)```
* it is not possible to call ```response(....)``` without the previous version of the tests.