### PR TITLE
Doc installation fix

### DIFF
--- a/.config.sh
+++ b/.config.sh
@@ -25,7 +25,7 @@ fi
 # searx.sh
 # ---------
 
-# SEARX_INTERNAL_URL="127.0.0.1:8888"
+SEARX_INTERNAL_URL="127.0.0.1:8888"
 
 # Only change, if you maintain a searx brand in your searx fork.
 # GIT_BRANCH="${GIT_BRANCH:-master}"

--- a/docs/build-templates/searx.rst
+++ b/docs/build-templates/searx.rst
@@ -132,6 +132,7 @@ ${fedora_build}
 
     .. code-block:: sh
 
+       $ sudo -H mkdir -p "${SEARX_SETTINGS_PATH}"
        $ sudo -H cp "$SEARX_SRC/searx/settings.yml" "${SEARX_SETTINGS_PATH}"
        $ sudo -H sed -i -e "s/ultrasecretkey/\\$(openssl rand -hex 16)/g" "$SEARX_SETTINGS_PATH"
        $ sudo -H sed -i -e "s/{instance_name}/searx@\\$(uname -n)/g" "$SEARX_SETTINGS_PATH"
@@ -147,7 +148,7 @@ ${fedora_build}
     .. code-block:: sh
 
        # enable debug ..
-       $ sudo -H sed -i -e "s/debug : False/debug : True/g" "$SEARX_SETTINGS_PATH"
+       $ sudo -H sed -i -e "s/'debug : False'/'debug : True'/g" "$SEARX_SETTINGS_PATH"
 
        # start webapp
        $ sudo -H -u ${SERVICE_USER} -i


### PR DESCRIPTION
## What does this PR do?

Fixes a few details in the ['Step by step installation'](https://searx.github.io/searx/admin/installation-searx.html#installation-basic) documentation page.


## Why is this change important?

There are a few details that can make the install go wrong:

 * before doing `sudo -H cp "$SEARX_SRC/searx/settings.yml" "${SEARX_SETTINGS_PATH}"` , the destination path should have been created.  Added a line with `sudo -H mkdir -p "${SEARX_SETTINGS_PATH}"`.
 * In searx.sh , uncommented the definition of  `SEARX_INTERNAL_URL` environment variable in .config.sh , hoping that this will make the documentation more clear by pointing to a correct URL.

This fix should hopefully ease a bit the install process for newcomers.
