### PR TITLE
[mod] searx.search: EngineRef, SearchQuery: add __repr__ and __eq__ methods

### DIFF
--- a/searx/search.py
+++ b/searx/search.py
@@ -57,8 +57,11 @@ class EngineRef:
         self.category = category
         self.from_bang = from_bang
 
-    def __str__(self):
-        return "(" + self.name + "," + self.category + "," + str(self.from_bang) + ")"
+    def __repr__(self):
+        return "EngineRef({!r}, {!r}, {!r})".format(self.name, self.category, self.from_bang)
+
+    def __eq__(self, other):
+        return self.name == other.name and self.category == other.category and self.from_bang == other.from_bang
 
 
 class SearchQuery:
@@ -87,8 +90,21 @@ class SearchQuery:
         self.timeout_limit = timeout_limit
         self.external_bang = external_bang
 
-    def __str__(self):
-        return self.query + ";" + str(self.engineref_list)
+    def __repr__(self):
+        return "SearchQuery({!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r})".\
+               format(self.query, self.engineref_list, self.categories, self.lang, self.safesearch,
+                      self.pageno, self.time_range, self.timeout_limit, self.external_bang)
+
+    def __eq__(self, other):
+        return self.query == other.query\
+            and self.engineref_list == other.engineref_list\
+            and self.categories == self.categories\
+            and self.lang == other.lang\
+            and self.safesearch == other.safesearch\
+            and self.pageno == other.pageno\
+            and self.time_range == other.time_range\
+            and self.timeout_limit == other.timeout_limit\
+            and self.external_bang == other.external_bang
 
 
 def send_http_request(engine, request_params):

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -21,6 +21,20 @@ TEST_ENGINES = [
 ]
 
 
+class SearchQueryTestCase(SearxTestCase):
+
+    def test_repr(self):
+        s = SearchQuery('test', [EngineRef('bing', 'general', False)], ['general'], 'all', 0, 1, '1', 5.0, 'g')
+        self.assertEqual(repr(s),
+                         "SearchQuery('test', [EngineRef('bing', 'general', False)], ['general'], 'all', 0, 1, '1', 5.0, 'g')")  # noqa
+
+    def test_eq(self):
+        s = SearchQuery('test', [EngineRef('bing', 'general', False)], ['general'], 'all', 0, 1, None, None, None)
+        t = SearchQuery('test', [EngineRef('google', 'general', False)], ['general'], 'all', 0, 1, None, None, None)
+        self.assertEqual(s, s)
+        self.assertNotEqual(s, t)
+
+
 class SearchTestCase(SearxTestCase):
 
     @classmethod

--- a/tests/unit/test_standalone_searx.py
+++ b/tests/unit/test_standalone_searx.py
@@ -7,6 +7,7 @@ import sys
 from mock import Mock, patch
 from nose2.tools import params
 
+from searx.search import SearchQuery
 from searx.testing import SearxTestCase
 
 
@@ -91,7 +92,7 @@ class StandaloneSearx(SearxTestCase):
         args = sas.parse_argument(['rain', ])
         search_q = sas.get_search_query(args)
         self.assertTrue(search_q)
-        self.assertEqual(str(search_q), 'rain;[]')
+        self.assertEqual(search_q, SearchQuery('rain', [], ['general'], 'all', 0, 1, None, None, None))
 
     def test_no_parsed_url(self):
         """test no_parsed_url func"""


### PR DESCRIPTION
## What does this PR do?

```python
a = searx.search.EngineRef('bing', 'general', False)
b = searx.search.EngineRef('google', 'general', False)
s = searx.search.SearchQuery('test', a, ['general'], 'all', 0, 1, '1', None, None)
t = searx.search.SearchQuery('test', b, ['general'], 'all', 0, 1, '1', None, None)
print(a)
print(b)
print(a == a)
print(a == b)
print(s)
print(t)
print(s == s)
print(s == t)
```

```
EngineRef('bing', 'general', False)
EngineRef('google', 'general', False)
True
False
SearchQuery('test', [EngineRef('bing', 'general', False)], ['general'], 'all', 0, 1, '1', None, None)
SearchQuery('test', [EngineRef('google', 'general', False)], ['general'], 'all', 0, 1, '1', None, None)
True
False
```

## Why is this change important?

* Help to debug https://github.com/searx/searx/pull/1591#issuecomment-723541549
* Might help debug later.

## How to test this PR locally?

`make test`

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
