### PR TITLE
[mod] upgrade requests to version 2.24.0. pyopenssl becomes optional.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
-certifi==2020.4.5.1
+certifi==2020.6.20
 babel==2.7.0
 flask-babel==1.0.0
 flask==1.1.2
-idna==2.9
+idna==2.10
 jinja2==2.11.1
 lxml==4.5.0
 pygments==2.1.3
 pyopenssl==19.1.0
 python-dateutil==2.8.0
 pyyaml==5.3.1
-requests[socks]==2.23.0
+requests[socks]==2.24.0

--- a/searx/__init__.py
+++ b/searx/__init__.py
@@ -15,12 +15,10 @@ along with searx. If not, see < http://www.gnu.org/licenses/ >.
 (C) 2013- by Adam Tauber, <asciimoo@gmail.com>
 '''
 
-import certifi
 import logging
 from os import environ
 from os.path import realpath, dirname, join, abspath, isfile
 from io import open
-from ssl import OPENSSL_VERSION_INFO, OPENSSL_VERSION
 from yaml import safe_load
 
 
@@ -81,13 +79,6 @@ else:
 
 logger = logging.getLogger('searx')
 logger.debug('read configuration from %s', settings_path)
-# Workaround for openssl versions <1.0.2
-# https://github.com/certifi/python-certifi/issues/26
-if OPENSSL_VERSION_INFO[0:3] < (1, 0, 2):
-    if hasattr(certifi, 'old_where'):
-        environ['REQUESTS_CA_BUNDLE'] = certifi.old_where()
-    logger.warning('You are using an old openssl version({0}), please upgrade above 1.0.2!'.format(OPENSSL_VERSION))
-
 logger.info('Initialisation done')
 
 if 'SEARX_SECRET' in environ:

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -78,13 +78,6 @@ from searx.plugins.oa_doi_rewrite import get_doi_resolver
 from searx.preferences import Preferences, ValidationException, LANGUAGE_CODES
 from searx.answerers import answerers
 
-# check if the pyopenssl package is installed.
-# It is needed for SSL connection without trouble, see #298
-try:
-    import OpenSSL.SSL  # NOQA
-except ImportError:
-    logger.critical("The pyopenssl package has to be installed.\n"
-                    "Some HTTPS connections will fail")
 
 # serve pages with HTTP/1.1
 from werkzeug.serving import WSGIRequestHandler


### PR DESCRIPTION
from [requests 2.24.0 changelog](https://github.com/psf/requests/blob/master/HISTORY.md#2240-2020-06-17): 
> pyOpenSSL TLS implementation is now only used if Python either doesn’t have an ssl module or doesn’t support SNI.


## What does this PR do?

* upgrade requests to version 2.24.0
* requirements.txt: pyopenssl is still required to install searx as a fallback.
* searx log a critical message if ssl modules doesn't support SNI, and pyOpenSSL is not installed.
* The message is logged from searx.poolrequests instead of searx.webapp.

## Why is this change important?

See 
* https://docs.python.org/3/library/ssl.html#ssl.HAS_SNI
* https://github.com/psf/requests/pull/5443

SNI is supported by Python version 3.2.

## How to test this PR locally?

check HTTPS connection are working in the following scenarios:
* upgrade with requests and pyopenssl
* requests 2.24.0, and without pyopenssl

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
