### PR TITLE
Force admins to set secret_key if debug mode is disabled

### DIFF
--- a/searx/__init__.py
+++ b/searx/__init__.py
@@ -85,3 +85,7 @@ if 'SEARX_SECRET' in environ:
     settings['server']['secret_key'] = environ['SEARX_SECRET']
 if 'SEARX_BIND_ADDRESS' in environ:
     settings['server']['bind_address'] = environ['SEARX_BIND_ADDRESS']
+
+if not searx_debug and settings['server']['secret_key'] == 'ultrasecretkey':
+    logger.error('server.secret_key is not changed. Please use something else instead of ultrasecretkey.')
+    exit(1)

--- a/searx/settings_robot.yml
+++ b/searx/settings_robot.yml
@@ -8,7 +8,7 @@ search:
 server:
     port : 11111
     bind_address : 127.0.0.1
-    secret_key : "ultrasecretkey" # change this!
+    secret_key : "changedultrasecretkey"
     base_url : False
     http_protocol_version : "1.0"
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+import os
+os.environ['SEARX_DEBUG'] = '1'


### PR DESCRIPTION
## What does this PR do?

This PR checks if the `server.secret_key` is changed from the default value when searx is not running in debug mode.

From now on if you do not change the secret_key, the following error message is returned:

```
$ SEARX_DEBUG=0 python3 searx/webapp.py
server.secret_key have to be changed if not in debug mode
```

## Why is this change important?

This check forces instance admins to configure a secret key for their instances.

## Related issues

Closes #819
