### PR TITLE
Bugfix of:  ERROR: centos-: uWSGI not yet implemented

### DIFF
--- a/utils/searx.sh
+++ b/utils/searx.sh
@@ -826,7 +826,7 @@ rst-doc() {
     # I use ubuntu-20.04 here to demonstrate that versions are also suported,
     # normaly debian-* and ubuntu-* are most the same.
 
-    for DIST_NAME in ubuntu-20.04 arch fedora centos; do
+    for DIST_NAME in ubuntu-20.04 arch fedora; do
         (
             DIST_ID=${DIST_NAME%-*}
             DIST_VERS=${DIST_NAME#*-}


### PR DESCRIPTION
Since there is no centos-7 documentation 'searx.sh doc' produce an error message::

    ERROR: centos-: uWSGI not yet implemented

This patch removes CentOS from  the docs build. 

OT: 

- CentOS 7 support was added by  #2176 
- CentOS 8 is the same as RHEL. 
- Adding support for CentOS 7 was only needed to distinguish between (the old) yum and dnf package managers
- The "yum vs dnf" topic is the same to Fedora & RHEL
- Adding a CentOS 8 container might be a little more up-to-date

To test run:

    make clean make docs

Partial patch of  #2204