### PR TITLE
[fix] missing 'alias' typo in docs/admin/installation-nginx.rst

### DIFF
--- a/docs/admin/installation-nginx.rst
+++ b/docs/admin/installation-nginx.rst
@@ -189,7 +189,7 @@ Started wiki`_ is always a good resource *to keep in the pocket*.
 	 }
 
 	 location /searx/static {
-	     /usr/local/searx/searx-src/searx/static;
+	     alias /usr/local/searx/searx-src/searx/static;
 	 }
 
 


### PR DESCRIPTION
Fix typo in nginx docs

## How to test this PR locally?
    make docs

Closes #2044
