### PR TITLE
[fix] /autocompleter: return HTTP 400 when q is empty as intent.

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -736,7 +736,7 @@ def autocompleter():
     disabled_engines = request.preferences.engines.get_disabled()
 
     # parse query
-    raw_text_query = RawTextQuery(str(request.form.get('q', b'')), disabled_engines)
+    raw_text_query = RawTextQuery(request.form.get('q', ''), disabled_engines)
 
     # check if search query is set
     if not raw_text_query.getSearchQuery():


### PR DESCRIPTION
## What does this PR do?

since commit c225db45c8a4ab466bff049216f7e0189dc1b067, ```/autocompleter``` : the ```q``` parameter is not or is empty, the code search for ```b''```.

This PR fix this: ```/autocompleter``` or ```/autocompleter?q=``` returns an HTTP error 400 as before.

## Why is this change important?

Bug fix of ```/autocompleter```

## How to test this PR locally?

1. start searx
1. check the URL ```/autocompleter```
1. check the URL ```/autocompleter?q=```
1. check the URL ```/autocompleter?q=test```

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

https://github.com/searx/searx/pull/2137
