### PR TITLE
[mod] .travis.yml: build documentation automatically on the master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ after_success:
 
 stages:
   - test
+  - name: documentation
+    if: env(GITHUB_TOKEN) IS present
   - name: docker
     if: branch = master AND type != pull_request AND env(DOCKER_USERNAME) IS present
 
@@ -32,6 +34,26 @@ jobs:
     - python: "3.6"
     - python: "3.7"
     - python: "3.8"
+    - stage: documentation
+      python: "3.8"
+      addons: []
+      before_install:
+        - sudo ./utils/searx.sh install buildhost
+      install: true
+      script:
+        - SEARX_DEBUG=1 make travis-gh-pages
+      after_success: true
+      deploy:
+        provider: pages
+        edge: false
+        token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
+        strategy: git
+        skip_cleanup: true
+        keep_history: true
+        local_dir: gh-pages
+        target_branch: gh-pages
+        on:
+          branch: master
     - stage: docker
       python: "3.8"
       git:

--- a/utils/makefile.sphinx
+++ b/utils/makefile.sphinx
@@ -168,6 +168,11 @@ $(BOOKS_CLEAN):
 	       $(DOCS_BUILD)/latex/$(patsubst books/%.clean,%,$@)
 
 # github pages
+PHONY += prepare-gh-pages
+prepare-gh-pages:
+	cp -r $(DOCS_DIST)/* $(GH_PAGES)/
+	touch $(GH_PAGES)/.nojekyll
+	echo "<html><head><META http-equiv='refresh' content='0;URL=index.html'></head></html>" > $(GH_PAGES)/404.html	
 
 PHONY += $(GH_PAGES)
 $(GH_PAGES)::
@@ -176,14 +181,18 @@ $(GH_PAGES)::
 	-cd $(GH_PAGES); git checkout gh-pages >/dev/null
 	-cd $(GH_PAGES); git pull
 	-cd $(GH_PAGES); ls -A | grep -v '.git$$' | xargs rm -rf
-	cp -r $(DOCS_DIST)/* $(GH_PAGES)/
-	touch $(GH_PAGES)/.nojekyll
-	echo "<html><head><META http-equiv='refresh' content='0;URL=index.html'></head></html>" > $(GH_PAGES)/404.html
+	$(MAKE) prepare-gh-pages
 	cd $(GH_PAGES);\
 		git add --all . ;\
 		git commit -m "gh-pages: updated" ;\
 		git push origin gh-pages
 
+PHONY += travis-gh-pages
+travis-gh-pages:
+	$(MAKE) docs
+	rm -Rf $(GH_PAGES)
+	mkdir -p $(GH_PAGES)
+	$(MAKE) prepare-gh-pages
 
 PHONY += docs-clean
 docs-clean: $(BOOKS_CLEAN)


### PR DESCRIPTION
## What does this PR do?

Build the documentation on the gh-branch after each commit on the master branch (if a GITUHB_TOKEN is defined).

## Why is this change important?

The source code of the documentation is updated sometimes directly or indirectly.
With an automatic build of the documentation, we make sure the documentation is up to date.
More over, we make sure the documentation build process is not broken.

## How to test this PR locally?

See https://travis-ci.org/github/dalf/searx/builds/739669574

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Close https://github.com/searx/searx/issues/2258
Related to 
* https://github.com/searx/searx/issues/2279
* https://github.com/searx/searx/issues/2278 ( use `SEARX_DEBUG=1` as a prefix)
