### PR TITLE
Mod engines init

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,11 +28,8 @@ numfig = True
 exclude_patterns = ['build-templates/*.rst']
 
 from searx import webapp
-import searx.engines
-searx.engines.initialize_engines(searx.settings['engines'])
 jinja_contexts = {
     'webapp': dict(**webapp.__dict__),
-    'engines': searx.engines.engines
 }
 
 # usage::   lorem :patch:`f373169` ipsum

--- a/searx/webutils.py
+++ b/searx/webutils.py
@@ -4,6 +4,7 @@ import csv
 import hashlib
 import hmac
 import re
+import inspect
 
 from io import StringIO
 from codecs import getincrementalencoder
@@ -125,3 +126,18 @@ def highlight_content(content, query):
                          content, flags=re.I | re.U)
 
     return content
+
+
+def is_flask_run_cmdline():
+    """Check if the application was started using "flask run" command line
+
+    Inspect the callstack.
+    See https://github.com/pallets/flask/blob/master/src/flask/__main__.py
+
+    Returns:
+        bool: True if the application was started using "flask run".
+    """
+    frames = inspect.stack()
+    if len(frames) < 2:
+        return False
+    return frames[-2].filename.endswith('flask/cli.py')


### PR DESCRIPTION
## What does this PR do?

Revert PR #2232 and #2230

webapp.py: Always call `initialize engines` except on the first run of werkzeug with the reload feature.
    
reload is activated when:
* searx_debug is True (SEARX_DEBUG environment variable or settings.yml)
* `FLASK_APP=searx/webapp.py FLASK_ENV=development flask run` (see https://flask.palletsprojects.com/en/1.1.x/cli/ )

Remove  `os.environ.get('UWSGI_ORIGINAL_PROC_NAME') is not None`: the code in this PR detects that ```__name__ != "__main__"``` (searx.webapp was imported).

```__name__ != "__main__"``` works for ```make test``` and ```make docs``` too.
    
## Why is this change important?

Fix `SEARX_DEBUG=0 make docs`
See https://github.com/searx/searx/issues/2204#issuecomment-701373438

## How to test this PR locally?

* `SEARX_DEBUG=0 make docs` : check docs/admin/engines.rst  (check the page contains the engine list).
* `SEARX_DEBUG=1 make docs`: check docs/admin/engines.rst
* `SEARX_DEBUG=0 python searx/webapp.py`: check engines are initialized once.
* `SEARX_DEBUG=1 python searx/webapp.py`: check engines are initialized once, check reload works as intended.
* `make docker`: check if the docker image works as expetected.
* `FLASK_APP=searx/webapp.py flask run` : check engines are initialized once.
* `FLASK_APP=searx/webapp.py FLASK_ENV=development flask run` : check engines are initialized once, check reload works as intended.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

* #2204
* #2232
* #2230

