### PR TITLE
Architecture clean up

### DIFF
--- a/searx/query.py
+++ b/searx/query.py
@@ -20,9 +20,8 @@ along with searx. If not, see < http://www.gnu.org/licenses/ >.
 import re
 
 from searx.languages import language_codes
-from searx.engines import (
-    categories, engines, engine_shortcuts
-)
+from searx.engines import categories, engines, engine_shortcuts
+from searx.search import EngineRef
 
 
 VALID_LANGUAGE_CODE = re.compile(r'^[a-z]{2,3}(-[a-zA-Z]{2})?$')
@@ -40,7 +39,7 @@ class RawTextQuery:
             self.disabled_engines = disabled_engines
 
         self.query_parts = []
-        self.engines = []
+        self.enginerefs = []
         self.languages = []
         self.timeout_limit = None
         self.external_bang = None
@@ -135,26 +134,21 @@ class RawTextQuery:
                     parse_next = True
                     engine_name = engine_shortcuts[prefix]
                     if engine_name in engines:
-                        self.engines.append({'category': 'none',
-                                             'name': engine_name,
-                                             'from_bang': True})
+                        self.enginerefs.append(EngineRef(engine_name, 'none', True))
 
                 # check if prefix is equal with engine name
                 elif prefix in engines:
                     parse_next = True
-                    self.engines.append({'category': 'none',
-                                         'name': prefix,
-                                         'from_bang': True})
+                    self.enginerefs.append(EngineRef(prefix, 'none', True))
 
                 # check if prefix is equal with categorie name
                 elif prefix in categories:
                     # using all engines for that search, which
                     # are declared under that categorie name
                     parse_next = True
-                    self.engines.extend({'category': prefix,
-                                         'name': engine.name}
-                                        for engine in categories[prefix]
-                                        if (engine.name, prefix) not in self.disabled_engines)
+                    self.enginerefs.extend(EngineRef(engine.name, prefix)
+                                           for engine in categories[prefix]
+                                           if (engine.name, prefix) not in self.disabled_engines)
 
             if query_part[0] == '!':
                 self.specific = True

--- a/searx/query.py
+++ b/searx/query.py
@@ -178,23 +178,3 @@ class RawTextQuery:
     def getFullQuery(self):
         # get full querry including whitespaces
         return ''.join(self.query_parts)
-
-
-class SearchQuery:
-    """container for all the search parameters (query, language, etc...)"""
-
-    def __init__(self, query, engines, categories, lang, safesearch, pageno, time_range,
-                 timeout_limit=None, preferences=None, external_bang=None):
-        self.query = query
-        self.engines = engines
-        self.categories = categories
-        self.lang = lang
-        self.safesearch = safesearch
-        self.pageno = pageno
-        self.time_range = None if time_range in ('', 'None', None) else time_range
-        self.timeout_limit = timeout_limit
-        self.preferences = preferences
-        self.external_bang = external_bang
-
-    def __str__(self):
-        return self.query + ";" + str(self.engines)

--- a/searx/search.py
+++ b/searx/search.py
@@ -16,26 +16,20 @@ along with searx. If not, see < http://www.gnu.org/licenses/ >.
 '''
 
 import gc
-import sys
 import threading
 from time import time
 from uuid import uuid4
 from _thread import start_new_thread
 
-from flask_babel import gettext
 import requests.exceptions
 import searx.poolrequests as requests_lib
-from searx.engines import (
-    categories, engines, settings
-)
+from searx.engines import engines, settings
 from searx.answerers import ask
 from searx.external_bang import get_bang_url
 from searx.utils import gen_useragent
-from searx.query import RawTextQuery, SearchQuery, VALID_LANGUAGE_CODE
 from searx.results import ResultContainer
 from searx import logger
 from searx.plugins import plugins
-from searx.exceptions import SearxParameterException
 
 
 logger = logger.getChild('search')
@@ -51,6 +45,26 @@ else:
         from sys import exit
 
         exit(1)
+
+
+class SearchQuery:
+    """container for all the search parameters (query, language, etc...)"""
+
+    def __init__(self, query, engines, categories, lang, safesearch, pageno, time_range,
+                 timeout_limit=None, preferences=None, external_bang=None):
+        self.query = query
+        self.engines = engines
+        self.categories = categories
+        self.lang = lang
+        self.safesearch = safesearch
+        self.pageno = pageno
+        self.time_range = None if time_range in ('', 'None', None) else time_range
+        self.timeout_limit = timeout_limit
+        self.preferences = preferences
+        self.external_bang = external_bang
+
+    def __str__(self):
+        return self.query + ";" + str(self.engines)
 
 
 def send_http_request(engine, request_params):
@@ -245,164 +259,6 @@ def default_request_params():
         'cookies': {},
         'verify': True
     }
-
-
-# remove duplicate queries.
-# FIXME: does not fix "!music !soundcloud", because the categories are 'none' and 'music'
-def deduplicate_query_engines(query_engines):
-    uniq_query_engines = {q["category"] + '|' + q["name"]: q for q in query_engines}
-    return uniq_query_engines.values()
-
-
-def get_search_query_from_webapp(preferences, form):
-    # no text for the query ?
-    if not form.get('q'):
-        raise SearxParameterException('q', '')
-
-    # set blocked engines
-    disabled_engines = preferences.engines.get_disabled()
-
-    # parse query, if tags are set, which change
-    # the serch engine or search-language
-    raw_text_query = RawTextQuery(form['q'], disabled_engines)
-
-    # set query
-    query = raw_text_query.getQuery()
-
-    # get and check page number
-    pageno_param = form.get('pageno', '1')
-    if not pageno_param.isdigit() or int(pageno_param) < 1:
-        raise SearxParameterException('pageno', pageno_param)
-    query_pageno = int(pageno_param)
-
-    # get language
-    # set specific language if set on request, query or preferences
-    # TODO support search with multible languages
-    if len(raw_text_query.languages):
-        query_lang = raw_text_query.languages[-1]
-    elif 'language' in form:
-        query_lang = form.get('language')
-    else:
-        query_lang = preferences.get_value('language')
-
-    # check language
-    if not VALID_LANGUAGE_CODE.match(query_lang):
-        raise SearxParameterException('language', query_lang)
-
-    # get safesearch
-    if 'safesearch' in form:
-        query_safesearch = form.get('safesearch')
-        # first check safesearch
-        if not query_safesearch.isdigit():
-            raise SearxParameterException('safesearch', query_safesearch)
-        query_safesearch = int(query_safesearch)
-    else:
-        query_safesearch = preferences.get_value('safesearch')
-
-    # safesearch : second check
-    if query_safesearch < 0 or query_safesearch > 2:
-        raise SearxParameterException('safesearch', query_safesearch)
-
-    # get time_range
-    query_time_range = form.get('time_range')
-
-    # check time_range
-    if query_time_range not in ('None', None, '', 'day', 'week', 'month', 'year'):
-        raise SearxParameterException('time_range', query_time_range)
-
-    # query_engines
-    query_engines = raw_text_query.engines
-
-    # timeout_limit
-    query_timeout = raw_text_query.timeout_limit
-    if query_timeout is None and 'timeout_limit' in form:
-        raw_time_limit = form.get('timeout_limit')
-        if raw_time_limit in ['None', '']:
-            raw_time_limit = None
-        else:
-            try:
-                query_timeout = float(raw_time_limit)
-            except ValueError:
-                raise SearxParameterException('timeout_limit', raw_time_limit)
-
-    # query_categories
-    query_categories = []
-
-    # if engines are calculated from query,
-    # set categories by using that informations
-    if query_engines and raw_text_query.specific:
-        additional_categories = set()
-        for engine in query_engines:
-            if 'from_bang' in engine and engine['from_bang']:
-                additional_categories.add('none')
-            else:
-                additional_categories.add(engine['category'])
-        query_categories = list(additional_categories)
-
-    # otherwise, using defined categories to
-    # calculate which engines should be used
-    else:
-        # set categories/engines
-        load_default_categories = True
-        for pd_name, pd in form.items():
-            if pd_name == 'categories':
-                query_categories.extend(categ for categ in map(str.strip, pd.split(',')) if categ in categories)
-            elif pd_name == 'engines':
-                pd_engines = [{'category': engines[engine].categories[0],
-                               'name': engine}
-                              for engine in map(str.strip, pd.split(',')) if engine in engines]
-                if pd_engines:
-                    query_engines.extend(pd_engines)
-                    load_default_categories = False
-            elif pd_name.startswith('category_'):
-                category = pd_name[9:]
-
-                # if category is not found in list, skip
-                if category not in categories:
-                    continue
-
-                if pd != 'off':
-                    # add category to list
-                    query_categories.append(category)
-                elif category in query_categories:
-                    # remove category from list if property is set to 'off'
-                    query_categories.remove(category)
-
-        if not load_default_categories:
-            if not query_categories:
-                query_categories = list(set(engine['category']
-                                            for engine in query_engines))
-        else:
-            # if no category is specified for this search,
-            # using user-defined default-configuration which
-            # (is stored in cookie)
-            if not query_categories:
-                cookie_categories = preferences.get_value('categories')
-                for ccateg in cookie_categories:
-                    if ccateg in categories:
-                        query_categories.append(ccateg)
-
-            # if still no category is specified, using general
-            # as default-category
-            if not query_categories:
-                query_categories = ['general']
-
-            # using all engines for that search, which are
-            # declared under the specific categories
-            for categ in query_categories:
-                query_engines.extend({'category': categ,
-                                      'name': engine.name}
-                                     for engine in categories[categ]
-                                     if (engine.name, categ) not in disabled_engines)
-
-    query_engines = deduplicate_query_engines(query_engines)
-    external_bang = raw_text_query.external_bang
-
-    return (SearchQuery(query, query_engines, query_categories,
-                        query_lang, query_safesearch, query_pageno,
-                        query_time_range, query_timeout, preferences,
-                        external_bang=external_bang),
-            raw_text_query)
 
 
 class Search:

--- a/searx/search.py
+++ b/searx/search.py
@@ -69,7 +69,7 @@ class SearchQuery:
         self.lang = lang
         self.safesearch = safesearch
         self.pageno = pageno
-        self.time_range = None if time_range in ('', 'None', None) else time_range
+        self.time_range = time_range
         self.timeout_limit = timeout_limit
         self.preferences = preferences
         self.external_bang = external_bang

--- a/searx/search.py
+++ b/searx/search.py
@@ -62,7 +62,7 @@ class SearchQuery:
     """container for all the search parameters (query, language, etc...)"""
 
     def __init__(self, query, engineref_list, categories, lang, safesearch, pageno, time_range,
-                 timeout_limit=None, preferences=None, external_bang=None):
+                 timeout_limit=None, external_bang=None):
         self.query = query
         self.engineref_list = engineref_list
         self.categories = categories
@@ -71,7 +71,6 @@ class SearchQuery:
         self.pageno = pageno
         self.time_range = time_range
         self.timeout_limit = timeout_limit
-        self.preferences = preferences
         self.external_bang = external_bang
 
     def __str__(self):
@@ -311,9 +310,6 @@ class Search:
         return False
 
     def _is_accepted(self, engine_name, engine):
-        if not self.search_query.preferences.validate_token(engine):
-            return False
-
         # skip suspended engines
         if engine.suspend_end_time >= time():
             logger.debug('Engine currently suspended: %s', engine_name)

--- a/searx/search.py
+++ b/searx/search.py
@@ -15,6 +15,7 @@ along with searx. If not, see < http://www.gnu.org/licenses/ >.
 (C) 2013- by Adam Tauber, <asciimoo@gmail.com>
 '''
 
+import typing
 import gc
 import threading
 from time import time
@@ -49,7 +50,9 @@ else:
 
 class EngineRef:
 
-    def __init__(self, name, category, from_bang=False):
+    __slots__ = 'name', 'category', 'from_bang'
+
+    def __init__(self, name: str, category: str, from_bang: bool=False):
         self.name = name
         self.category = category
         self.from_bang = from_bang
@@ -61,8 +64,19 @@ class EngineRef:
 class SearchQuery:
     """container for all the search parameters (query, language, etc...)"""
 
-    def __init__(self, query, engineref_list, categories, lang, safesearch, pageno, time_range,
-                 timeout_limit=None, external_bang=None):
+    __slots__ = 'query', 'engineref_list', 'categories', 'lang', 'safesearch', 'pageno', 'time_range',\
+                'timeout_limit', 'external_bang'
+
+    def __init__(self,
+                 query: str,
+                 engineref_list: typing.List[EngineRef],
+                 categories: typing.List[str],
+                 lang: str,
+                 safesearch: bool,
+                 pageno: int,
+                 time_range: typing.Optional[str],
+                 timeout_limit: typing.Optional[float]=None,
+                 external_bang: typing.Optional[str]=False):
         self.query = query
         self.engineref_list = engineref_list
         self.categories = categories
@@ -274,6 +288,8 @@ def default_request_params():
 class Search:
     """Search information container"""
 
+    __slots__ = "search_query", "result_container", "start_time", "actual_timeout"
+
     def __init__(self, search_query):
         # init vars
         super().__init__()
@@ -396,7 +412,7 @@ class Search:
             actual_timeout = min(query_timeout, max_request_timeout)
 
         logger.debug("actual_timeout={0} (default_timeout={1}, ?timeout_limit={2}, max_request_timeout={3})"
-                     .format(self.actual_timeout, default_timeout, query_timeout, max_request_timeout))
+                     .format(actual_timeout, default_timeout, query_timeout, max_request_timeout))
 
         return requests, actual_timeout
 
@@ -427,6 +443,8 @@ class Search:
 
 class SearchWithPlugins(Search):
     """Similar to the Search class but call the plugins."""
+
+    __slots__ = 'ordered_plugin_list', 'request'
 
     def __init__(self, search_query, ordered_plugin_list, request):
         super().__init__(search_query)

--- a/searx/webadapter.py
+++ b/searx/webadapter.py
@@ -1,0 +1,162 @@
+from searx.exceptions import SearxParameterException
+from searx.query import RawTextQuery, VALID_LANGUAGE_CODE
+from searx.engines import categories, engines
+from searx.search import SearchQuery
+
+
+# remove duplicate queries.
+# FIXME: does not fix "!music !soundcloud", because the categories are 'none' and 'music'
+def deduplicate_query_engines(query_engines):
+    uniq_query_engines = {q["category"] + '|' + q["name"]: q for q in query_engines}
+    return uniq_query_engines.values()
+
+
+def get_search_query_from_webapp(preferences, form):
+    # no text for the query ?
+    if not form.get('q'):
+        raise SearxParameterException('q', '')
+
+    # set blocked engines
+    disabled_engines = preferences.engines.get_disabled()
+
+    # parse query, if tags are set, which change
+    # the serch engine or search-language
+    raw_text_query = RawTextQuery(form['q'], disabled_engines)
+
+    # set query
+    query = raw_text_query.getQuery()
+
+    # get and check page number
+    pageno_param = form.get('pageno', '1')
+    if not pageno_param.isdigit() or int(pageno_param) < 1:
+        raise SearxParameterException('pageno', pageno_param)
+    query_pageno = int(pageno_param)
+
+    # get language
+    # set specific language if set on request, query or preferences
+    # TODO support search with multible languages
+    if len(raw_text_query.languages):
+        query_lang = raw_text_query.languages[-1]
+    elif 'language' in form:
+        query_lang = form.get('language')
+    else:
+        query_lang = preferences.get_value('language')
+
+    # check language
+    if not VALID_LANGUAGE_CODE.match(query_lang):
+        raise SearxParameterException('language', query_lang)
+
+    # get safesearch
+    if 'safesearch' in form:
+        query_safesearch = form.get('safesearch')
+        # first check safesearch
+        if not query_safesearch.isdigit():
+            raise SearxParameterException('safesearch', query_safesearch)
+        query_safesearch = int(query_safesearch)
+    else:
+        query_safesearch = preferences.get_value('safesearch')
+
+    # safesearch : second check
+    if query_safesearch < 0 or query_safesearch > 2:
+        raise SearxParameterException('safesearch', query_safesearch)
+
+    # get time_range
+    query_time_range = form.get('time_range')
+
+    # check time_range
+    if query_time_range not in ('None', None, '', 'day', 'week', 'month', 'year'):
+        raise SearxParameterException('time_range', query_time_range)
+
+    # query_engines
+    query_engines = raw_text_query.engines
+
+    # timeout_limit
+    query_timeout = raw_text_query.timeout_limit
+    if query_timeout is None and 'timeout_limit' in form:
+        raw_time_limit = form.get('timeout_limit')
+        if raw_time_limit in ['None', '']:
+            raw_time_limit = None
+        else:
+            try:
+                query_timeout = float(raw_time_limit)
+            except ValueError:
+                raise SearxParameterException('timeout_limit', raw_time_limit)
+
+    # query_categories
+    query_categories = []
+
+    # if engines are calculated from query,
+    # set categories by using that informations
+    if query_engines and raw_text_query.specific:
+        additional_categories = set()
+        for engine in query_engines:
+            if 'from_bang' in engine and engine['from_bang']:
+                additional_categories.add('none')
+            else:
+                additional_categories.add(engine['category'])
+        query_categories = list(additional_categories)
+
+    # otherwise, using defined categories to
+    # calculate which engines should be used
+    else:
+        # set categories/engines
+        load_default_categories = True
+        for pd_name, pd in form.items():
+            if pd_name == 'categories':
+                query_categories.extend(categ for categ in map(str.strip, pd.split(',')) if categ in categories)
+            elif pd_name == 'engines':
+                pd_engines = [{'category': engines[engine].categories[0],
+                               'name': engine}
+                              for engine in map(str.strip, pd.split(',')) if engine in engines]
+                if pd_engines:
+                    query_engines.extend(pd_engines)
+                    load_default_categories = False
+            elif pd_name.startswith('category_'):
+                category = pd_name[9:]
+
+                # if category is not found in list, skip
+                if category not in categories:
+                    continue
+
+                if pd != 'off':
+                    # add category to list
+                    query_categories.append(category)
+                elif category in query_categories:
+                    # remove category from list if property is set to 'off'
+                    query_categories.remove(category)
+
+        if not load_default_categories:
+            if not query_categories:
+                query_categories = list(set(engine['category']
+                                            for engine in query_engines))
+        else:
+            # if no category is specified for this search,
+            # using user-defined default-configuration which
+            # (is stored in cookie)
+            if not query_categories:
+                cookie_categories = preferences.get_value('categories')
+                for ccateg in cookie_categories:
+                    if ccateg in categories:
+                        query_categories.append(ccateg)
+
+            # if still no category is specified, using general
+            # as default-category
+            if not query_categories:
+                query_categories = ['general']
+
+            # using all engines for that search, which are
+            # declared under the specific categories
+            for categ in query_categories:
+                query_engines.extend({'category': categ,
+                                      'name': engine.name}
+                                     for engine in categories[categ]
+                                     if (engine.name, categ) not in disabled_engines)
+
+    query_engines = deduplicate_query_engines(query_engines)
+    external_bang = raw_text_query.external_bang
+
+    return (SearchQuery(query, query_engines, query_categories,
+                        query_lang, query_safesearch, query_pageno,
+                        query_time_range, query_timeout, preferences,
+                        external_bang=external_bang),
+            raw_text_query)

--- a/searx/webadapter.py
+++ b/searx/webadapter.py
@@ -64,7 +64,8 @@ def get_search_query_from_webapp(preferences, form):
     query_time_range = form.get('time_range')
 
     # check time_range
-    if query_time_range not in ('None', None, '', 'day', 'week', 'month', 'year'):
+    query_time_range = None if query_time_range in ('', 'None') else query_time_range
+    if query_time_range not in (None, 'day', 'week', 'month', 'year'):
         raise SearxParameterException('time_range', query_time_range)
 
     # query_engines

--- a/searx/webadapter.py
+++ b/searx/webadapter.py
@@ -1,19 +1,22 @@
+import typing
 from searx.exceptions import SearxParameterException
 from searx.query import RawTextQuery, VALID_LANGUAGE_CODE
 from searx.engines import categories, engines
 from searx.search import SearchQuery, EngineRef
+from searx.preferences import Preferences
 
 
 # remove duplicate queries.
 # FIXME: does not fix "!music !soundcloud", because the categories are 'none' and 'music'
-def deduplicate_engineref_list(engineref_list):
+def deduplicate_engineref_list(engineref_list: typing.List[EngineRef]) -> typing.List[EngineRef]:
     engineref_dict = {q.category + '|' + q.name: q for q in engineref_list}
     return engineref_dict.values()
 
 
-def validate_engineref_list(engineref_list, preferences):
+def validate_engineref_list(engineref_list: typing.List[EngineRef], preferences: Preferences):
     """
     Validate query_engines according to the preferences
+
         Returns:
             list of existing engines with a validated token
             list of unknown engine
@@ -36,14 +39,14 @@ def validate_engineref_list(engineref_list, preferences):
     return valid, unknown, no_token
 
 
-def parse_pageno(form):
+def parse_pageno(form: typing.Dict[str, str]) -> int:
     pageno_param = form.get('pageno', '1')
     if not pageno_param.isdigit() or int(pageno_param) < 1:
         raise SearxParameterException('pageno', pageno_param)
     return int(pageno_param)
 
 
-def parse_lang(raw_text_query, form, preferences):
+def parse_lang(raw_text_query: RawTextQuery, form: typing.Dict[str, str], preferences: Preferences) -> str:
     # get language
     # set specific language if set on request, query or preferences
     # TODO support search with multible languages
@@ -61,7 +64,7 @@ def parse_lang(raw_text_query, form, preferences):
     return query_lang
 
 
-def parse_safesearch(form, preferences):
+def parse_safesearch(form: typing.Dict[str, str], preferences: Preferences) -> int:
     if 'safesearch' in form:
         query_safesearch = form.get('safesearch')
         # first check safesearch
@@ -78,7 +81,7 @@ def parse_safesearch(form, preferences):
     return query_safesearch
 
 
-def parse_time_range(form):
+def parse_time_range(form: typing.Dict[str, str]) -> str:
     query_time_range = form.get('time_range')
     # check time_range
     query_time_range = None if query_time_range in ('', 'None') else query_time_range
@@ -87,7 +90,7 @@ def parse_time_range(form):
     return query_time_range
 
 
-def parse_timeout(raw_text_query, form):
+def parse_timeout(raw_text_query: RawTextQuery, form: typing.Dict[str, str]) -> typing.Optional[float]:
     query_timeout = raw_text_query.timeout_limit
     if query_timeout is None and 'timeout_limit' in form:
         raw_time_limit = form.get('timeout_limit')
@@ -187,7 +190,8 @@ def parse_generic(form, preferences, disabled_engines):
     return query_engineref_list, query_categories
 
 
-def get_search_query_from_webapp(preferences, form):
+def get_search_query_from_webapp(preferences: Preferences, form: typing.Dict[str, str])\
+        -> typing.Tuple[SearchQuery, RawTextQuery, typing.List[EngineRef], typing.List[EngineRef]]:
     # no text for the query ?
     if not form.get('q'):
         raise SearxParameterException('q', '')

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -513,7 +513,7 @@ def index_error(output_format, error_message):
         request.errors.append(gettext('search error'))
         return render(
             'index.html',
-            selected_categories=get_selected_categories(request.form, request.preferences),
+            selected_categories=get_selected_categories(request.preferences, request.form),
         )
 
 
@@ -535,7 +535,7 @@ def index():
         if output_format == 'html':
             return render(
                 'index.html',
-                selected_categories=get_selected_categories(request.form, request.preferences),
+                selected_categories=get_selected_categories(request.preferences, request.form),
             )
         else:
             return index_error(output_format, 'No query'), 400
@@ -816,7 +816,7 @@ def preferences():
     # end of stats
 
     return render('preferences.html',
-                  selected_categories=get_selected_categories(request.form, request.preferences),
+                  selected_categories=get_selected_categories(request.preferences, request.form),
                   all_categories=_get_ordered_categories(),
                   locales=settings['locales'],
                   current_locale=request.preferences.get_value("locale"),

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -67,10 +67,11 @@ from searx.webutils import (
     get_static_files, get_result_templates, get_themes,
     prettify_url, new_hmac
 )
+from searx.webadapter import get_search_query_from_webapp
 from searx.utils import html_to_text, gen_useragent, dict_subset, match_language
 from searx.version import VERSION_STRING
 from searx.languages import language_codes as languages
-from searx.search import SearchWithPlugins, get_search_query_from_webapp
+from searx.search import SearchWithPlugins
 from searx.query import RawTextQuery
 from searx.autocomplete import searx_bang, backends as autocomplete_backends
 from searx.plugins import plugins

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -562,7 +562,7 @@ def index():
     raw_text_query = None
     result_container = None
     try:
-        search_query, raw_text_query = get_search_query_from_webapp(request.preferences, request.form)
+        search_query, raw_text_query, _, _ = get_search_query_from_webapp(request.preferences, request.form)
         # search = Search(search_query) #  without plugins
         search = SearchWithPlugins(search_query, request.user_plugins, request)
 

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -5,7 +5,7 @@ from searx.preferences import Preferences
 from searx.engines import engines
 
 import searx.search
-from searx.search import SearchQuery
+from searx.search import SearchQuery, EngineRef
 
 
 SAFESEARCH = 0
@@ -41,7 +41,7 @@ class SearchTestCase(SearxTestCase):
 
     def test_timeout_simple(self):
         searx.search.max_request_timeout = None
-        search_query = SearchQuery('test', [{'category': 'general', 'name': PUBLIC_ENGINE_NAME}],
+        search_query = SearchQuery('test', [EngineRef(PUBLIC_ENGINE_NAME, 'general')],
                                    ['general'], 'en-US', SAFESEARCH, PAGENO, None, None,
                                    preferences=Preferences(['oscar'], ['general'], engines, []))
         search = searx.search.Search(search_query)
@@ -50,7 +50,7 @@ class SearchTestCase(SearxTestCase):
 
     def test_timeout_query_above_default_nomax(self):
         searx.search.max_request_timeout = None
-        search_query = SearchQuery('test', [{'category': 'general', 'name': PUBLIC_ENGINE_NAME}],
+        search_query = SearchQuery('test', [EngineRef(PUBLIC_ENGINE_NAME, 'general')],
                                    ['general'], 'en-US', SAFESEARCH, PAGENO, None, 5.0,
                                    preferences=Preferences(['oscar'], ['general'], engines, []))
         search = searx.search.Search(search_query)
@@ -59,7 +59,7 @@ class SearchTestCase(SearxTestCase):
 
     def test_timeout_query_below_default_nomax(self):
         searx.search.max_request_timeout = None
-        search_query = SearchQuery('test', [{'category': 'general', 'name': PUBLIC_ENGINE_NAME}],
+        search_query = SearchQuery('test', [EngineRef(PUBLIC_ENGINE_NAME, 'general')],
                                    ['general'], 'en-US', SAFESEARCH, PAGENO, None, 1.0,
                                    preferences=Preferences(['oscar'], ['general'], engines, []))
         search = searx.search.Search(search_query)
@@ -68,7 +68,7 @@ class SearchTestCase(SearxTestCase):
 
     def test_timeout_query_below_max(self):
         searx.search.max_request_timeout = 10.0
-        search_query = SearchQuery('test', [{'category': 'general', 'name': PUBLIC_ENGINE_NAME}],
+        search_query = SearchQuery('test', [EngineRef(PUBLIC_ENGINE_NAME, 'general')],
                                    ['general'], 'en-US', SAFESEARCH, PAGENO, None, 5.0,
                                    preferences=Preferences(['oscar'], ['general'], engines, []))
         search = searx.search.Search(search_query)
@@ -77,7 +77,7 @@ class SearchTestCase(SearxTestCase):
 
     def test_timeout_query_above_max(self):
         searx.search.max_request_timeout = 10.0
-        search_query = SearchQuery('test', [{'category': 'general', 'name': PUBLIC_ENGINE_NAME}],
+        search_query = SearchQuery('test', [EngineRef(PUBLIC_ENGINE_NAME, 'general')],
                                    ['general'], 'en-US', SAFESEARCH, PAGENO, None, 15.0,
                                    preferences=Preferences(['oscar'], ['general'], engines, []))
         search = searx.search.Search(search_query)
@@ -85,7 +85,7 @@ class SearchTestCase(SearxTestCase):
         self.assertEqual(search.actual_timeout, 10.0)
 
     def test_query_private_engine_without_token(self):
-        search_query = SearchQuery('test', [{'category': 'general', 'name': PRIVATE_ENGINE_NAME}],
+        search_query = SearchQuery('test', [EngineRef(PRIVATE_ENGINE_NAME, 'general')],
                                    ['general'], 'en-US', SAFESEARCH, PAGENO, None, 2.0,
                                    preferences=Preferences(['oscar'], ['general'], engines, []))
         search = searx.search.Search(search_query)
@@ -95,7 +95,7 @@ class SearchTestCase(SearxTestCase):
     def test_query_private_engine_with_incorrect_token(self):
         preferences_with_tokens = Preferences(['oscar'], ['general'], engines, [])
         preferences_with_tokens.parse_dict({'tokens': 'bad-token'})
-        search_query = SearchQuery('test', [{'category': 'general', 'name': PRIVATE_ENGINE_NAME}],
+        search_query = SearchQuery('test', [EngineRef(PRIVATE_ENGINE_NAME, 'general')],
                                    ['general'], 'en-US', SAFESEARCH, PAGENO, None, 2.0,
                                    preferences=preferences_with_tokens)
         search = searx.search.Search(search_query)
@@ -105,7 +105,7 @@ class SearchTestCase(SearxTestCase):
     def test_query_private_engine_with_correct_token(self):
         preferences_with_tokens = Preferences(['oscar'], ['general'], engines, [])
         preferences_with_tokens.parse_dict({'tokens': 'my-token'})
-        search_query = SearchQuery('test', [{'category': 'general', 'name': PRIVATE_ENGINE_NAME}],
+        search_query = SearchQuery('test', [EngineRef(PRIVATE_ENGINE_NAME, 'general')],
                                    ['general'], 'en-US', SAFESEARCH, PAGENO, None, 2.0,
                                    preferences=preferences_with_tokens)
         search = searx.search.Search(search_query)
@@ -114,7 +114,7 @@ class SearchTestCase(SearxTestCase):
 
     def test_external_bang(self):
         search_query = SearchQuery('yes yes',
-                                   [{'category': 'general', 'name': PUBLIC_ENGINE_NAME}],
+                                   [EngineRef(PUBLIC_ENGINE_NAME, 'general')],
                                    ['general'], 'en-US', SAFESEARCH, PAGENO, None, None,
                                    preferences=Preferences(['oscar'], ['general'], engines, [],),
                                    external_bang="yt")
@@ -124,7 +124,7 @@ class SearchTestCase(SearxTestCase):
         self.assertTrue(results.redirect_url is not None)
 
         search_query = SearchQuery('youtube never gonna give you up',
-                                   [{'category': 'general', 'name': PUBLIC_ENGINE_NAME}],
+                                   [EngineRef(PUBLIC_ENGINE_NAME, 'general')],
                                    ['general'], 'en-US', SAFESEARCH, PAGENO, None, None,
                                    preferences=Preferences(['oscar'], ['general'], engines, []),)
 

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -1,17 +1,13 @@
 # -*- coding: utf-8 -*-
 
 from searx.testing import SearxTestCase
-from searx.preferences import Preferences
-from searx.engines import engines
-
-import searx.search
 from searx.search import SearchQuery, EngineRef
+import searx.search
 
 
 SAFESEARCH = 0
 PAGENO = 1
 PUBLIC_ENGINE_NAME = 'general dummy'
-PRIVATE_ENGINE_NAME = 'general private offline'
 TEST_ENGINES = [
     {
         'name': PUBLIC_ENGINE_NAME,
@@ -20,15 +16,6 @@ TEST_ENGINES = [
         'shortcut': 'gd',
         'timeout': 3.0,
         'tokens': [],
-    },
-    {
-        'name': PRIVATE_ENGINE_NAME,
-        'engine': 'dummy-offline',
-        'categories': 'general',
-        'shortcut': 'do',
-        'timeout': 3.0,
-        'offline': True,
-        'tokens': ['my-token'],
     },
 ]
 
@@ -42,8 +29,7 @@ class SearchTestCase(SearxTestCase):
     def test_timeout_simple(self):
         searx.search.max_request_timeout = None
         search_query = SearchQuery('test', [EngineRef(PUBLIC_ENGINE_NAME, 'general')],
-                                   ['general'], 'en-US', SAFESEARCH, PAGENO, None, None,
-                                   preferences=Preferences(['oscar'], ['general'], engines, []))
+                                   ['general'], 'en-US', SAFESEARCH, PAGENO, None, None)
         search = searx.search.Search(search_query)
         search.search()
         self.assertEqual(search.actual_timeout, 3.0)
@@ -51,8 +37,7 @@ class SearchTestCase(SearxTestCase):
     def test_timeout_query_above_default_nomax(self):
         searx.search.max_request_timeout = None
         search_query = SearchQuery('test', [EngineRef(PUBLIC_ENGINE_NAME, 'general')],
-                                   ['general'], 'en-US', SAFESEARCH, PAGENO, None, 5.0,
-                                   preferences=Preferences(['oscar'], ['general'], engines, []))
+                                   ['general'], 'en-US', SAFESEARCH, PAGENO, None, 5.0)
         search = searx.search.Search(search_query)
         search.search()
         self.assertEqual(search.actual_timeout, 3.0)
@@ -60,8 +45,7 @@ class SearchTestCase(SearxTestCase):
     def test_timeout_query_below_default_nomax(self):
         searx.search.max_request_timeout = None
         search_query = SearchQuery('test', [EngineRef(PUBLIC_ENGINE_NAME, 'general')],
-                                   ['general'], 'en-US', SAFESEARCH, PAGENO, None, 1.0,
-                                   preferences=Preferences(['oscar'], ['general'], engines, []))
+                                   ['general'], 'en-US', SAFESEARCH, PAGENO, None, 1.0)
         search = searx.search.Search(search_query)
         search.search()
         self.assertEqual(search.actual_timeout, 1.0)
@@ -69,8 +53,7 @@ class SearchTestCase(SearxTestCase):
     def test_timeout_query_below_max(self):
         searx.search.max_request_timeout = 10.0
         search_query = SearchQuery('test', [EngineRef(PUBLIC_ENGINE_NAME, 'general')],
-                                   ['general'], 'en-US', SAFESEARCH, PAGENO, None, 5.0,
-                                   preferences=Preferences(['oscar'], ['general'], engines, []))
+                                   ['general'], 'en-US', SAFESEARCH, PAGENO, None, 5.0)
         search = searx.search.Search(search_query)
         search.search()
         self.assertEqual(search.actual_timeout, 5.0)
@@ -78,45 +61,15 @@ class SearchTestCase(SearxTestCase):
     def test_timeout_query_above_max(self):
         searx.search.max_request_timeout = 10.0
         search_query = SearchQuery('test', [EngineRef(PUBLIC_ENGINE_NAME, 'general')],
-                                   ['general'], 'en-US', SAFESEARCH, PAGENO, None, 15.0,
-                                   preferences=Preferences(['oscar'], ['general'], engines, []))
+                                   ['general'], 'en-US', SAFESEARCH, PAGENO, None, 15.0)
         search = searx.search.Search(search_query)
         search.search()
         self.assertEqual(search.actual_timeout, 10.0)
-
-    def test_query_private_engine_without_token(self):
-        search_query = SearchQuery('test', [EngineRef(PRIVATE_ENGINE_NAME, 'general')],
-                                   ['general'], 'en-US', SAFESEARCH, PAGENO, None, 2.0,
-                                   preferences=Preferences(['oscar'], ['general'], engines, []))
-        search = searx.search.Search(search_query)
-        results = search.search()
-        self.assertEqual(results.results_length(), 0)
-
-    def test_query_private_engine_with_incorrect_token(self):
-        preferences_with_tokens = Preferences(['oscar'], ['general'], engines, [])
-        preferences_with_tokens.parse_dict({'tokens': 'bad-token'})
-        search_query = SearchQuery('test', [EngineRef(PRIVATE_ENGINE_NAME, 'general')],
-                                   ['general'], 'en-US', SAFESEARCH, PAGENO, None, 2.0,
-                                   preferences=preferences_with_tokens)
-        search = searx.search.Search(search_query)
-        results = search.search()
-        self.assertEqual(results.results_length(), 0)
-
-    def test_query_private_engine_with_correct_token(self):
-        preferences_with_tokens = Preferences(['oscar'], ['general'], engines, [])
-        preferences_with_tokens.parse_dict({'tokens': 'my-token'})
-        search_query = SearchQuery('test', [EngineRef(PRIVATE_ENGINE_NAME, 'general')],
-                                   ['general'], 'en-US', SAFESEARCH, PAGENO, None, 2.0,
-                                   preferences=preferences_with_tokens)
-        search = searx.search.Search(search_query)
-        results = search.search()
-        self.assertEqual(results.results_length(), 1)
 
     def test_external_bang(self):
         search_query = SearchQuery('yes yes',
                                    [EngineRef(PUBLIC_ENGINE_NAME, 'general')],
                                    ['general'], 'en-US', SAFESEARCH, PAGENO, None, None,
-                                   preferences=Preferences(['oscar'], ['general'], engines, [],),
                                    external_bang="yt")
         search = searx.search.Search(search_query)
         results = search.search()
@@ -125,8 +78,7 @@ class SearchTestCase(SearxTestCase):
 
         search_query = SearchQuery('youtube never gonna give you up',
                                    [EngineRef(PUBLIC_ENGINE_NAME, 'general')],
-                                   ['general'], 'en-US', SAFESEARCH, PAGENO, None, None,
-                                   preferences=Preferences(['oscar'], ['general'], engines, []),)
+                                   ['general'], 'en-US', SAFESEARCH, PAGENO, None, None)
 
         search = searx.search.Search(search_query)
         results = search.search()

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -5,6 +5,7 @@ from searx.preferences import Preferences
 from searx.engines import engines
 
 import searx.search
+from searx.search import SearchQuery
 
 
 SAFESEARCH = 0
@@ -40,53 +41,53 @@ class SearchTestCase(SearxTestCase):
 
     def test_timeout_simple(self):
         searx.search.max_request_timeout = None
-        search_query = searx.query.SearchQuery('test', [{'category': 'general', 'name': PUBLIC_ENGINE_NAME}],
-                                               ['general'], 'en-US', SAFESEARCH, PAGENO, None, None,
-                                               preferences=Preferences(['oscar'], ['general'], engines, []))
+        search_query = SearchQuery('test', [{'category': 'general', 'name': PUBLIC_ENGINE_NAME}],
+                                   ['general'], 'en-US', SAFESEARCH, PAGENO, None, None,
+                                   preferences=Preferences(['oscar'], ['general'], engines, []))
         search = searx.search.Search(search_query)
         search.search()
         self.assertEqual(search.actual_timeout, 3.0)
 
     def test_timeout_query_above_default_nomax(self):
         searx.search.max_request_timeout = None
-        search_query = searx.query.SearchQuery('test', [{'category': 'general', 'name': PUBLIC_ENGINE_NAME}],
-                                               ['general'], 'en-US', SAFESEARCH, PAGENO, None, 5.0,
-                                               preferences=Preferences(['oscar'], ['general'], engines, []))
+        search_query = SearchQuery('test', [{'category': 'general', 'name': PUBLIC_ENGINE_NAME}],
+                                   ['general'], 'en-US', SAFESEARCH, PAGENO, None, 5.0,
+                                   preferences=Preferences(['oscar'], ['general'], engines, []))
         search = searx.search.Search(search_query)
         search.search()
         self.assertEqual(search.actual_timeout, 3.0)
 
     def test_timeout_query_below_default_nomax(self):
         searx.search.max_request_timeout = None
-        search_query = searx.query.SearchQuery('test', [{'category': 'general', 'name': PUBLIC_ENGINE_NAME}],
-                                               ['general'], 'en-US', SAFESEARCH, PAGENO, None, 1.0,
-                                               preferences=Preferences(['oscar'], ['general'], engines, []))
+        search_query = SearchQuery('test', [{'category': 'general', 'name': PUBLIC_ENGINE_NAME}],
+                                   ['general'], 'en-US', SAFESEARCH, PAGENO, None, 1.0,
+                                   preferences=Preferences(['oscar'], ['general'], engines, []))
         search = searx.search.Search(search_query)
         search.search()
         self.assertEqual(search.actual_timeout, 1.0)
 
     def test_timeout_query_below_max(self):
         searx.search.max_request_timeout = 10.0
-        search_query = searx.query.SearchQuery('test', [{'category': 'general', 'name': PUBLIC_ENGINE_NAME}],
-                                               ['general'], 'en-US', SAFESEARCH, PAGENO, None, 5.0,
-                                               preferences=Preferences(['oscar'], ['general'], engines, []))
+        search_query = SearchQuery('test', [{'category': 'general', 'name': PUBLIC_ENGINE_NAME}],
+                                   ['general'], 'en-US', SAFESEARCH, PAGENO, None, 5.0,
+                                   preferences=Preferences(['oscar'], ['general'], engines, []))
         search = searx.search.Search(search_query)
         search.search()
         self.assertEqual(search.actual_timeout, 5.0)
 
     def test_timeout_query_above_max(self):
         searx.search.max_request_timeout = 10.0
-        search_query = searx.query.SearchQuery('test', [{'category': 'general', 'name': PUBLIC_ENGINE_NAME}],
-                                               ['general'], 'en-US', SAFESEARCH, PAGENO, None, 15.0,
-                                               preferences=Preferences(['oscar'], ['general'], engines, []))
+        search_query = SearchQuery('test', [{'category': 'general', 'name': PUBLIC_ENGINE_NAME}],
+                                   ['general'], 'en-US', SAFESEARCH, PAGENO, None, 15.0,
+                                   preferences=Preferences(['oscar'], ['general'], engines, []))
         search = searx.search.Search(search_query)
         search.search()
         self.assertEqual(search.actual_timeout, 10.0)
 
     def test_query_private_engine_without_token(self):
-        search_query = searx.query.SearchQuery('test', [{'category': 'general', 'name': PRIVATE_ENGINE_NAME}],
-                                               ['general'], 'en-US', SAFESEARCH, PAGENO, None, 2.0,
-                                               preferences=Preferences(['oscar'], ['general'], engines, []))
+        search_query = SearchQuery('test', [{'category': 'general', 'name': PRIVATE_ENGINE_NAME}],
+                                   ['general'], 'en-US', SAFESEARCH, PAGENO, None, 2.0,
+                                   preferences=Preferences(['oscar'], ['general'], engines, []))
         search = searx.search.Search(search_query)
         results = search.search()
         self.assertEqual(results.results_length(), 0)
@@ -94,9 +95,9 @@ class SearchTestCase(SearxTestCase):
     def test_query_private_engine_with_incorrect_token(self):
         preferences_with_tokens = Preferences(['oscar'], ['general'], engines, [])
         preferences_with_tokens.parse_dict({'tokens': 'bad-token'})
-        search_query = searx.query.SearchQuery('test', [{'category': 'general', 'name': PRIVATE_ENGINE_NAME}],
-                                               ['general'], 'en-US', SAFESEARCH, PAGENO, None, 2.0,
-                                               preferences=preferences_with_tokens)
+        search_query = SearchQuery('test', [{'category': 'general', 'name': PRIVATE_ENGINE_NAME}],
+                                   ['general'], 'en-US', SAFESEARCH, PAGENO, None, 2.0,
+                                   preferences=preferences_with_tokens)
         search = searx.search.Search(search_query)
         results = search.search()
         self.assertEqual(results.results_length(), 0)
@@ -104,28 +105,28 @@ class SearchTestCase(SearxTestCase):
     def test_query_private_engine_with_correct_token(self):
         preferences_with_tokens = Preferences(['oscar'], ['general'], engines, [])
         preferences_with_tokens.parse_dict({'tokens': 'my-token'})
-        search_query = searx.query.SearchQuery('test', [{'category': 'general', 'name': PRIVATE_ENGINE_NAME}],
-                                               ['general'], 'en-US', SAFESEARCH, PAGENO, None, 2.0,
-                                               preferences=preferences_with_tokens)
+        search_query = SearchQuery('test', [{'category': 'general', 'name': PRIVATE_ENGINE_NAME}],
+                                   ['general'], 'en-US', SAFESEARCH, PAGENO, None, 2.0,
+                                   preferences=preferences_with_tokens)
         search = searx.search.Search(search_query)
         results = search.search()
         self.assertEqual(results.results_length(), 1)
 
     def test_external_bang(self):
-        search_query = searx.query.SearchQuery('yes yes',
-                                               [{'category': 'general', 'name': PUBLIC_ENGINE_NAME}],
-                                               ['general'], 'en-US', SAFESEARCH, PAGENO, None, None,
-                                               preferences=Preferences(['oscar'], ['general'], engines, [],),
-                                               external_bang="yt")
+        search_query = SearchQuery('yes yes',
+                                   [{'category': 'general', 'name': PUBLIC_ENGINE_NAME}],
+                                   ['general'], 'en-US', SAFESEARCH, PAGENO, None, None,
+                                   preferences=Preferences(['oscar'], ['general'], engines, [],),
+                                   external_bang="yt")
         search = searx.search.Search(search_query)
         results = search.search()
         # For checking if the user redirected with the youtube external bang
         self.assertTrue(results.redirect_url is not None)
 
-        search_query = searx.query.SearchQuery('youtube never gonna give you up',
-                                               [{'category': 'general', 'name': PUBLIC_ENGINE_NAME}],
-                                               ['general'], 'en-US', SAFESEARCH, PAGENO, None, None,
-                                               preferences=Preferences(['oscar'], ['general'], engines, []),)
+        search_query = SearchQuery('youtube never gonna give you up',
+                                   [{'category': 'general', 'name': PUBLIC_ENGINE_NAME}],
+                                   ['general'], 'en-US', SAFESEARCH, PAGENO, None, None,
+                                   preferences=Preferences(['oscar'], ['general'], engines, []),)
 
         search = searx.search.Search(search_query)
         results = search.search()

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -3,6 +3,7 @@
 from searx.testing import SearxTestCase
 from searx.search import SearchQuery, EngineRef
 import searx.search
+import searx.engines
 
 
 SAFESEARCH = 0

--- a/tests/unit/test_webadapter.py
+++ b/tests/unit/test_webadapter.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+from searx.testing import SearxTestCase
+from searx.preferences import Preferences
+from searx.engines import engines
+
+import searx.search
+from searx.search import EngineRef, SearchQuery
+from searx.webadapter import validate_engineref_list
+
+
+PRIVATE_ENGINE_NAME = 'general private offline'
+TEST_ENGINES = [
+    {
+        'name': PRIVATE_ENGINE_NAME,
+        'engine': 'dummy-offline',
+        'categories': 'general',
+        'shortcut': 'do',
+        'timeout': 3.0,
+        'offline': True,
+        'tokens': ['my-token'],
+    },
+]
+SEARCHQUERY = [EngineRef(PRIVATE_ENGINE_NAME, 'general')]
+
+
+class ValidateQueryCase(SearxTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        searx.engines.initialize_engines(TEST_ENGINES)
+
+    def test_query_private_engine_without_token(self):
+        preferences = Preferences(['oscar'], ['general'], engines, [])
+        valid, unknown, invalid_token = validate_engineref_list(SEARCHQUERY, preferences)
+        self.assertEqual(len(valid), 0)
+        self.assertEqual(len(unknown), 0)
+        self.assertEqual(len(invalid_token), 1)
+
+    def test_query_private_engine_with_incorrect_token(self):
+        preferences_with_tokens = Preferences(['oscar'], ['general'], engines, [])
+        preferences_with_tokens.parse_dict({'tokens': 'bad-token'})
+        valid, unknown, invalid_token = validate_engineref_list(SEARCHQUERY, preferences_with_tokens)
+        self.assertEqual(len(valid), 0)
+        self.assertEqual(len(unknown), 0)
+        self.assertEqual(len(invalid_token), 1)
+
+    def test_query_private_engine_with_correct_token(self):
+        preferences_with_tokens = Preferences(['oscar'], ['general'], engines, [])
+        preferences_with_tokens.parse_dict({'tokens': 'my-token'})
+        valid, unknown, invalid_token = validate_engineref_list(SEARCHQUERY, preferences_with_tokens)
+        self.assertEqual(len(valid), 1)
+        self.assertEqual(len(unknown), 0)
+        self.assertEqual(len(invalid_token), 0)

--- a/utils/standalone_searx.py
+++ b/utils/standalone_searx.py
@@ -30,6 +30,7 @@ import codecs
 import searx.query
 import searx.search
 import searx.engines
+import searx.webapdater
 import searx.preferences
 import searx.webadapter
 import argparse

--- a/utils/standalone_searx.py
+++ b/utils/standalone_searx.py
@@ -31,6 +31,7 @@ import searx.query
 import searx.search
 import searx.engines
 import searx.preferences
+import searx.webadapter
 import argparse
 
 searx.engines.initialize_engines(settings['engines'])
@@ -64,7 +65,7 @@ form = {
 preferences = searx.preferences.Preferences(['oscar'], searx.engines.categories.keys(), searx.engines.engines, [])
 preferences.key_value_settings['safesearch'].parse(args.safesearch)
 
-search_query, raw_text_query = searx.search.get_search_query_from_webapp(preferences, form)
+search_query, raw_text_query = searx.webadapter.get_search_query_from_webapp(preferences, form)
 search = searx.search.Search(search_query)
 result_container = search.search()
 

--- a/utils/standalone_searx.py
+++ b/utils/standalone_searx.py
@@ -65,7 +65,7 @@ form = {
 preferences = searx.preferences.Preferences(['oscar'], searx.engines.categories.keys(), searx.engines.engines, [])
 preferences.key_value_settings['safesearch'].parse(args.safesearch)
 
-search_query, raw_text_query = searx.webadapter.get_search_query_from_webapp(preferences, form)
+search_query, raw_text_query, _, _ = searx.webadapter.get_search_query_from_webapp(preferences, form)
 search = searx.search.Search(search_query)
 result_container = search.search()
 


### PR DESCRIPTION
## What does this PR do?

Architecture clean up.

### Overview

Some notes:
* There is no functional changes.
* Add ```__slots__``` to some classes to make clear the list of the attributes.

#### web
* searx.query
* searx.webadapter
* searx.webapp
* searx.autocomplete
* searx.preferences

#### core
* searx.search
* searx.external_bang
* searx.poolrequests
* searx.languages (engines call searx.utils.is_valid_lang)
* searx.results
	
The entry point of the core is searx.search.Search
* input: searx.search.SearchQuery
* output: searx.results.ResultContainer

#### both:
* searx.utils
* searx.brand
* searx.exceptions
	
#### other:
* searx.testing

### searx/search.py

* [SearchQuery](https://github.com/searx/searx/blob/fd8a63bd26e5890e2a125b9db69e5720cdec61d7/searx/search.py#L65-L92)
	* was previously in query.py
	* this object is the entry point to the Search class, it doesn't contain any reference to RawTextQuery
	* time_range parameter: 'None' or '' are not accepted anymore (see [searx.webadapter.parse_time_range](https://github.com/searx/searx/blob/fd8a63bd26e5890e2a125b9db69e5720cdec61d7/searx/webadapter.py#L87)). Previously: https://github.com/searx/searx/blob/ae07f4a211ecba0331bcab5903e3263c646f8bdb/searx/query.py#L194
	* remove reference to the [preferences parameters](https://github.com/searx/searx/blob/ae07f4a211ecba0331bcab5903e3263c646f8bdb/searx/query.py#L196) (see below searx.search.Search)

* [EngineRef](https://github.com/searx/searx/blob/fd8a63bd26e5890e2a125b9db69e5720cdec61d7/searx/search.py#L52-L62)
	* was previously a [Dict](https://github.com/searx/searx/blob/ae07f4a211ecba0331bcab5903e3263c646f8bdb/searx/query.py#L138-L140) with two or three keys: name, category, from_bang
	* make clear that this is a engine reference (see tests/unit/test_search.py for example)
	* all variables using this class are renamed accordingly.

* Search class:
	* important change in the search method: the token is not more checked in this method. The check is done before (see [searx.webadapter](https://github.com/searx/searx/blob/fd8a63bd26e5890e2a125b9db69e5720cdec61d7/searx/webadapter.py#L34-L36))

### searx/query.py

* RawTextQuery
	* engines attribute is replace by enginerefs

### searx/webadapter.py

* get_search_query_from_webapp
	* previously in webapp.py
	* in charge of checking the engine tokens (actually done by the validate_engineref_list function)
	* returns a SearchQuery, RawTextQuery, the list of unknown engine, the list of engine without token (might be useful to display them in result page)
* each parameter has a dedicated function (parse_pageno, page_lang,....).
	* for example, it makes clear that query_pageno depend only of the form, not from the preferences, not from the cookies.
	* easier to add test about each of them.
* parse_category_form
	* parse the ```category=general,music``` and ```category_music=on```
	* get_search_query_from_webapp and get_selected_categories functions call this function
* get_selected_categories
	* from a form (optional) and preferences, return the selected categories
	* was https://github.com/searx/searx/blob/272158944bf13503e2597018fc60a00baddec660/searx/webapp.py#L371-L385
	* note: searx.webapp.render iterates over request.args and searx.webapdater.get_selected_categories iterates over request.form (related to https://gitlab.e.foundation/e/cloud/my-spot/commit/812bac9d9649b5ba53a97a43c15b739692706afa )

### searx/webapp.py

* render function:
	* remove selected_categories, set in preferences() and index() using the new searx.webadapter.get_selected_categories function.
	* remove all_categories: set in the preferences() function.


## Why is this change important?

* It makes the code more readable (at least I hope it is the case)
* without huge changes, it makes https://github.com/searx/searx/issues/2067 easier to implement.

## How to test this PR locally?

N/A. This section has to be written.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

* https://github.com/searx/searx/issues/2067