### PR TITLE
[enh] Add multiple outgoing proxies

### DIFF
--- a/docs/admin/settings.rst
+++ b/docs/admin/settings.rst
@@ -36,18 +36,26 @@ Global Settings
        image_proxy : False           # proxying image results through searx
        default_locale : ""           # default interface locale
 
-   # uncomment below section if you want to use a proxy
+   outgoing: # communication with search engines
+       request_timeout : 2.0 # default timeout in seconds, can be override by engine
+       # max_request_timeout: 10.0 # the maximum timeout in seconds
+       useragent_suffix : "" # suffix of searx_useragent, could contain informations like an email address to the administrator
+       pool_connections : 100 # Number of different hosts
+       pool_maxsize : 10 # Number of simultaneous requests by host
 
-   #outgoing_proxies :
-   #    http : http://127.0.0.1:8080
-   #    https: http://127.0.0.1:8080
+       #proxies:
+       #    http:
+       #        - http://proxy1:8080
+       #        - http://proxy2:8080
+       #    https:
+       #        - http://proxy1:8080
+       #        - http://proxy2:8080
+       #        - socks5://user:password@proxy3:1080
+       #        - socks5h://user:password@proxy4:1080
 
-   # uncomment below section only if you have more than one network interface
-   # which can be the source of outgoing search requests
-
-   #source_ips:
-   #  - 1.1.1.1
-   #  - 1.1.1.2
+       #source_ips:
+       #    - 1.1.1.1
+       #    - 1.1.1.2
 
    locales:
        en : English
@@ -105,15 +113,16 @@ Global Settings
   code, like ``fr``, ``en``, ``de``.
 
 .. _requests proxies: http://requests.readthedocs.io/en/latest/user/advanced/#proxies
-.. _PR SOCKS support: https://github.com/kennethreitz/requests/pull/478
+.. _PySocks: https://pypi.org/project/PySocks/
 
-``outgoing_proxies`` :
-  Define a proxy you wish to use, see `requests proxies`_.  SOCKS proxies are
-  not supported / see `PR SOCKS support`.
+``proxies`` :
+  Define one or more proxies you wish to use, see `requests proxies`_.
+  If there are more than one proxy for one protocol (http, https),
+  requests to the engines are distributed in a round-robin fashion.
 
 ``source_ips`` :
   If you use multiple network interfaces, define from which IP the requests must
-  be made.
+  be made. This parameter is ignored when ``proxies`` is set.
 
 ``locales`` :
   Locales codes and their names.  Available translations of searx interface.
@@ -139,6 +148,15 @@ Engine settings
      api_key : 'apikey'
      disabled : True
      language : en_US
+     #proxies:
+     #    http:
+     #        - http://proxy1:8080
+     #        - http://proxy2:8080
+     #    https:
+     #        - http://proxy1:8080
+     #        - http://proxy2:8080
+     #        - socks5://user:password@proxy3:1080
+     #        - socks5h://user:password@proxy4:1080
 
 ``name`` :
   Name that will be used across searx to define this engine.  In settings, on

--- a/searx/search.py
+++ b/searx/search.py
@@ -119,7 +119,7 @@ def send_http_request(engine, request_params):
 
     # setting engine based proxies
     if hasattr(engine, 'proxies'):
-        request_args['proxies'] = engine.proxies
+        request_args['proxies'] = requests_lib.get_proxies(engine.proxies)
 
     # specific type of request (GET or POST)
     if request_params['method'] == 'GET':

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -63,13 +63,15 @@ outgoing: # communication with search engines
     pool_connections : 100 # Number of different hosts
     pool_maxsize : 10 # Number of simultaneous requests by host
 # uncomment below section if you want to use a proxy
-# see http://docs.python-requests.org/en/latest/user/advanced/#proxies
-# SOCKS proxies are also supported: see http://requests.readthedocs.io/en/master/user/advanced/#socks
-#    proxies :
-#        http : socks5h://127.0.0.1:9050
-#        https: socks5h://127.0.0.1:9050
-#    using_tor_proxy : True
-#    extra_proxy_timeout : 10.0 # Extra seconds to add in order to account for the time taken by the proxy
+# see https://2.python-requests.org/en/latest/user/advanced/#proxies
+# SOCKS proxies are also supported: see https://2.python-requests.org/en/latest/user/advanced/#socks
+#    proxies:
+#        http:
+#            - http://proxy1:8080
+#            - http://proxy2:8080
+#        https:
+#            - http://proxy1:8080
+#            - http://proxy2:8080
 # uncomment below section only if you have more than one network interface
 # which can be the source of outgoing search requests
 #    source_ips:

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -78,6 +78,7 @@ from searx.plugins import plugins
 from searx.plugins.oa_doi_rewrite import get_doi_resolver
 from searx.preferences import Preferences, ValidationException, LANGUAGE_CODES
 from searx.answerers import answerers
+from searx.poolrequests import get_global_proxies
 
 
 # serve pages with HTTP/1.1
@@ -148,8 +149,6 @@ _category_names = (gettext('files'),
                    gettext('map'),
                    gettext('onions'),
                    gettext('science'))
-
-outgoing_proxies = settings['outgoing'].get('proxies') or None
 
 _flask_babel_get_translations = flask_babel.get_translations
 
@@ -905,7 +904,7 @@ def image_proxy():
                         stream=True,
                         timeout=settings['outgoing']['request_timeout'],
                         headers=headers,
-                        proxies=outgoing_proxies)
+                        proxies=get_global_proxies())
 
     if resp.status_code == 304:
         return '', resp.status_code

--- a/tests/unit/test_poolrequests.py
+++ b/tests/unit/test_poolrequests.py
@@ -1,0 +1,89 @@
+from unittest.mock import patch
+from requests.models import Response
+
+from searx.testing import SearxTestCase
+
+import searx.poolrequests
+from searx.poolrequests import get_proxy_cycles, get_proxies
+
+
+CONFIG = {'http': ['http://localhost:9090', 'http://localhost:9092'],
+          'https': ['http://localhost:9091', 'http://localhost:9093']}
+
+
+class TestProxy(SearxTestCase):
+
+    def test_noconfig(self):
+        cycles = get_proxy_cycles(None)
+        self.assertIsNone(cycles)
+
+        cycles = get_proxy_cycles(False)
+        self.assertIsNone(cycles)
+
+    def test_oldconfig(self):
+        config = {
+            'http': 'http://localhost:9090',
+            'https': 'http://localhost:9091',
+        }
+        cycles = get_proxy_cycles(config)
+        self.assertEqual(next(cycles['http']), 'http://localhost:9090')
+        self.assertEqual(next(cycles['http']), 'http://localhost:9090')
+        self.assertEqual(next(cycles['https']), 'http://localhost:9091')
+        self.assertEqual(next(cycles['https']), 'http://localhost:9091')
+
+    def test_one_proxy(self):
+        config = {
+            'http': ['http://localhost:9090'],
+            'https': ['http://localhost:9091'],
+        }
+        cycles = get_proxy_cycles(config)
+        self.assertEqual(next(cycles['http']), 'http://localhost:9090')
+        self.assertEqual(next(cycles['http']), 'http://localhost:9090')
+        self.assertEqual(next(cycles['https']), 'http://localhost:9091')
+        self.assertEqual(next(cycles['https']), 'http://localhost:9091')
+
+    def test_multiple_proxies(self):
+        cycles = get_proxy_cycles(CONFIG)
+        self.assertEqual(next(cycles['http']), 'http://localhost:9090')
+        self.assertEqual(next(cycles['http']), 'http://localhost:9092')
+        self.assertEqual(next(cycles['http']), 'http://localhost:9090')
+        self.assertEqual(next(cycles['https']), 'http://localhost:9091')
+        self.assertEqual(next(cycles['https']), 'http://localhost:9093')
+        self.assertEqual(next(cycles['https']), 'http://localhost:9091')
+
+    def test_getproxies_none(self):
+        self.assertIsNone(get_proxies(None))
+
+    def test_getproxies_config(self):
+        cycles = get_proxy_cycles(CONFIG)
+        self.assertEqual(get_proxies(cycles), {
+            'http': 'http://localhost:9090',
+            'https': 'http://localhost:9091'
+        })
+        self.assertEqual(get_proxies(cycles), {
+            'http': 'http://localhost:9092',
+            'https': 'http://localhost:9093'
+        })
+
+    @patch('searx.poolrequests.get_global_proxies')
+    def test_request(self, mock_get_global_proxies):
+        method = 'GET'
+        url = 'http://localhost'
+        custom_proxies = {
+            'https': 'http://localhost:1080'
+        }
+        global_proxies = {
+            'http': 'http://localhost:9092',
+            'https': 'http://localhost:9093'
+        }
+        mock_get_global_proxies.return_value = global_proxies
+
+        # check the global proxies usage
+        with patch.object(searx.poolrequests.SessionSinglePool, 'request', return_value=Response()) as mock_method:
+            searx.poolrequests.request(method, url)
+        mock_method.assert_called_once_with(method=method, url=url, proxies=global_proxies)
+
+        # check if the proxies parameter overrides the global proxies
+        with patch.object(searx.poolrequests.SessionSinglePool, 'request', return_value=Response()) as mock_method:
+            searx.poolrequests.request(method, url, proxies=custom_proxies)
+        mock_method.assert_called_once_with(method=method, url=url, proxies=custom_proxies)


### PR DESCRIPTION
## What does this PR do?

credits go to @bauruine see https://github.com/searx/searx/pull/1958

Add support for multiple outgoing proxies.

## Why is this change important?

Public instances require often use multi proxies.
Without this PR, an additional proxy / dispatch layer is required.

Moreover it provides a way to dispatch the requests to different outgoing sources.

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

(should be part of the `make test`)

In one terminal:
```sh
pip install proxy.py
. ./local/py3/bin/activate 
proxy --hostname 127.0.0.1 --port 9000
```

In another terminal:
```
. ./local/py3/bin/activate 
proxy --hostname 127.0.0.1 --port 9001
```

In settings.yml
```
   outgoing:
       proxies:
           http:
               - http://localhost:9000
               - http://localhost:9001
           https:
               - http://localhost:9000
               - http://localhost:9001
```

Look at the proxy logs.

---

Second test with [ EDIT see [comment bellow](https://github.com/searx/searx/pull/2319#pullrequestreview-536045954) ] :
```
  - name : google
    engine : google
    shortcut : go
    outgoing:
       proxies:
           http:
               - http://localhost:9000
               - http://localhost:9001
           https:
               - http://localhost:9000
               - http://localhost:9001
```

Check that there are new connection for google in the proxy logs (there is some delay).

## Related issues

* Close https://github.com/searx/searx/pull/1958
* Close https://github.com/searx/searx/issues/1899
* Close https://github.com/searx/searx/issues/1512