### PR TITLE
[enh] stop searx when an engine raise an SyntaxError exception

### DIFF
--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -74,6 +74,9 @@ def load_engine(engine_data):
 
     try:
         engine = load_module(engine_module + '.py', engine_dir)
+    except (SyntaxError, KeyboardInterrupt, SystemExit, SystemError, ImportError, RuntimeError) as e:
+        logger.exception('Fatal exception in engine "{}"'.format(engine_module))
+        sys.exit(1)
     except:
         logger.exception('Cannot load engine "{}"'.format(engine_module))
         return None


### PR DESCRIPTION
and some other exceptions:
* KeyboardInterrupt
* SystemExit
* RuntimeError
* SystemError
* ImportError: an engine with an unmet dependency will stop everything.

## What does this PR do?

Update version of https://github.com/searx/searx/pull/2160

This PR make stop searx loading when Python raises a SyntaxError exception

## Why is this change important?

In the https://github.com/asciimoo/searx/pull/2159 , Travis, ```make test``` are ok despite a syntax error: https://travis-ci.org/github/asciimoo/searx/jobs/721829981#L938

## How to test this PR locally?

1. check searx starts as before
1. add an syntax error in an engine
1. check searx stops

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues


