### PR TITLE
[fix] various fixes of searx.webadapter

### DIFF
--- a/searx/search.py
+++ b/searx/search.py
@@ -72,11 +72,11 @@ class SearchQuery:
                  engineref_list: typing.List[EngineRef],
                  categories: typing.List[str],
                  lang: str,
-                 safesearch: bool,
+                 safesearch: int,
                  pageno: int,
                  time_range: typing.Optional[str],
                  timeout_limit: typing.Optional[float]=None,
-                 external_bang: typing.Optional[str]=False):
+                 external_bang: typing.Optional[str]=None):
         self.query = query
         self.engineref_list = engineref_list
         self.categories = categories


### PR DESCRIPTION
## What does this PR do?

* Fix `?q=test&engines=wikipedia`: fix exception ( should not be `engine['category']` : https://github.com/searx/searx/blob/584760cf5419051bd3f37e733147e048356f7ffc/searx/webadapter.py#L179
* Fix `?q=test&engines=wikipedia&categories=images`: now the engines from images category are included. Before the categories were selected, but not the engines https://github.com/searx/searx/blob/584760cf5419051bd3f37e733147e048356f7ffc/searx/webadapter.py#L178
* Fix parse_timeout: make sure a value is always returned
* Various typing fixes (searx.webadapter, searx.search.SearchQuery)

## Why is this change important?

Various fixes

## How to test this PR locally?

* `?q=test&engines=wikipedia`
* `?q=test&engines=wikipedia&categories=images`
* `?q=test&timeout_limit=`

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
