### PR TITLE
[fix] fix of / and /search

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -537,10 +537,12 @@ def index():
 
     # redirect to search if there's a query in the request
     if request.form.get('q'):
-        return redirect(url_for('search'), 308)
+        query = ('?' + request.query_string.decode()) if request.query_string else ''
+        return redirect(url_for('search') + query, 308)
 
     return render(
         'index.html',
+        selected_categories=get_selected_categories(request.preferences, request.form),
     )
 
 
@@ -556,8 +558,8 @@ def search():
     if output_format not in ['html', 'csv', 'json', 'rss']:
         output_format = 'html'
 
-    # check if there is query
-    if request.form.get('q') is None:
+    # check if there is query (not None and not an empty string)
+    if not request.form.get('q'):
         if output_format == 'html':
             return render(
                 'index.html',

--- a/tests/unit/test_webapp.py
+++ b/tests/unit/test_webapp.py
@@ -75,9 +75,32 @@ class ViewsTestCase(SearxTestCase):
         self.assertEqual(result.status_code, 200)
         self.assertIn(b'<div class="title"><h1>searx</h1></div>', result.data)
 
-    def test_index_html(self):
+    def test_index_html_post(self):
         result = self.app.post('/', data={'q': 'test'})
         self.assertEqual(result.status_code, 308)
+        self.assertEqual(result.location, 'http://localhost/search')
+
+    def test_index_html_get(self):
+        result = self.app.post('/?q=test')
+        self.assertEqual(result.status_code, 308)
+        self.assertEqual(result.location, 'http://localhost/search?q=test')
+
+    def test_search_empty_html(self):
+        result = self.app.post('/search', data={'q': ''})
+        self.assertEqual(result.status_code, 200)
+        self.assertIn(b'<div class="title"><h1>searx</h1></div>', result.data)
+
+    def test_search_empty_json(self):
+        result = self.app.post('/search', data={'q': '', 'format': 'json'})
+        self.assertEqual(result.status_code, 400)
+
+    def test_search_empty_csv(self):
+        result = self.app.post('/search', data={'q': '', 'format': 'csv'})
+        self.assertEqual(result.status_code, 400)
+
+    def test_search_empty_rss(self):
+        result = self.app.post('/search', data={'q': '', 'format': 'rss'})
+        self.assertEqual(result.status_code, 400)
 
     def test_search_html(self):
         result = self.app.post('/search', data={'q': 'test'})


### PR DESCRIPTION
## What does this PR do?

* URL / : the index page displayed the selected or the default category.
* URL / : when the q parameter is set using the URL, the redirect includes the URL query.
* URL /search : an empty query doesn't raise an exception.
* improve the tests about the above use cases (see the result of `make test.coverage`)

## Why is this change important?

Various bug fixes.

Note: Chrome caches the HTTP redirect forever:
* https://superuser.com/questions/304589/how-can-i-make-chrome-stop-caching-redirects/869739#869739
* https://bugs.chromium.org/p/chromium/issues/detail?id=91740
* so `/?q=test` is cached forever even without this PR.
* The solution seems to add a `Cache-Control` header.

Currently, this PR doesn't fix this issue if this is a problem.

## How to test this PR locally?

* go to `/`, check the default category is selected.
* go to `/?categories=map`, check the map category is selected.
* go to `/?q=test&theme=simple`, check searx redirects to `/search?q=test&theme=simple`.
* go to `/search`, press enter : check there is no error.


## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
