### PR TITLE
Fix drop python2

### DIFF
--- a/searx/engines/json_engine.py
+++ b/searx/engines/json_engine.py
@@ -1,4 +1,4 @@
-from collections import Iterable
+from collections.abc import Iterable
 from json import loads
 from urllib.parse import urlencode
 from searx.utils import to_string

--- a/searx/utils.py
+++ b/searx/utils.py
@@ -3,8 +3,8 @@ import os
 import sys
 import re
 import json
+import importlib
 
-from imp import load_source
 from numbers import Number
 from os.path import splitext, join
 from io import open
@@ -445,8 +445,11 @@ def load_module(filename, module_dir):
     if modname in sys.modules:
         del sys.modules[modname]
     filepath = join(module_dir, filename)
-    module = load_source(modname, filepath)
-    module.name = modname
+    # and https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
+    spec = importlib.util.spec_from_file_location(modname, filepath)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[modname] = module
+    spec.loader.exec_module(module)
     return module
 
 


### PR DESCRIPTION
## What does this PR do?

Drop Python 2 references.

---
partial backport of https://gitlab.e.foundation/e/cloud/my-spot/commit/2cc736bdea21aab0c7b1680622df9c1496526411
note `SourceFileLoader(modname, filepath).load_module()` is deprecated in Python 3.5
see https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly

---

This PR remove this line
```python
module.name = modname
```
from searx.utils.load_module.

load_module is referenced by : 
* searx.engine.load_engine
* searx.answeres.load_answeres

The ```.name``` attribute is referenced by this line https://github.com/searx/searx/blob/584760cf5419051bd3f37e733147e048356f7ffc/searx/engines/__init__.py#L107

But just above, the settings.yml configuration is copied into the module: 
https://github.com/searx/searx/blob/584760cf5419051bd3f37e733147e048356f7ffc/searx/engines/__init__.py#L84-L93

Each engine configuration has the ```name``` attribute, for example:
https://github.com/searx/searx/blob/584760cf5419051bd3f37e733147e048356f7ffc/searx/settings.yml#L439-L448

In this case: 
* load_module (master branch), set the name attribute to `xpath` (the module name)
* load_engine set the name attribute to `library genesis` (from settings.yml)

So in the end it is safe to remove this line : https://github.com/searx/searx/blob/584760cf5419051bd3f37e733147e048356f7ffc/searx/utils.py#L449

## Why is this change important?

Remove usage of deprecated API.

## How to test this PR locally?

* `make test`
* try the JSON engine.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Partial fix of https://github.com/searx/searx/issues/1674