### PR TITLE
[mod] URL for the static file contains the sha1

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -295,12 +295,19 @@ def get_result_template(theme, template_name):
 
 
 def url_for_theme(endpoint, override_theme=None, **values):
+    suffix = ""
     if endpoint == 'static' and values.get('filename'):
+        filename = values['filename']
+        # check if this is a static within the theme
         theme_name = get_current_theme_name(override=override_theme)
-        filename_with_theme = "themes/{}/{}".format(theme_name, values['filename'])
+        filename_with_theme = "themes/{}/{}".format(theme_name, filename)
         if filename_with_theme in static_files:
-            values['filename'] = filename_with_theme
-    url = url_for(endpoint, **values)
+            values['filename'] = filename = filename_with_theme
+        # add sha1
+        sha1 = static_files.get(filename)
+        if sha1:
+            suffix = "?" + sha1
+    url = url_for(endpoint, **values) + suffix
     if settings['server']['base_url']:
         if url.startswith('/'):
             url = url[1:]

--- a/searx/webutils.py
+++ b/searx/webutils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import io
 import os
 import csv
 import hashlib
@@ -63,13 +64,20 @@ def get_themes(templates_path):
     return themes
 
 
+def get_sha1_for_file(filename):
+    m = hashlib.sha1()
+    with io.open(filename, 'rb') as f:
+        m.update(f.read())
+    return m.hexdigest()
+
+
 def get_static_files(static_path):
-    static_files = set()
+    static_files = dict()
     static_path_length = len(static_path) + 1
     for directory, _, files in os.walk(static_path):
         for filename in files:
             f = os.path.join(directory[static_path_length:], filename)
-            static_files.add(f)
+            static_files[f] = get_sha1_for_file(os.path.join(directory, filename))
     return static_files
 
 

--- a/tests/unit/test_webapp.py
+++ b/tests/unit/test_webapp.py
@@ -14,6 +14,11 @@ class ViewsTestCase(SearxTestCase):
         webapp.app.config['TESTING'] = True  # to get better error messages
         self.app = webapp.app.test_client()
 
+        # remove sha for the static file
+        # so the tests don't have to care about the changing URLs
+        for k in webapp.static_files:
+            webapp.static_files[k] = None
+
         # set some defaults
         test_results = [
             {


### PR DESCRIPTION
## What does this PR do?

for example, instead of 
```html
<link rel="stylesheet" href="/static/css/bootstrap.min.css" type="text/css" />
```

the HTML becomes:
```html
<link rel="stylesheet" href="/static/css/bootstrap.min.css?0d0624d4eb8096f13cc9f981ed648b3a6624e532" type="text/css" />
```

## Why is this change important?

* allow to cache the static files forever
* avoid bugs when the static files are updated but not reloaded

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
