### PR TITLE
Add key to settings.yml for opening result links in a new tab

### DIFF
--- a/searx/preferences.py
+++ b/searx/preferences.py
@@ -364,7 +364,7 @@ class Preferences(object):
                 choices=themes
             ),
             'results_on_new_tab': MapSetting(
-                False,
+                settings['ui'].get('results_on_new_tab', False),
                 map={
                     '0': False,
                     '1': True,

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -25,6 +25,7 @@ ui:
     default_locale : "" # Default interface locale - leave blank to detect from browser information or use codes from the 'locales' config section
     theme_args :
         oscar_style : logicodev # default style of oscar
+#   results_on_new_tab: False  # Open result links in a new tab by default
 #   categories_order :
 #     - general
 #     - files


### PR DESCRIPTION
## What does this PR do?

Adds a configuration key in `settings.yml` for opening result links in new tab by default.

## Why is this change important?

Gives admins the ability to set opening result links in a new tab by default.  Users can still override this functionality in the preferences cookie(s).

## How to test this PR locally?

Add `results_on_new_tab: True` to the `ui` section in `settings.yml`, restart Searx, perform a search, click a result link and it should open in a new tab.  Comment out the key or set the value to `False`, restart Searx, perform a search, click a result link and it should open in the same tab.

## Author's checklist

Does not alter functionality by default.  It only activates when the correct key and value is added to `settings.yml`.

## Related issues

Closes #1552 
Closes #444 