### PR TITLE
Add minimum safe search option based on #1392

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -4,6 +4,7 @@ general:
 
 search:
     safe_search : 0 # Filter results. 0: None, 1: Moderate, 2: Strict
+    minimum_safe_search : 0 # Enforce a minimum safe_search
     autocomplete : "" # Existing autocomplete backends: "dbpedia", "duckduckgo", "google", "startpage", "swisscows", "qwant", "wikipedia" - leave blank to turn it off by default
     default_lang : "" # Default search language - leave blank to detect from browser information or use codes from 'languages.py'
     ban_time_on_fail : 5 # ban time in seconds after engine errors

--- a/searx/templates/oscar/preferences.html
+++ b/searx/templates/oscar/preferences.html
@@ -194,6 +194,7 @@
                                 </tr>
                         {% for search_engine in engines_by_category[categ] %}
                             {% if not search_engine.private %}
+                            {% if minimum_safesearch > 0 and search_engine.safesearch or minimum_safesearch == 0 %}
                                 <tr>
                                     {% if not rtl %}
                                     <td class="onoff-checkbox">
@@ -219,6 +220,7 @@
                                     </td>
                                     {% endif %}
                                 </tr>
+                            {% endif %}
                             {% endif %}
                         {% endfor %}
                           </table>

--- a/searx/webadapter.py
+++ b/searx/webadapter.py
@@ -76,7 +76,8 @@ def parse_safesearch(preferences: Preferences, form: Dict[str, str]) -> int:
         query_safesearch = preferences.get_value('safesearch')
 
     # safesearch : second check
-    if query_safesearch < 0 or query_safesearch > 2:
+    minimum_safe_search = int(settings['search'].get('minimum_safe_search', 0))
+    if query_safesearch < 0 or query_safesearch > 2 or query_safesearch < minimum_safe_search:
         raise SearxParameterException('safesearch', query_safesearch)
 
     return query_safesearch

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -350,10 +350,12 @@ def image_proxify(url):
 
 def render(template_name, override_theme=None, **kwargs):
     disabled_engines = request.preferences.engines.get_disabled()
+    minimum_safesearch = settings.get('search').get('minimum_safe_search', 0)
 
     enabled_categories = set(category for engine_name in engines
                              for category in engines[engine_name].categories
-                             if (engine_name, category) not in disabled_engines)
+                             if (engine_name, category) not in disabled_engines and
+                             _engine_minimum_safesearch(engine_name, minimum_safesearch))
 
     if 'categories' not in kwargs:
         kwargs['categories'] = [x for x in
@@ -373,6 +375,7 @@ def render(template_name, override_theme=None, **kwargs):
     kwargs['method'] = request.preferences.get_value('method')
 
     kwargs['safesearch'] = str(request.preferences.get_value('safesearch'))
+    kwargs['minimum_safesearch'] = minimum_safesearch
 
     kwargs['language_codes'] = languages
     if 'current_language' not in kwargs:
@@ -420,6 +423,10 @@ def render(template_name, override_theme=None, **kwargs):
 
     return render_template(
         '{}/{}'.format(kwargs['theme'], template_name), **kwargs)
+
+
+def _engine_minimum_safesearch(name, minimum_safesearch):
+    return minimum_safesearch > 0 and engines[name].safesearch
 
 
 def _get_ordered_categories():


### PR DESCRIPTION
## What does this PR do?

This PR is the renovated version of #1392. It adds a new options to `settings.yml` called `minimum_safe_search`. Thus, instance administrators can control the minimum level of safe search on their instances. Possible values are `0`, `1` and `2`.

This PR is also superior to the previous because if an admin configures this option, only the engines which meet the criteria are displayed on the preferences page.

## Why is this change important?

This PR gives more control to instance admins by letting them enforce minimal safe search requirements.

## Related issues

Closes #1392
