### PR TITLE
[fix] Sphinx 3.2.1 build: add missing "engines" variable in the jinja context

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,6 +10,7 @@ GIT_BRANCH = os.environ.get("GIT_BRANCH", "master")
 from searx.brand import SEARX_URL
 from searx.brand import DOCS_URL
 
+
 # Project --------------------------------------------------------------
 
 project = u'searx'
@@ -27,8 +28,10 @@ numfig = True
 exclude_patterns = ['build-templates/*.rst']
 
 from searx import webapp
+from searx.engines import engines
 jinja_contexts = {
-    'webapp': dict(**webapp.__dict__)
+    'webapp': dict(**webapp.__dict__),
+    'engines': engines
 }
 
 # usage::   lorem :patch:`f373169` ipsum


### PR DESCRIPTION
## What does this PR do?

Fix PR #2210 which upgrade Sphinx version to 3.2.1.

The admin/engines.html page is empty.

## Why is this change important?

Fix the admin/engines.html page.

## How to test this PR locally?

Check the admin/engines.html page.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

#2210
