### PR TITLE
Various bug fixes

### DIFF
--- a/searx/engines/command.py
+++ b/searx/engines/command.py
@@ -14,8 +14,8 @@ along with searx. If not, see < http://www.gnu.org/licenses/ >.
 '''
 
 
+import re
 from os.path import expanduser, isabs, realpath, commonprefix
-from re import MULTILINE, search as re_search
 from shlex import split as shlex_split
 from subprocess import Popen, PIPE
 from time import time
@@ -59,7 +59,7 @@ def init(engine_settings):
     if 'parse_regex' in engine_settings:
         parse_regex = engine_settings['parse_regex']
         for result_key, regex in parse_regex.items():
-            _compiled_parse_regex[result_key] = re.compile(regex, flags=MULTILINE)
+            _compiled_parse_regex[result_key] = re.compile(regex, flags=re.MULTILINE)
     if 'delimiter' in engine_settings:
         delimiter = engine_settings['delimiter']
 

--- a/searx/engines/scanr_structures.py
+++ b/searx/engines/scanr_structures.py
@@ -11,7 +11,7 @@
 """
 
 from json import loads, dumps
-from urllib.parse import html_to_text
+from searx.utils import html_to_text
 
 # engine dependent config
 categories = ['science']


### PR DESCRIPTION
## What does this PR do?

This PR fixes:
- the command engine
- the scanr_structures engine. Note: the certificate is valid valid, but the API has changed : .../api/v2/structures/search )
- the locked categories (in settings.yml). Note: when locked, the categories is set to general without choice :
https://github.com/searx/searx/blob/45f58a4a2a0b89f4b416c28ea769139b16f6436d/searx/preferences.py#L330

## Why is this change important?

Bug fixes.

## How to test this PR locally?

- command engine: check the example in settings.yml works as expected.
- scanr_structures: impossible to test since the API has changed (related to #2289 )
- locked categories: add in settings.yml
```yml
preferences:
    lock:
      - categories
```
and check the categories are locked (using a bang, a URL parameter, using the UI).

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
