### PR TITLE
Let admins lock user preferences

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -33,6 +33,15 @@ ui:
 #     - it
 #     - science
 
+# Lock arbitrary settings on the preferences page.
+# To find the ID of the user setting you want to lock, check
+# the ID of the form on the page "preferences".
+#preferences:
+#    lock:
+#      - language
+#      - autocomplete
+#      - method
+
 # searx supports result proxification using an external service: https://github.com/asciimoo/morty
 # uncomment below section if you have running morty proxy
 # the key is base64 encoded (keep the !!binary notation)

--- a/searx/settings_robot.yml
+++ b/searx/settings_robot.yml
@@ -17,6 +17,9 @@ ui:
     templates_path : ""
     default_theme : oscar
 
+preferences:
+    lock: []
+
 outgoing:
     request_timeout : 1.0 # seconds
     useragent_suffix : ""

--- a/searx/templates/courgette/preferences.html
+++ b/searx/templates/courgette/preferences.html
@@ -5,10 +5,13 @@
     <h2>{{ _('Preferences') }}</h2>
 
     <form method="post" action="{{ url_for('preferences') }}" id="search_form">
+    {% if 'categories' not in locked_preferences %}
     <fieldset>
         <legend>{{ _('Default categories') }}</legend>
         {% include 'courgette/categories.html' %}
     </fieldset>
+    {% endif %}
+    {% if 'language' not in locked_preferences %}
     <fieldset>
         <legend>{{ _('Search language') }}</legend>
         <p>
@@ -20,6 +23,8 @@
             </select>
         </p>
     </fieldset>
+    {% endif %}
+    {% if 'locale' not in locked_preferences %}
     <fieldset>
         <legend>{{ _('Interface language') }}</legend>
         <p>
@@ -30,6 +35,8 @@
             </select>
         </p>
     </fieldset>
+    {% endif %}
+    {% if 'autocomplete' not in locked_preferences %}
     <fieldset>
         <legend>{{ _('Autocomplete') }}</legend>
         <p>
@@ -41,6 +48,8 @@
             </select>
         </p>
     </fieldset>
+    {% endif %}
+    {% if 'image_proxy' not in locked_preferences %}
     <fieldset>
         <legend>{{ _('Image proxy') }}</legend>
         <p>
@@ -50,6 +59,8 @@
             </select>
         </p>
     </fieldset>
+    {% endif %}
+    {% if 'method' not in locked_preferences %}
     <fieldset>
         <legend>{{ _('Method') }}</legend>
         <p>
@@ -59,6 +70,8 @@
             </select>
         </p>
     </fieldset>
+    {% endif %}
+    {% if 'safesearch' not in locked_preferences %}
     <fieldset>
         <legend>{{ _('SafeSearch') }}</legend>
         <p>
@@ -69,6 +82,8 @@
             </select>
         </p>
     </fieldset>
+    {% endif %}
+    {% if 'theme' not in locked_preferences %}
     <fieldset>
         <legend>{{ _('Themes') }}</legend>
         <p>
@@ -92,6 +107,7 @@
             </select>
         </p>
     </fieldset>
+    {% endif %}
     <fieldset>
         <legend>{{ _('Currently used search engines') }}</legend>
 

--- a/searx/templates/legacy/preferences.html
+++ b/searx/templates/legacy/preferences.html
@@ -10,6 +10,7 @@
         {% set display_tooltip = false %}
         {% include 'legacy/categories.html' %}
     </fieldset>
+    {% if 'language' not in locked_preferences %}
     <fieldset>
         <legend>{{ _('Search language') }}</legend>
         <p>
@@ -21,6 +22,8 @@
         </select>
         </p>
     </fieldset>
+    {% endif %}
+    {% if 'locale' not in locked_preferences %}
     <fieldset>
         <legend>{{ _('Interface language') }}</legend>
         <p>
@@ -31,6 +34,8 @@
         </select>
         </p>
     </fieldset>
+    {% endif %}
+    {% if 'autocomplete' not in locked_preferences %}
     <fieldset>
         <legend>{{ _('Autocomplete') }}</legend>
         <p>
@@ -42,6 +47,8 @@
         </select>
         </p>
     </fieldset>
+    {% endif %}
+    {% if 'image_proxy' not in locked_preferences %}
     <fieldset>
         <legend>{{ _('Image proxy') }}</legend>
         <p>
@@ -51,6 +58,8 @@
         </select>
         </p>
     </fieldset>
+    {% endif %}
+    {% if 'method' not in locked_preferences %}
     <fieldset>
         <legend>{{ _('Method') }}</legend>
         <p>
@@ -60,6 +69,8 @@
         </select>
         </p>
     </fieldset>
+    {% endif %}
+    {% if 'safesearch' not in locked_preferences %}
     <fieldset>
         <legend>{{ _('SafeSearch') }}</legend>
         <p>
@@ -70,6 +81,8 @@
         </select>
         </p>
     </fieldset>
+    {% endif %}
+    {% if 'theme' not in locked_preferences %}
     <fieldset>
         <legend>{{ _('Themes') }}</legend>
         <p>
@@ -80,6 +93,8 @@
         </select>
         </p>
     </fieldset>
+    {% endif %}
+    {% if 'results_on_new_tab' not in locked_preferences %}
     <fieldset>
         <legend>{{ _('Results on new tabs') }}</legend>
         <p>
@@ -89,6 +104,7 @@
             </select>
         </p>
     </fieldset>
+    {% endif %}
     <fieldset>
     <legend>{{ _('Currently used search engines') }}</legend>
 

--- a/searx/templates/oscar/preferences.html
+++ b/searx/templates/oscar/preferences.html
@@ -25,6 +25,7 @@
             <div class="tab-pane active" id="tab_general">
                 <fieldset>
                 <div class="container-fluid">
+                    {% if 'categories' not in locked_preferences %}
                     <div class="row form-group">
                         {% if rtl %}
                         <div class="col-sm-11 col-md-10">
@@ -38,12 +39,16 @@
                         </div>
                         {% endif %}
                     </div>
+                    {% endif %}
+                    {% if 'language' not in locked_preferences %}
                     {% set language_label = _('Search language') %}
                     {% set language_info = _('What language do you prefer for search?') %}
                     {{ preferences_item_header(language_info, language_label, rtl, 'language') }}
                                                 {% include 'oscar/languages.html' %}
                     {{ preferences_item_footer(language_info, language_label, rtl) }}
+                    {% endif %}
 
+                    {% if 'locale' not in locked_preferences %}
                     {% set locale_label = _('Interface language') %}
                     {% set locale_info = _('Change the language of the layout') %}
                     {{ preferences_item_header(locale_info, locale_label, rtl, 'locale') }}
@@ -53,7 +58,9 @@
                             {% endfor %}
                         </select>
                     {{ preferences_item_footer(locale_info, locale_label, rtl) }}
+                    {% endif %}
 
+                    {% if 'autocomplete' not in locked_preferences %}
                     {% set autocomplete_label = _('Autocomplete') %}
                     {% set autocomplete_info = _('Find stuff as you type') %}
                     {{ preferences_item_header(autocomplete_info, autocomplete_label, rtl, 'autocomplete') }}
@@ -64,7 +71,9 @@
                             {% endfor %}
                         </select>
                     {{ preferences_item_footer(autocomplete_info, autocomplete_label, rtl) }}
+                    {% endif %}
 
+                    {% if 'image_proxy' not in locked_preferences %}
                     {% set image_proxy_label = _('Image proxy') %}
                     {% set image_proxy_info = _('Proxying image results through searx') %}
                     {{ preferences_item_header(image_proxy_info, image_proxy_label, rtl, 'image_proxy') }}
@@ -73,7 +82,9 @@
                             <option value="" {% if not image_proxy %}selected="selected"{% endif %}>{{ _('Disabled')}}</option>
                         </select>
                     {{ preferences_item_footer(image_proxy_info, image_proxy_label, rtl) }}
+                    {% endif %}
 
+                    {% if 'method' not in locked_preferences %}
                     {% set method_label = _('Method') %}
                     {% set method_info = _('Change how forms are submited, <a href="http://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Request_methods" rel="external">learn more about request methods</a>') %}
                     {{ preferences_item_header(method_info, method_label, rtl, 'method') }}
@@ -82,7 +93,9 @@
                             <option value="GET" {% if method == 'GET' %}selected="selected"{% endif %}>GET</option>
                         </select>
                     {{ preferences_item_footer(method_info, method_label, rtl) }}
+                    {% endif %}
 
+                    {% if 'safesearch' not in locked_preferences %}
                     {% set safesearch_label = _('SafeSearch') %}
                     {% set safesearch_info = _('Filter content') %}
                     {{ preferences_item_header(safesearch_info, safesearch_label, rtl, 'safesearch') }}
@@ -92,7 +105,9 @@
                             <option value="0" {% if safesearch == '0' %}selected="selected"{% endif %}>{{ _('None') }}</option>
                         </select>
                     {{ preferences_item_footer(safesearch_info, safesearch_label, rtl) }}
+                    {% endif %}
 
+                    {% if 'theme' not in locked_preferences %}
                     {% set theme_label = _('Themes') %}
                     {% set theme_info = _('Change searx layout') %}
                     {{ preferences_item_header(theme_info, theme_label, rtl, 'theme') }}
@@ -102,7 +117,9 @@
                             {% endfor %}
                         </select>
                     {{ preferences_item_footer(theme_info, theme_label, rtl) }}
+                    {% endif %}
 
+                    {% if 'oscar-style' not in locked_preferences %}
                     {{ preferences_item_header(_('Choose style for this theme'), _('Style'), rtl, 'oscar_style') }}
                         <select class="form-control {{ custom_select_class(rtl) }}" name="oscar-style" id="oscar_style">
                             <option value="logicodev" >Logicodev</option>
@@ -110,7 +127,9 @@
                             <option value="logicodev-dark" {% if preferences.get_value('oscar-style') == 'logicodev-dark' %}selected="selected"{% endif %}>Logicodev dark</option>
                         </select>
                     {{ preferences_item_footer(_('Choose style for this theme'), _('Style'), rtl) }}
+                    {% endif %}
 
+                    {% if 'results_on_new_tab' not in locked_preferences %}
                     {% set label = _('Results on new tabs') %}
                     {% set info = _('Open result links on new browser tabs') %}
                     {{ preferences_item_header(info, label, rtl, 'results_on_new_tab') }}
@@ -119,7 +138,9 @@
                             <option value="0" {% if not results_on_new_tab %}selected="selected"{% endif %}>{{ _('Off')}}</option>
                         </select>
                     {{ preferences_item_footer(info, label, rtl) }}
+                    {% endif %}
 
+                    {% if 'doi_resolver' not in locked_preferences %}
                     {% set label = _('Open Access DOI resolver') %}
                     {% set info = _('Redirect to open-access versions of publications when available (plugin required)') %}
                     {{ preferences_item_header(info, label, rtl, 'doi_resolver') }}
@@ -131,6 +152,7 @@
                              {% endfor %}
                          </select>
                     {{ preferences_item_footer(info, label, rtl) }}
+                    {% endif %}
 
                     {% set label = _('Engine tokens') %}
                     {% set info = _('Access tokens for private engines') %}

--- a/searx/templates/pix-art/preferences.html
+++ b/searx/templates/pix-art/preferences.html
@@ -5,6 +5,7 @@
     <h2>{{ _('Preferences') }}</h2>
 
     <form method="post" action="{{ url_for('preferences') }}" id="search_form">
+    {% if 'language' not in locked_preferences %}
     <fieldset>
         <legend>{{ _('Search language') }}</legend>
         <p>
@@ -16,6 +17,8 @@
         </select>
         </p>
     </fieldset>
+    {% endif %}
+    {% if 'locale' not in locked_preferences %}
     <fieldset>
         <legend>{{ _('Interface language') }}</legend>
         <p>
@@ -26,6 +29,8 @@
         </select>
         </p>
     </fieldset>
+    {% endif %}
+    {% if 'method' not in locked_preferences %}
     <fieldset>
         <legend>{{ _('Method') }}</legend>
         <p>
@@ -35,6 +40,8 @@
         </select>
         </p>
     </fieldset>
+    {% endif %}
+    {% if 'theme' not in locked_preferences %}
     <fieldset>
         <legend>{{ _('Themes') }}</legend>
         <p>
@@ -45,6 +52,7 @@
         </select>
         </p>
     </fieldset>
+    {% endif %}
     <fieldset>
     <legend>{{ _('Currently used search engines') }}</legend>
 

--- a/searx/templates/simple/preferences.html
+++ b/searx/templates/simple/preferences.html
@@ -30,11 +30,14 @@
 {{ tabs_open() }}
 
 {{ tab_header('maintab', 'general', _('General')) }}
+  {% if 'categories' not in locked_preferences %}
   <fieldset>
     <legend>{{ _('Default categories') }}</legend>
     {% set display_tooltip = false %}
     {% include 'simple/categories.html' %}
   </fieldset>
+  {% endif %}
+  {% if 'language' not in locked_preferences %}
   <fieldset>
     <legend>{{ _('Search language') }}</legend>
     <p class="value">{{- '' -}}
@@ -47,6 +50,8 @@
     </p>
     <div class="description">{{ _('What language do you prefer for search?') }}</div>
   </fieldset>
+  {% endif %}
+  {% if 'autocomplete' not in locked_preferences %}
   <fieldset>
     <legend>{{ _('Autocomplete') }}</legend>
     <p class="value">
@@ -59,6 +64,8 @@
     </p>
     <div class="description">{{ _('Find stuff as you type') }}</div>
   </fieldset>
+  {% endif %}
+  {% if 'safesearch' not in locked_preferences %}
   <fieldset>
     <legend>{{ _('SafeSearch') }}</legend>
     <p class="value">
@@ -70,7 +77,9 @@
     </p>
     <p class="description">{{ _('Filter content') }}</p>
   </fieldset>
+  {% endif %}
   {{ plugin_preferences('general') }}
+  {% if 'doi_resolver' not in locked_preferences %}
   <fieldset>
     <legend>{{ _('Open Access DOI resolver') }}</legend>
     <p class="value">
@@ -84,6 +93,7 @@
     </p>
     <div class="description"><!-- {{ _('Redirect to open-access versions of publications when available (plugin required)') }} --></div>
   </fieldset>
+  {% endif %}
   {{ tab_footer() }}
 
   {{ tab_header('maintab', 'engines', _('Engines')) }}
@@ -129,6 +139,7 @@
   {{ tab_footer() }}
 
   {{ tab_header('maintab', 'ui', _('User interface')) }}
+  {% if 'locale' not in locked_preferences %}
   <fieldset>
     <legend>{{ _('Interface language') }}</legend>
     <p class="value">
@@ -140,6 +151,8 @@
     </p>
     <div class="description">{{ _('Change the language of the layout') }}</div>
   </fieldset>
+  {% endif %}
+  {% if 'theme' not in locked_preferences %}
   <fieldset>
     <legend>{{ _('Themes') }}</legend>
     <p class="value">
@@ -151,6 +164,8 @@
     </p>
     <div class="description">{{ _('Change searx layout') }}</div>
   </fieldset>
+  {% endif %}
+  {% if 'results_on_new_tab' not in locked_preferences %}
   <fieldset>
     <legend>{{ _('Results on new tabs') }}</legend>
     <p class="value">
@@ -161,6 +176,7 @@
     </p>
     <div class="description">{{_('Open result links on new browser tabs') }}</div>
   </fieldset>
+  {% endif %}
   {{ plugin_preferences('ui') }}
   {{ tab_footer() }}
 
@@ -197,6 +213,7 @@
   {{ tab_footer() }}
 
   {{ tab_header('maintab', 'privacy', _('Privacy')) }}
+  {% if 'method' not in locked_preferences %}
   <fieldset>
     <legend>{{ _('Method') }}</legend>
     <p class="value">
@@ -207,6 +224,8 @@
     </p>
     <div class="description">{{ _('Search language') }}</div>
   </fieldset>
+  {% endif %}
+  {% if 'image_proxy' not in locked_preferences %}
   <fieldset>
     <legend>{{ _('Image proxy') }}</legend>
     <p class="value">
@@ -217,6 +236,7 @@
     </p>
     <div class="description">{{ _('Proxying image results through searx') }}</div>
   </fieldset>
+  {% endif %}
   {{ plugin_preferences('privacy') }}
 
   {{ tab_footer() }}

--- a/searx/webadapter.py
+++ b/searx/webadapter.py
@@ -4,7 +4,7 @@ from searx.webutils import VALID_LANGUAGE_CODE
 from searx.query import RawTextQuery
 from searx.engines import categories, engines
 from searx.search import SearchQuery, EngineRef
-from searx.preferences import Preferences
+from searx.preferences import Preferences, is_locked
 
 
 # remove duplicate queries.
@@ -48,6 +48,8 @@ def parse_pageno(form: Dict[str, str]) -> int:
 
 
 def parse_lang(preferences: Preferences, form: Dict[str, str], raw_text_query: RawTextQuery) -> str:
+    if is_locked('language'):
+        return preferences.get_value('langueage')
     # get language
     # set specific language if set on request, query or preferences
     # TODO support search with multible languages
@@ -66,6 +68,9 @@ def parse_lang(preferences: Preferences, form: Dict[str, str], raw_text_query: R
 
 
 def parse_safesearch(preferences: Preferences, form: Dict[str, str]) -> int:
+    if is_locked('safesearch'):
+        return preferences.get_value('safesearch')
+
     if 'safesearch' in form:
         query_safesearch = form.get('safesearch')
         # first check safesearch
@@ -117,6 +122,9 @@ def parse_specific(raw_text_query: RawTextQuery) -> Tuple[List[EngineRef], List[
 
 
 def parse_category_form(query_categories: List[str], name: str, value: str) -> None:
+    if is_locked('categories'):
+        return preferences.get_value('categories')
+
     if name == 'categories':
         query_categories.extend(categ for categ in map(str.strip, value.split(',')) if categ in categories)
     elif name.startswith('category_'):

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -828,6 +828,10 @@ def preferences():
             stats[engine_stat.get('name')]['warn_time'] = True
     # end of stats
 
+    locked_preferences = list()
+    if 'preferences' in settings and 'lock' in settings['preferences']:
+        locked_preferences = settings['preferences']['lock']
+
     return render('preferences.html',
                   selected_categories=get_selected_categories(request.preferences, request.form),
                   all_categories=_get_ordered_categories(),
@@ -848,6 +852,7 @@ def preferences():
                   theme=get_current_theme_name(),
                   preferences_url_params=request.preferences.get_as_url_params(),
                   base_url=get_base_url(),
+                  locked_preferences=locked_preferences,
                   preferences=True)
 
 

--- a/tests/unit/test_preferences.py
+++ b/tests/unit/test_preferences.py
@@ -141,4 +141,4 @@ class TestPreferences(SearxTestCase):
         pref.parse_encoded_data(url_params)
         self.assertEqual(
             vars(pref.key_value_settings['categories']),
-            {'value': ['general'], 'choices': ['general', 'none']})
+            {'value': ['general'], 'locked': False, 'choices': ['general', 'none']})


### PR DESCRIPTION
## What does this PR do?

This PR adds a new attribute to `Setting` in `Preferences` called `locked`. If a `Setting` is `locked`, users cannot change the default value configured in `settings.yml` using the `/preferences` page. Locked settings does not even show up there.

### How to configure it from `settings.yml`?

A new setting is added to the configuration file: `preferences.lock`. It expects a list of preferences form IDs from the `/preferences` page.

#### Example configuration

```yaml
preferences:
    lock: ['autocomplete', 'safesearch', 'method']
```

We had a long conversation about how to refer to the locked settings in #2251. I decided to go with the IDs from the preferences page not only because it is simpler to implement. But rather I think the "administrator journey" is the following when deciding to which setting to lock:
1. Look at the `/preferences` page to see what users can configure
2. Decide if they want to let users configure that specific setting
3. If not, right click on the element and copy their ID to `settings.yml`. If yes, move on to the next setting.

Furthermore, this approach avoids the possible confusion over which settings can be overwritten by users or not.

## Why is this change important?

It is possible that admins do not want to let users customize specific user settings. For example they might lock the search method to POST to help users with their privacy by disabling riskier options.

## How to test this PR locally?

1. Lock a user setting from `settings.yml`
2. Check if it shows up in the Preferences page
3. Check if you can change the setting from the search URL

## Related issues

Closes #1392
Closes #2251