### PR TITLE
Small changes

### DIFF
--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -38,22 +38,22 @@ def get(*args, **kwargs):
 def searx_bang(full_query):
     '''check if the searchQuery contain a bang, and create fitting autocompleter results'''
     # check if there is a query which can be parsed
-    if len(full_query.getSearchQuery()) == 0:
+    if len(full_query.getQuery()) == 0:
         return []
 
     results = []
 
     # check if current query stats with !bang
-    first_char = full_query.getSearchQuery()[0]
+    first_char = full_query.getQuery()[0]
     if first_char == '!' or first_char == '?':
-        if len(full_query.getSearchQuery()) == 1:
+        if len(full_query.getQuery()) == 1:
             # show some example queries
             # TODO, check if engine is not avaliable
             results.append(first_char + "images")
             results.append(first_char + "wikipedia")
             results.append(first_char + "osm")
         else:
-            engine_query = full_query.getSearchQuery()[1:]
+            engine_query = full_query.getQuery()[1:]
 
             # check if query starts with categorie name
             for categorie in categories:
@@ -72,14 +72,14 @@ def searx_bang(full_query):
 
     # check if current query stats with :bang
     elif first_char == ':':
-        if len(full_query.getSearchQuery()) == 1:
+        if len(full_query.getQuery()) == 1:
             # show some example queries
             results.append(":en")
             results.append(":en_us")
             results.append(":english")
             results.append(":united_kingdom")
         else:
-            engine_query = full_query.getSearchQuery()[1:]
+            engine_query = full_query.getQuery()[1:]
 
             for lc in language_codes:
                 lang_id, lang_name, country, english_name = map(str.lower, lc)

--- a/searx/query.py
+++ b/searx/query.py
@@ -162,14 +162,14 @@ class RawTextQuery:
             # append query part to query_part list
             self.query_parts.append(query_part)
 
-    def changeSearchQuery(self, search_query):
+    def changeQuery(self, query):
         if len(self.query_parts):
-            self.query_parts[-1] = search_query
+            self.query_parts[-1] = query
         else:
-            self.query_parts.append(search_query)
+            self.query_parts.append(query)
         return self
 
-    def getSearchQuery(self):
+    def getQuery(self):
         if len(self.query_parts):
             return self.query_parts[-1]
         else:

--- a/searx/search.py
+++ b/searx/search.py
@@ -268,7 +268,7 @@ def get_search_query_from_webapp(preferences, form):
     raw_text_query = RawTextQuery(form['q'], disabled_engines)
 
     # set query
-    query = raw_text_query.getSearchQuery()
+    query = raw_text_query.getQuery()
 
     # get and check page number
     pageno_param = form.get('pageno', '1')

--- a/searx/search.py
+++ b/searx/search.py
@@ -40,7 +40,6 @@ from searx.exceptions import SearxParameterException
 
 logger = logger.getChild('search')
 
-number_of_searches = 0
 max_request_timeout = settings.get('outgoing', {}).get('max_request_timeout' or None)
 if max_request_timeout is None:
     logger.info('max_request_timeout={0}'.format(max_request_timeout))
@@ -497,9 +496,6 @@ class Search:
 
         # init vars
         requests = []
-
-        # increase number of searches
-        number_of_searches += 1
 
         # set default useragent
         # user_agent = request.headers.get('User-Agent', '')

--- a/searx/search.py
+++ b/searx/search.py
@@ -97,48 +97,6 @@ def search_one_http_request(engine, query, request_params):
     return engine.response(response)
 
 
-def search_one_offline_request(engine, query, request_params):
-    return engine.search(query, request_params)
-
-
-def search_one_request_safe(engine_name, query, request_params, result_container, start_time, timeout_limit):
-    if engines[engine_name].offline:
-        return search_one_offline_request_safe(engine_name, query, request_params, result_container, start_time, timeout_limit)  # noqa
-    return search_one_http_request_safe(engine_name, query, request_params, result_container, start_time, timeout_limit)
-
-
-def search_one_offline_request_safe(engine_name, query, request_params, result_container, start_time, timeout_limit):
-    engine = engines[engine_name]
-
-    try:
-        search_results = search_one_offline_request(engine, query, request_params)
-
-        if search_results:
-            result_container.extend(engine_name, search_results)
-
-            engine_time = time() - start_time
-            result_container.add_timing(engine_name, engine_time, engine_time)
-            with threading.RLock():
-                engine.stats['engine_time'] += engine_time
-                engine.stats['engine_time_count'] += 1
-
-    except ValueError as e:
-        record_offline_engine_stats_on_error(engine, result_container, start_time)
-        logger.exception('engine {0} : invalid input : {1}'.format(engine_name, e))
-    except Exception as e:
-        record_offline_engine_stats_on_error(engine, result_container, start_time)
-        result_container.add_unresponsive_engine(engine_name, 'unexpected crash', str(e))
-        logger.exception('engine {0} : exception : {1}'.format(engine_name, e))
-
-
-def record_offline_engine_stats_on_error(engine, result_container, start_time):
-    engine_time = time() - start_time
-    result_container.add_timing(engine.name, engine_time, engine_time)
-
-    with threading.RLock():
-        engine.stats['errors'] += 1
-
-
 def search_one_http_request_safe(engine_name, query, request_params, result_container, start_time, timeout_limit):
     # set timeout for all HTTP requests
     requests_lib.set_timeout_for_thread(timeout_limit, start_time=start_time)
@@ -212,6 +170,48 @@ def search_one_http_request_safe(engine_name, query, request_params, result_cont
             # anyway, reset the suspend variables
             engine.continuous_errors = 0
             engine.suspend_end_time = 0
+
+
+def record_offline_engine_stats_on_error(engine, result_container, start_time):
+    engine_time = time() - start_time
+    result_container.add_timing(engine.name, engine_time, engine_time)
+
+    with threading.RLock():
+        engine.stats['errors'] += 1
+
+
+def search_one_offline_request(engine, query, request_params):
+    return engine.search(query, request_params)
+
+
+def search_one_offline_request_safe(engine_name, query, request_params, result_container, start_time, timeout_limit):
+    engine = engines[engine_name]
+
+    try:
+        search_results = search_one_offline_request(engine, query, request_params)
+
+        if search_results:
+            result_container.extend(engine_name, search_results)
+
+            engine_time = time() - start_time
+            result_container.add_timing(engine_name, engine_time, engine_time)
+            with threading.RLock():
+                engine.stats['engine_time'] += engine_time
+                engine.stats['engine_time_count'] += 1
+
+    except ValueError as e:
+        record_offline_engine_stats_on_error(engine, result_container, start_time)
+        logger.exception('engine {0} : invalid input : {1}'.format(engine_name, e))
+    except Exception as e:
+        record_offline_engine_stats_on_error(engine, result_container, start_time)
+        result_container.add_unresponsive_engine(engine_name, 'unexpected crash', str(e))
+        logger.exception('engine {0} : exception : {1}'.format(engine_name, e))
+
+
+def search_one_request_safe(engine_name, query, request_params, result_container, start_time, timeout_limit):
+    if engines[engine_name].offline:
+        return search_one_offline_request_safe(engine_name, query, request_params, result_container, start_time, timeout_limit)  # noqa
+    return search_one_http_request_safe(engine_name, query, request_params, result_container, start_time, timeout_limit)
 
 
 def search_multiple_requests(requests, result_container, start_time, timeout_limit):

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -679,13 +679,13 @@ def index():
 
     # suggestions: use RawTextQuery to get the suggestion URLs with the same bang
     suggestion_urls = list(map(lambda suggestion: {
-                               'url': raw_text_query.changeSearchQuery(suggestion).getFullQuery(),
+                               'url': raw_text_query.changeQuery(suggestion).getFullQuery(),
                                'title': suggestion
                                },
                                result_container.suggestions))
 
     correction_urls = list(map(lambda correction: {
-                               'url': raw_text_query.changeSearchQuery(correction).getFullQuery(),
+                               'url': raw_text_query.changeQuery(correction).getFullQuery(),
                                'title': correction
                                },
                                result_container.corrections))
@@ -744,7 +744,7 @@ def autocompleter():
     raw_text_query = RawTextQuery(request.form.get('q', ''), disabled_engines)
 
     # check if search query is set
-    if not raw_text_query.getSearchQuery():
+    if not raw_text_query.getQuery():
         return '', 400
 
     # run autocompleter
@@ -765,12 +765,12 @@ def autocompleter():
         else:
             language = language.split('-')[0]
         # run autocompletion
-        raw_results.extend(completer(raw_text_query.getSearchQuery(), language))
+        raw_results.extend(completer(raw_text_query.getQuery(), language))
 
     # parse results (write :language and !engine back to result string)
     results = []
     for result in raw_results:
-        raw_text_query.changeSearchQuery(result)
+        raw_text_query.changeQuery(result)
 
         # add parsed result
         results.append(raw_text_query.getFullQuery())


### PR DESCRIPTION
## What does this PR do?

1. searx.query.RawTextQuery: rename the methods getSearchQuery and changeSearchQuery
1. searx.search: remove the unused global variable number_of_searches
1. searx.search: change the function declaration order.

There is no functional change.

## Why is this change important?

1. searx.query.RawTextQuery: getSearchQuery is confusing, the method returns a ```str``` not a [SearchQuery](https://github.com/searx/searx/blob/ae07f4a211ecba0331bcab5903e3263c646f8bdb/searx/query.py#L183) object
1. number_of_searches : if there is some statistics, it should go into the ```searx/engines/__init__.py```
1. searx.search: function declaration order: it make the code more readable (perhaps not a shared opinion).

## How to test this PR locally?

* Make sure there is no usage of getSearchQuery, changeSearchQuery, number_of_searches

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Partial implementation of #2189
