### PR TITLE
[enh] add default http headers - closes #715

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -17,6 +17,12 @@ server:
     image_proxy : False # Proxying image results through searx
     http_protocol_version : "1.0"  # 1.0 and 1.1 are supported
     method: "POST" # POST queries are more secure as they don't show up in history but may cause problems when using Firefox containers
+    default_http_headers:
+        X-Content-Type-Options : nosniff
+        X-XSS-Protection : 1; mode=block
+        X-Download-Options : noopen
+        X-Robots-Tag : noindex, nofollow
+        Referrer-Policy : no-referrer
 
 ui:
     static_path : "" # Custom static path - leave it blank if you didn't change

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -488,6 +488,16 @@ def pre_request():
 
 
 @app.after_request
+def add_default_headers(response):
+    # set default http headers
+    for header, value in settings['server'].get('default_http_headers', {}).items():
+        if header in response.headers:
+            continue
+        response.headers[header] = value
+    return response
+
+
+@app.after_request
 def post_request(response):
     total_time = time() - request.start_time
     timings_all = ['total;dur=' + str(round(total_time * 1000, 3))]


### PR DESCRIPTION
## What does this PR do?

Adds default HTTP headers to every response. It is configurable from `settings.yml`.

## Why is this change important?

This PR provides better security/privacy defaults for searx instances.

## How to test this PR locally?

Easiest way is to call `curl -I http://127.0.0.1:8888/`. It can be also tested in browser with the HTTP inspector.

## Related issues

Closes #715

