### PR TITLE
[mod] searx.RawTextQuery: the constructor call parse_query

### DIFF
--- a/searx/query.py
+++ b/searx/query.py
@@ -45,10 +45,11 @@ class RawTextQuery:
         self.timeout_limit = None
         self.external_bang = None
         self.specific = False
+        self._parse_query()
 
     # parse query, if tags are set, which
     # change the search engine or search-language
-    def parse_query(self):
+    def _parse_query(self):
         self.query_parts = []
 
         # split query, including whitespaces

--- a/searx/search.py
+++ b/searx/search.py
@@ -266,7 +266,6 @@ def get_search_query_from_webapp(preferences, form):
     # parse query, if tags are set, which change
     # the serch engine or search-language
     raw_text_query = RawTextQuery(form['q'], disabled_engines)
-    raw_text_query.parse_query()
 
     # set query
     query = raw_text_query.getSearchQuery()

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -737,7 +737,6 @@ def autocompleter():
 
     # parse query
     raw_text_query = RawTextQuery(str(request.form.get('q', b'')), disabled_engines)
-    raw_text_query.parse_query()
 
     # check if search query is set
     if not raw_text_query.getSearchQuery():

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -7,7 +7,6 @@ class TestQuery(SearxTestCase):
     def test_simple_query(self):
         query_text = 'the query'
         query = RawTextQuery(query_text, [])
-        query.parse_query()
 
         self.assertEqual(query.getFullQuery(), query_text)
         self.assertEqual(len(query.query_parts), 1)
@@ -19,7 +18,6 @@ class TestQuery(SearxTestCase):
         query_text = 'the query'
         full_query = ':' + language + ' ' + query_text
         query = RawTextQuery(full_query, [])
-        query.parse_query()
 
         self.assertEqual(query.getFullQuery(), full_query)
         self.assertEqual(len(query.query_parts), 3)
@@ -32,7 +30,6 @@ class TestQuery(SearxTestCase):
         query_text = 'the query'
         full_query = ':' + language + ' ' + query_text
         query = RawTextQuery(full_query, [])
-        query.parse_query()
 
         self.assertEqual(query.getFullQuery(), full_query)
         self.assertEqual(len(query.query_parts), 3)
@@ -44,7 +41,6 @@ class TestQuery(SearxTestCase):
         query_text = 'the query'
         full_query = ':' + language + ' ' + query_text
         query = RawTextQuery(full_query, [])
-        query.parse_query()
 
         self.assertEqual(query.getFullQuery(), full_query)
         self.assertEqual(len(query.query_parts), 3)
@@ -56,7 +52,6 @@ class TestQuery(SearxTestCase):
         query_text = 'the query'
         full_query = ':' + language + ' ' + query_text
         query = RawTextQuery(full_query, [])
-        query.parse_query()
 
         self.assertEqual(query.getFullQuery(), full_query)
         self.assertEqual(len(query.query_parts), 1)
@@ -66,7 +61,6 @@ class TestQuery(SearxTestCase):
     def test_timeout_below100(self):
         query_text = '<3 the query'
         query = RawTextQuery(query_text, [])
-        query.parse_query()
 
         self.assertEqual(query.getFullQuery(), query_text)
         self.assertEqual(len(query.query_parts), 3)
@@ -76,7 +70,6 @@ class TestQuery(SearxTestCase):
     def test_timeout_above100(self):
         query_text = '<350 the query'
         query = RawTextQuery(query_text, [])
-        query.parse_query()
 
         self.assertEqual(query.getFullQuery(), query_text)
         self.assertEqual(len(query.query_parts), 3)
@@ -86,7 +79,6 @@ class TestQuery(SearxTestCase):
     def test_timeout_above1000(self):
         query_text = '<3500 the query'
         query = RawTextQuery(query_text, [])
-        query.parse_query()
 
         self.assertEqual(query.getFullQuery(), query_text)
         self.assertEqual(len(query.query_parts), 3)
@@ -97,7 +89,6 @@ class TestQuery(SearxTestCase):
         # invalid number: it is not bang but it is part of the query
         query_text = '<xxx the query'
         query = RawTextQuery(query_text, [])
-        query.parse_query()
 
         self.assertEqual(query.getFullQuery(), query_text)
         self.assertEqual(len(query.query_parts), 1)


### PR DESCRIPTION
## What does this PR do?

The [RawTextQuery](https://github.com/asciimoo/searx/blob/093dd42bb05feafb2cc77304d3b1a9a1a3016949/searx/query.py#L33) usage is:
  1. call the constructor
  2. call the [```parse_query()```](https://github.com/asciimoo/searx/blob/093dd42bb05feafb2cc77304d3b1a9a1a3016949/searx/query.py#L52) to actually parse the query.
  
```git grep -A2 "RawTextQuery("``` shows that all instantiations of the RawTextQuery class is followed by a call to the ```parse_query()``` method.

This PR:
* rename RawTextQuery.parse_query to RawTextQuery._parse_query
* RawTextQuery constructor call RawTextQuery._parse_query

## Why is this change important?

Small modification to make the code readable.

## How to test this PR locally?

* ```make test```
* check that searx bang still works as expected.
* check autocomplete still works as expected.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Related to #2143
