### PR TITLE
Fix XPATH of lobste.rs engine && add timeout

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -457,11 +457,13 @@ engines:
     engine : xpath
     search_url : https://lobste.rs/search?utf8=%E2%9C%93&q={query}&what=stories&order=relevance
     results_xpath : //li[contains(@class, "story")]
-    url_xpath : .//span[@class="link"]/a/@href
-    title_xpath : .//span[@class="link"]/a
+    url_xpath : .//a[@class="u-url"]/@href
+    title_xpath : .//a[@class="u-url"]
     content_xpath : .//a[@class="domain"]
     categories : it
     shortcut : lo
+    timeout : 3.0
+    disabled: True
 
   - name : metager
     engine : xpath


### PR DESCRIPTION
## What does this PR do?

This PR adjusts the XPATHs of the lobste.rs engine. It also adds a timeout of 3 seconds. To avoid slowing down the loading of results in the IT category, the engine has been disabled.

## Why is this change important?

Without this fixes the engine does not return results.

## How to test this PR locally?

Example queries

```
!lo linux
```

```
!lo json
```

```
!lo searx
```

## Related issues

Closes #1738
