### PR TITLE
Add yacy improvements: HTTP digest auth, category checking

### DIFF
--- a/searx/engines/yacy.py
+++ b/searx/engines/yacy.py
@@ -16,6 +16,8 @@ from json import loads
 from dateutil import parser
 from urllib.parse import urlencode
 
+from requests.auth import HTTPDigestAuth
+
 from searx.utils import html_to_text
 
 # engine dependent config
@@ -23,6 +25,8 @@ categories = ['general', 'images']  # TODO , 'music', 'videos', 'files'
 paging = True
 language_support = True
 number_of_results = 5
+http_digest_auth_user = ""
+http_digest_auth_pass = ""
 
 # search-url
 base_url = 'http://localhost:8090'
@@ -51,6 +55,9 @@ def request(query, params):
                           limit=number_of_results,
                           search_type=search_type)
 
+    if http_digest_auth_user and http_digest_auth_pass:
+        params['auth'] = HTTPDigestAuth(http_digest_auth_user, http_digest_auth_pass)
+
     # add language tag if specified
     if params['language'] != 'all':
         params['url'] += '&lr=lang_' + params['language'].split('-')[0]
@@ -75,7 +82,7 @@ def response(resp):
 
     for result in search_results[0].get('items', []):
         # parse image results
-        if result.get('image') and result.get('width') and result.get('height'):
+        if resp.search_params.get('category') == 'images':
 
             result_url = ''
             if 'url' in result:
@@ -104,5 +111,4 @@ def response(resp):
 
         # TODO parse video, audio and file results
 
-    # return results
     return results

--- a/searx/search.py
+++ b/searx/search.py
@@ -97,7 +97,8 @@ def send_http_request(engine, request_params):
     request_args = dict(
         headers=request_params['headers'],
         cookies=request_params['cookies'],
-        verify=request_params['verify']
+        verify=request_params['verify'],
+        auth=request_params['auth']
     )
 
     # setting engine based proxies
@@ -281,7 +282,8 @@ def default_request_params():
         'data': {},
         'url': '',
         'cookies': {},
-        'verify': True
+        'verify': True,
+        'auth': None
     }
 
 


### PR DESCRIPTION
## What does this PR do?

This PR is based on the work of @0xhtml. As the fork which contained the branch, I had to "reimplement" the feature in the PR.
It adds HTTP Digest authentication to YaCy and cleans up the images result parsing.

## Why is this change important?

Lets instances connect to a YaCy instance with authentication.

## Related issues

Closes #1660
