### PR TITLE
Fix RuntimeError during search with translated errors

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -735,12 +735,12 @@ def search():
 
 
 def __get_translated_errors(unresponsive_engines):
-    translated_errors = []
+    translated_errors = set()
     for unresponsive_engine in unresponsive_engines:
         error_msg = gettext(unresponsive_engine[1])
         if unresponsive_engine[2]:
             error_msg = "{} {}".format(error_msg, unresponsive_engine[2])
-        translated_errors.append((unresponsive_engine[0], error_msg))
+        translated_errors.add((unresponsive_engine[0], error_msg))
     return translated_errors
 
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes the following runtime error:
```
 File "/usr/local/searx/searx-src/searx/webapp.py", line 704, in index
    unresponsive_engines=__get_translated_errors(result_container.unresponsive_engines),
  File "/usr/local/searx/searx-src/searx/webapp.py", line 717, in __get_translated_errors
    for unresponsive_engine in unresponsive_engines:
RuntimeError: Set changed size during iteration
```

The error happens because sets cannot be modified during iteration.

## Why is this change important?

Previously `__get_translated_errors` returned a list of translated error messages. But `unresponsive_engines` is a set.

## Related issues

Closes #2305