### PR TITLE
[fix] opensearch.xml URL contains method and autocomplete parameters

### DIFF
--- a/searx/templates/__common__/opensearch.xml
+++ b/searx/templates/__common__/opensearch.xml
@@ -15,4 +15,8 @@
   {% if autocomplete %}
     <Url rel="suggestions" type="application/x-suggestions+json" template="{{ host }}autocompleter?q={searchTerms}"/>
   {% endif %}
+
+  <Url type="application/opensearchdescription+xml"
+      rel="self"
+      template="{{ opensearch_url }}" />
 </OpenSearchDescription>

--- a/searx/templates/__common__/opensearch_response_rss.xml
+++ b/searx/templates/__common__/opensearch_response_rss.xml
@@ -9,7 +9,7 @@
     <opensearch:totalResults>{{ number_of_results }}</opensearch:totalResults>
     <opensearch:startIndex>1</opensearch:startIndex>
     <opensearch:itemsPerPage>{{ number_of_results }}</opensearch:itemsPerPage>
-    <atom:link rel="search" type="application/opensearchdescription+xml" href="{{ base_url }}opensearch.xml"/>
+    <atom:link rel="search" type="application/opensearchdescription+xml" href="{{ opensearch_url }}"/>
     <opensearch:Query role="request" searchTerms="{{ q|e }}" startPage="1" />
     {% if error_message %}
     <item>

--- a/searx/templates/courgette/base.html
+++ b/searx/templates/courgette/base.html
@@ -22,7 +22,7 @@
         {% endblock %}
         {% block meta %}{% endblock %}
         {% block head %}
-        <link title="{{ instance_name }}" type="application/opensearchdescription+xml" rel="search" href="{{ url_for('opensearch') }}"/>
+        <link title="{{ instance_name }}" type="application/opensearchdescription+xml" rel="search" href="{{ opensearch_url }}"/>
         {% endblock %}
         <script type="text/javascript">
             searx = {};

--- a/searx/templates/legacy/base.html
+++ b/searx/templates/legacy/base.html
@@ -17,7 +17,7 @@
         {% endblock %}
         {% block meta %}{% endblock %}
         {% block head %}
-        <link title="{{ instance_name }}" type="application/opensearchdescription+xml" rel="search" href="{{ url_for('opensearch') }}"/>
+        <link title="{{ instance_name }}" type="application/opensearchdescription+xml" rel="search" href="{{ opensearch_url }}"/>
         {% endblock %}
     </head>
     <body class="{{ endpoint }}_endpoint" >

--- a/searx/templates/oscar/base.html
+++ b/searx/templates/oscar/base.html
@@ -37,7 +37,7 @@
     {% block head %}
     {% endblock %}
 
-    <link title="{{ instance_name }}" type="application/opensearchdescription+xml" rel="search" href="{{ url_for('opensearch') }}"/>
+    <link title="{{ instance_name }}" type="application/opensearchdescription+xml" rel="search" href="{{ opensearch_url }}"/>
     <noscript>
         <style type="text/css">
             .tab-content > .active_if_nojs, .active_if_nojs {display: block !important; visibility: visible !important;}

--- a/searx/templates/simple/base.html
+++ b/searx/templates/simple/base.html
@@ -29,7 +29,7 @@
           data-no-item-found="{{ _('No item found') }}"></script>
   <!--<![endif]-->
   {% block head %}
-  <link title="{{ instance_name }}" type="application/opensearchdescription+xml" rel="search" href="{{ url_for('opensearch') }}"/>
+  <link title="{{ instance_name }}" type="application/opensearchdescription+xml" rel="search" href="{{ opensearch_url }}"/>
   {% endblock %}
   <link rel="shortcut icon" href="{{ url_for('static', filename='img/favicon.png') }}" />
 </head>

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -386,6 +386,9 @@ def render(template_name, override_theme=None, **kwargs):
 
     kwargs['proxify'] = proxify if settings.get('result_proxy', {}).get('url') else None
 
+    kwargs['opensearch_url'] = url_for('opensearch') + '?' \
+        + urlencode({'method': kwargs['method'], 'autocomplete': kwargs['autocomplete']})
+
     kwargs['get_result_template'] = get_result_template
 
     kwargs['theme'] = get_current_theme_name(override=override_theme)


### PR DESCRIPTION
## What does this PR do?

When the user add searx as a search engine, the browser loads the /opensearch.xml URL without the cookies.
Without the query parameters, the user preferences are ignored (method and autocomplete).

In addition, opensearch.xml is modified to support automatic updates,
see https://developer.mozilla.org/en-US/docs/Web/OpenSearch

## Why is this change important?

The user choice between the GET and POST method is ignored in opensearch.xml
This PR fixes this issue.

## How to test this PR locally?

With Firefox, with Chrome (with Safari ?):
* Add the instance without preferences
* Check the browser uses the 'POST' method (if default) 
* Remove the instance
* Change to the 'GET' method
* Add the instance again
* Check the browser uses the 'GET' method 

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

* https://github.com/searx/searx/issues/2245
* https://github.com/searx/searx/issues/2069#issuecomment-671099077