### PR TITLE
[mod] preferences.py: check language setting with a regex instead of match_language

### DIFF
--- a/searx/preferences.py
+++ b/searx/preferences.py
@@ -10,7 +10,7 @@ from urllib.parse import parse_qs, urlencode
 
 from searx import settings, autocomplete
 from searx.languages import language_codes as languages
-from searx.utils import match_language
+from searx.webutils import VALID_LANGUAGE_CODE
 
 
 COOKIE_MAX_AGE = 60 * 60 * 24 * 365 * 5  # 5 years
@@ -162,9 +162,7 @@ class SearchLanguageSetting(EnumStringSetting):
     """Available choices may change, so user's value may not be in choices anymore"""
 
     def _validate_selection(self, selection):
-        if selection != "" and not match_language(
-                # pylint: disable=no-member
-                selection, self.choices, fallback=None):
+        if selection != '' and not VALID_LANGUAGE_CODE.match(selection):
             raise ValidationException('Invalid language code: "{0}"'.format(selection))
 
     def parse(self, data):
@@ -181,6 +179,7 @@ class SearchLanguageSetting(EnumStringSetting):
                 data = lang
             else:
                 data = self.value
+        self._validate_selection(data)
         self.value = data
 
 

--- a/searx/query.py
+++ b/searx/query.py
@@ -22,9 +22,7 @@ import re
 from searx.languages import language_codes
 from searx.engines import categories, engines, engine_shortcuts
 from searx.search import EngineRef
-
-
-VALID_LANGUAGE_CODE = re.compile(r'^[a-z]{2,3}(-[a-zA-Z]{2})?$')
+from searx.webutils import VALID_LANGUAGE_CODE
 
 
 class RawTextQuery:

--- a/searx/webadapter.py
+++ b/searx/webadapter.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Optional, Tuple
 from searx.exceptions import SearxParameterException
-from searx.query import RawTextQuery, VALID_LANGUAGE_CODE
+from searx.webutils import VALID_LANGUAGE_CODE
+from searx.query import RawTextQuery
 from searx.engines import categories, engines
 from searx.search import SearchQuery, EngineRef
 from searx.preferences import Preferences

--- a/searx/webutils.py
+++ b/searx/webutils.py
@@ -11,6 +11,8 @@ from codecs import getincrementalencoder
 from searx import logger
 
 
+VALID_LANGUAGE_CODE = re.compile(r'^[a-z]{2,3}(-[a-zA-Z]{2})?$')
+
 logger = logger.getChild('webutils')
 
 


### PR DESCRIPTION
## What does this PR do?

 searx/preferences.py : check the value of the `language` cookie using a regex instead of the [match_language](https://github.com/searx/searx/blob/ecb9f28869f081dc75182053c727523ed7e20d12/searx/utils.py#L219) function.

## Why is this change important?

See issue  #2220 and the commit https://github.com/searx/searx/commit/fd65c1292179fb082e965a1ee6a88b9298a54fc1

Without this PR, when the language parameter is set from the cookies, the validity is checked using the match_language function:
https://github.com/searx/searx/blob/21dbc7e852a5c48097c0067e78f0600972e54823/searx/preferences.py#L165-L168

When the language parameter is set from the URL or from the query, the validity is checked using a regex:
https://github.com/searx/searx/blob/21dbc7e852a5c48097c0067e78f0600972e54823/searx/search.py#L281-L290

With this PR, the `language` value check is the same (cookie, form value). See note below.

## How to test this PR locally?

* `make test`
* check different values for the `language` cookie.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Close #2220

## Note

https://github.com/searx/searx/blob/ecb9f28869f081dc75182053c727523ed7e20d12/searx/webadapter.py#L49-L64

With this PR, `query_lang = form.get('language')` is redundant since `request.form` is already parsed: https://github.com/searx/searx/blob/ecb9f28869f081dc75182053c727523ed7e20d12/searx/webapp.py#L448 (it was already the case for `language` value recognized by the match_language function). The code could be:

```python
def parse_lang(preferences: Preferences, form: Dict[str, str], raw_text_query: RawTextQuery) -> str:
    # get language
    # set specific language if set on request, query or preferences
    # TODO support search with multible languages
    if len(raw_text_query.languages):
        query_lang = raw_text_query.languages[-1]
    else:
        query_lang = preferences.get_value('language')

    return query_lang
```

I think it is better to have another PR to deal with that since the `form` parameter can be removed the `get_search_query_from_webapp` function.