### PR TITLE
Fix typo virualenv

### DIFF
--- a/docs/admin/installation-searx.rst
+++ b/docs/admin/installation-searx.rst
@@ -52,7 +52,7 @@ In the same shell create *virtualenv*:
    :end-before: END create virtualenv
 
 To install searx's dependencies, exit the searx *bash* session you opened above
-and restart a new.  Before install, first check if your *virualenv* was sourced
+and restart a new.  Before install, first check if your *virtualenv* was sourced
 from the login (*~/.profile*):
 
 .. kernel-include:: $DOCS_BUILD/includes/searx.rst

--- a/docs/dev/makefile.rst
+++ b/docs/dev/makefile.rst
@@ -68,7 +68,7 @@ Python environment
 
    ``source ./local/py3/bin/activate``
 
-With Makefile we do no longer need to build up the virualenv manually (as
+With Makefile we do no longer need to build up the virtualenv manually (as
 described in the :ref:`devquickstart` guide).  Jump into your git working tree
 and release a ``make pyenv``:
 


### PR DESCRIPTION
## What does this PR do?

Just change a small typo in documentation.


## Why is this change important?


"virtualenv" was obviously misspelt as "virualenv".

