### PR TITLE
[fix] docker and k8s: run searx

### DIFF
--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -19,20 +19,24 @@ help() {
 	exit 0
 }
 
-if ! grep docker /proc/1/cgroup -qa; then
-    help
-fi
-
 export DEFAULT_BIND_ADDRESS="0.0.0.0:8080"
 if [ -z "${BIND_ADDRESS}" ]; then
     export BIND_ADDRESS="${DEFAULT_BIND_ADDRESS}"
 fi
 
-export SEARX_VERSION=$(su searx -c 'python3 -c "import six; import searx.version; six.print_(searx.version.VERSION_STRING)"' 2>/dev/null)
-printf 'searx version %s\n\n' "${SEARX_VERSION}"
-
 export UWSGI_SETTINGS_PATH=/etc/searx/uwsgi.ini
 export SEARX_SETTINGS_PATH=/etc/searx/settings.yml
+
+# Parse special command line
+# see docs/admin/installation-docker.rst
+# display the help message without the version
+if [ "$1" = "help" ]; then
+	help
+fi
+
+# Version
+export SEARX_VERSION=$(su searx -c 'python3 -c "import six; import searx.version; six.print_(searx.version.VERSION_STRING)"' 2>/dev/null)
+printf 'searx version %s\n\n' "${SEARX_VERSION}"
 
 # Parse command line
 FORCE_CONF_UPDATE=0

--- a/docs/admin/installation-docker.rst
+++ b/docs/admin/installation-docker.rst
@@ -39,7 +39,7 @@ Command line
 
     docker run --rm -it searx/searx -h
 
-.. program-output:: ../dockerfiles/docker-entrypoint.sh -h
+.. program-output:: ../dockerfiles/docker-entrypoint.sh help
 
 
 Build the image


### PR DESCRIPTION
## What does this PR do?

docs/admin/installation-docker.rst calls dockerfiles/docker-entrypoint.sh to include the help message inside the documentation.

dockerfiles/docker-entrypoint.sh detects if docker is running using ```grep docker /proc/1/cgroup -qa```.

This method doesn't work with k8s, see #2181

This PR fixes this issue:
* add a new parameter ```docs``` to dockerfiles/docker-entrypoint.sh 
* docs/admin/installation-docker.rst calls ```dockerfiles/docker-entrypoint.sh  docs```.

## Why is this change important?

Without this PR it is possible to run the searx docker with k8s.

## How to test this PR locally?

* ```make docker```
* add a new docker image to microk8s
* check if searx has started

## Author's checklist


## Related issues

Close #2181