### PR TITLE
[fix] make docker produces clean tag version

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -120,7 +120,7 @@ docker_build() {
 
     # "git describe" to get the Docker version (for example : v0.15.0-89-g0585788e)
     # awk to remove the "v" and the "g"
-    SEARX_GIT_VERSION=$(git describe --match "v[0-9]*\.[0-9]*\.[0-9]*" HEAD 2>/dev/null | awk -F'-' '{OFS="-"; $1=substr($1, 2); $3=substr($3, 2); print}')
+    SEARX_GIT_VERSION=$(git describe --match "v[0-9]*\.[0-9]*\.[0-9]*" HEAD 2>/dev/null | awk -F'-' '{OFS="-"; $1=substr($1, 2); if ($3) { $3=substr($3, 2); }  print}')
 
     # add the suffix "-dirty" if the repository has uncommited change
     # /!\ HACK for searx/searx: ignore searx/brand.py and utils/brand.env


### PR DESCRIPTION
## What does this PR do?

Currently ```make docker``` produces tag like ```0.17.0--``` instead of ```0.17.0```.

## Why is this change important?

Simplify maintenance for admin using docker.

## How to test this PR locally?

* call ```make docker```, check that the docker version is similar to ```0.17.0-93-a03cdf84```
* create a git tag ```0.18.0```
* call ```make docker```, check that the docker version is ```0.18.0```

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Close #2152
