### PR TITLE
[fix] requirements-dev.txt: set versions for all sphinx* packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,11 +80,11 @@ run:  buildenv pyenvinstall
 sphinx-doc-prebuilds:: buildenv pyenvinstall prebuild-includes
 
 PHONY += docs
-docs:  sphinx-doc-prebuilds sphinx-doc
+docs:  sphinx-doc-prebuilds
 	$(call cmd,sphinx,html,docs,docs)
 
 PHONY += docs-live
-docs-live:  sphinx-doc-prebuilds sphinx-live
+docs-live:  sphinx-doc-prebuilds
 	$(call cmd,sphinx_autobuild,html,docs,docs)
 
 PHONY += prebuild-includes

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,9 +12,13 @@ selenium==3.141.0
 twine==3.2.0; python_version >= "3.6"
 twine==1.15.0; python_version < "3.6"
 Pallets-Sphinx-Themes==1.2.3
-Sphinx==3.0.1
+Sphinx==3.2.1; python_version >= '3.6'
+Sphinx==3.0.1; python_version < '3.6'
 sphinx-issues==1.2.0
 sphinx-jinja==1.1.1
-sphinx-tabs==1.1.13
+sphinx-tabs==1.3.0; python_version >= '3.6'
+sphinx-tabs==1.1.13; python_version < '3.6'
 sphinxcontrib-programoutput==0.16
+sphinx-autobuild==2020.9.1; python_version >= '3.6'
+sphinx-autobuild==0.7.1; python_version < '3.6'
 linuxdoc @ git+http://github.com/return42/linuxdoc.git@70673dcf69e705e08d81f53794895dc15c4920b3#egg=linuxdoc

--- a/utils/makefile.sphinx
+++ b/utils/makefile.sphinx
@@ -21,23 +21,6 @@ else
   SPHINX_VERBOSE =
 endif
 
-## SPHINXVERS variable
-## ===================
-##
-## .. _requirement-specifiers: https://pip.pypa.io/en/stable/reference/pip_install/#requirement-specifiers
-##
-## Sphinx version to use, when building documentation.  Set this when calling
-## build target.  The default value is empty (install latest), to select a
-## specific version use a requirement-specifiers_.  E.g. to build your target
-## 'doc' with a select sphinx-doc_ version 1.7.9::
-##
-##     make SPHINXVERS='==1.7.9' docs
-##
-## To build with latest 1.7::
-##
-##     make SPHINXVERS='>=1.7,<1.8' docs
-##
-SPHINXVERS  ?=
 
 docs-help:
 	@echo  'makefile.sphinx:'
@@ -55,17 +38,6 @@ docs-help:
 # ------------------------------------------------------------------------------
 # requirements
 # ------------------------------------------------------------------------------
-
-sphinx-doc-prebuilds:: $(PY_ENV)
-
-sphinx-doc: sphinx-doc-prebuilds
-	@echo "PYENV     installing Sphinx$(SPHINXVERS)"
-	$(Q)$(PY_ENV_BIN)/pip install $(PIP_VERBOSE) 'Sphinx$(SPHINXVERS)'
-
-sphinx-live: sphinx-doc-prebuilds
-	@echo "PYENV     installing Sphinx$(SPHINXVERS)"
-	$(Q)$(PY_ENV_BIN)/pip install $(PIP_VERBOSE) 'Sphinx$(SPHINXVERS)' sphinx-autobuild
-
 
 PHONY += msg-texlive texlive
 
@@ -107,7 +79,7 @@ quiet_cmd_sphinx = SPHINX    $@ --> file://$(abspath $(DOCS_DIST)/$5)
 	-b $2 -c $3 -d $(DOCS_BUILD)/.doctrees $4 $(DOCS_DIST)/$5
 
 quiet_cmd_sphinx_autobuild = SPHINX    $@ --> file://$(abspath $(DOCS_DIST)/$5)
-      cmd_sphinx_autobuild = PATH="$(PY_ENV_BIN):$(PATH)" $(PY_ENV_BIN)/sphinx-autobuild  $(SPHINX_VERBOSE) --poll -B --host 0.0.0.0 --port 8080 $(SPHINXOPTS)\
+      cmd_sphinx_autobuild = PATH="$(PY_ENV_BIN):$(PATH)" $(PY_ENV_BIN)/sphinx-autobuild  $(SPHINX_VERBOSE) --open-browser --host 0.0.0.0 --port 8080 $(SPHINXOPTS)\
 	-b $2 -c $3 -d $(DOCS_BUILD)/.doctrees $4 $(DOCS_DIST)/$5
 
 quiet_cmd_sphinx_clean = CLEAN     $@


### PR DESCRIPTION
## What does this PR do?

Set versions for all sphinx* packages.

The last version of sphinx-autobuild is 2020.9.1, but the command line has changed, see https://github.com/searx/searx/issues/2204

This PR set the version to 0.7.1

## Why is this change important?

Without this PR ```make docs-live``` doesn't work

## How to test this PR locally?

```
make clean docs
make clean docs-live
```

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Related to #2204 (partial fix)