### PR TITLE
pep8 to pycodestyle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ test.sh:
 test.pep8: pyenvinstall
 	@echo "TEST      pycodestyle (formerly pep8)"
 	$(Q)$(PY_ENV_ACT); pycodestyle --exclude='searx/static, searx/languages.py, searx/engines/gigablast.py' \
-        --max-line-length=120 --ignore "E402,W503" searx tests
+        --max-line-length=120 --ignore "E117,E252,E402,E722,E741,W503,W504,W605" searx tests
 
 test.unit: pyenvinstall
 	@echo "TEST      tests/unit"

--- a/Makefile
+++ b/Makefile
@@ -235,8 +235,8 @@ test.sh:
 	shellcheck -x .config.sh
 
 test.pep8: pyenvinstall
-	@echo "TEST      pep8"
-	$(Q)$(PY_ENV_ACT); pep8 --exclude='searx/static, searx/languages.py, searx/engines/gigablast.py' \
+	@echo "TEST      pycodestyle (formerly pep8)"
+	$(Q)$(PY_ENV_ACT); pycodestyle --exclude='searx/static, searx/languages.py, searx/engines/gigablast.py' \
         --max-line-length=120 --ignore "E402,W503" searx tests
 
 test.unit: pyenvinstall

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 mock==2.0.0
 nose2[coverage_plugin]==0.9.2
 cov-core==1.15.0
-pep8==1.7.0
+pycodestyle==2.6.0
 pylint==2.4.4
 plone.testing==5.0.0
 splinter==0.11.0


### PR DESCRIPTION
## What does this PR do?

change pep8 dev package requirement to latest pycodestyle

based on the readme from pycodestyle

> This package used to be called pep8 but was renamed to pycodestyle to reduce confusion

https://github.com/PyCQA/pycodestyle

as result makefile will use pycodestyle but test name will still be `test.pep8`

e: some error and warning will be ignored for now

## Why is this change important?

updated package is better

## How to test this PR locally?

```console
$ make clean test.pep8
```

e: updated with virtualenv
e2: chg based on suggestion

## Author's checklist

## Related issues
