### PR TITLE
[fix] fix a test_standalone_searx test case

### DIFF
--- a/tests/unit/test_standalone_searx.py
+++ b/tests/unit/test_standalone_searx.py
@@ -8,7 +8,8 @@ import sys
 from mock import Mock, patch
 from nose2.tools import params
 
-from searx.search import SearchQuery
+from searx.search import SearchQuery, EngineRef
+from searx.engines import initialize_engines
 from searx.testing import SearxTestCase
 
 
@@ -24,6 +25,13 @@ def get_standalone_searx_module():
 
 class StandaloneSearx(SearxTestCase):
     """Unit test for standalone_searx."""
+
+    @classmethod
+    def setUpClass(cls):
+        engine_list = [{'engine': 'dummy', 'name': 'engine1', 'shortcut': 'e1'},
+                       {'engine': 'dummy', 'name': 'engine2', 'shortcut': 'e2'}]
+
+        initialize_engines(engine_list)
 
     def test_parse_argument_no_args(self):
         """Test parse argument without args."""
@@ -95,7 +103,9 @@ class StandaloneSearx(SearxTestCase):
         args = sas.parse_argument(['rain', ])
         search_q = sas.get_search_query(args)
         self.assertTrue(search_q)
-        self.assertEqual(search_q, SearchQuery('rain', [], ['general'], 'all', 0, 1, None, None, None))
+        self.assertEqual(search_q, SearchQuery('rain', [EngineRef('engine1', 'general', False),
+                                                        EngineRef('engine2', 'general', False)],
+                         ['general'], 'all', 0, 1, None, None, None))
 
     def test_no_parsed_url(self):
         """test no_parsed_url func"""


### PR DESCRIPTION
## What does this PR do?

If test_engines_init.py runs before test_standalone_searx.py, the engine list is not empty.
It makes test_get_search_query flaky.

This commit initializes the engline list in test_standalone_searx.py

## Why is this change important?

Fix a flaky test with a well define runtime.

## How to test this PR locally?

... it is not easy to reproduce:
* @return42 has experienced this error
* the github action branch has the same error : see https://github.com/dalf/searx/runs/1411204212?check_suite_focus=true#step:6:167

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Related to : 
* https://github.com/searx/searx/pull/1591#issuecomment-723541549
* https://github.com/searx/searx/pull/2309

