### PR TITLE
[fix] make.run - use SEARX_DEBUG=1 instead of modifing settings.yml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,13 +66,10 @@ clean: pyclean docs-clean node.clean test.clean
 PHONY += run
 run:  buildenv pyenvinstall
 	$(Q) ( \
-	sed -i -e "s/debug : False/debug : True/g" ./searx/settings.yml ; \
 	sleep 2 ; \
 	xdg-open http://127.0.0.1:8888/ ; \
-	sleep 3 ; \
-	sed -i -e "s/debug : True/debug : False/g" ./searx/settings.yml ; \
 	) &
-	$(PY_ENV)/bin/python ./searx/webapp.py
+	SEARX_DEBUG=1 $(PY_ENV)/bin/python ./searx/webapp.py
 
 # docs
 # ----


### PR DESCRIPTION
## What does this PR do?

This PR fixes (only) the '`make run`' error from issue #2278

Reloading webapp.py when a file is changed exit with error::

    $ make run
    ....
    INFO:werkzeug: * Detected change in 'searx/searx/engines/deviantart.py', reloading
    INFO:werkzeug: * Restarting with stat
    ERROR:searx:server.secret_key is not changed. Please use something else instead of ultrasecretkey.
    make: *** [Makefile:69: run] Error 1

Patch suggested by @dalf 

## Why is this change important?

See https://github.com/searx/searx/issues/2278#issuecomment-719732579

## How to test this PR locally?

     make run
