### PR TITLE
WIP: feat(engine): support DICT protocol, add dict engine

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pyopenssl==19.1.0
 python-dateutil==2.8.0
 pyyaml==5.3.1
 requests[socks]==2.24.0
+py-dict-client==0.1.4

--- a/searx/dict_client.py
+++ b/searx/dict_client.py
@@ -1,0 +1,75 @@
+from time import time
+from urllib.parse import urlparse
+from dictionary_client import DictionaryClient
+from threading import local
+
+import requests
+import socks
+
+from searx import settings
+
+proxyTypes = dict(
+    socks5=socks.SOCKS5,
+    socks4=socks.SOCKS4,
+    http=socks.HTTP
+)
+
+threadLocal = local()
+connect = settings['outgoing'].get('pool_connections', 100)  # Magic number kept from previous code
+maxsize = settings['outgoing'].get('pool_maxsize', requests.adapters.DEFAULT_POOLSIZE)  # Picked from constructor
+
+def dict_request(method, query, **kwargs):
+    time_before_request = time()
+
+    # timeout
+    if 'timeout' in kwargs:
+        timeout = kwargs['timeout']
+    else:
+        timeout = getattr(threadLocal, 'timeout', None)
+        if timeout is not None:
+            kwargs['timeout'] = timeout
+
+    dc = DictionaryClient(host=kwargs['host'], port=kwargs['port'], sock_class=socks.socksocket)
+
+    # get proxy config
+    proxies = kwargs.get('proxies')
+    if proxies is None:
+        proxies = settings['outgoing'].get('proxies')
+    if proxies is not None and 'dict' in proxies:
+        parsedProxy = urlparse(proxies['dict'])
+        proxyType = proxyTypes.get(parsedProxy.scheme, None)
+        dc.sock.setProxy(proxyType, parsedProxy.hostname, parsedProxy.port)
+
+    # map available dict methods
+    dict_methods = dict(
+        define=dc.define,
+        match=dc.match
+    )
+    dict_response = dict_methods.get(method)(query, db=kwargs['db'])
+    response = dict(
+        content=dict_response.content,
+        databases=dc.databases
+    )
+
+    # request finished here
+    time_after_request = time()
+
+    # is there a timeout for this engine ?
+    if timeout is not None:
+        timeout_overhead = 0.2  # seconds
+        # start_time = when the user request started
+        start_time = getattr(threadLocal, 'start_time', time_before_request)
+        search_duration = time_after_request - start_time
+        if search_duration > timeout + timeout_overhead:
+            raise requests.exceptions.Timeout(response=response)
+
+    dc.disconnect()
+
+    if hasattr(threadLocal, 'total_time'):
+        threadLocal.total_time += time_after_request - time_before_request
+
+    return response
+
+
+def dict_define(query, **kwargs):
+    return dict_request('define', query, **kwargs)

--- a/searx/engines/dict.py
+++ b/searx/engines/dict.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+"""
+ DICT protocol
+ @website     https://tools.ietf.org/html/rfc2229
+ @provide-api yes
+ @using-api   yes
+ @results     DICT
+ @stable      yes
+ @parse       title, content
+"""
+
+from dictionary_client import DictionaryClient
+
+categories = ['general']
+paging = False
+db = '*'
+host = 'localhost'
+port = 2628
+result_template = 'dict.html'
+DICT = True
+
+
+def request(query, params):
+    params['query'] = query
+    params['method'] = 'define'
+    return params
+
+
+def response(resp):
+    results = []
+    if not resp or not resp['content']:
+        return results
+
+    for definition in resp['content']:
+        results.append({
+            'title': resp['databases'][definition['db']],
+            'content': definition['definition'],
+            'template': 'dict.html'
+        })
+    return results

--- a/searx/poolrequests.py
+++ b/searx/poolrequests.py
@@ -4,6 +4,7 @@ from itertools import cycle
 from threading import RLock, local
 
 import requests
+import socks
 
 from searx import settings
 from searx import logger
@@ -79,7 +80,6 @@ if settings['outgoing'].get('source_ips'):
 else:
     http_adapters = cycle((HTTPAdapterWithConnParams(pool_connections=connect, pool_maxsize=maxsize), ))
     https_adapters = cycle((HTTPAdapterWithConnParams(pool_connections=connect, pool_maxsize=maxsize), ))
-
 
 class SessionSinglePool(requests.Session):
 

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -68,6 +68,7 @@ outgoing: # communication with search engines
 #    proxies :
 #        http : socks5h://127.0.0.1:9050
 #        https: socks5h://127.0.0.1:9050
+#        dict: socks5h://127.0.0.1:9050
 #    using_tor_proxy : True
 #    extra_proxy_timeout : 10.0 # Extra seconds to add in order to account for the time taken by the proxy
 # uncomment below section only if you have more than one network interface
@@ -996,6 +997,19 @@ engines:
 #    engine : doku
 #    shortcut : uw
 #    base_url : 'http://doc.ubuntu-fr.org'
+
+# - name : dictd
+#   # localhost and all db by default
+#   engine : dict
+#   shortcut : d
+#   timeout : 1.0
+
+# - name : 'dict.org'
+#   engine : dict
+#   host : 'dict.org'
+#   port : 2628
+#   db : '*'
+#   timeout : 3.0
 
 # Be careful when enabling this engine if you are
 # running a public instance. Do not expose any sensitive

--- a/searx/templates/oscar/result_templates/dict.html
+++ b/searx/templates/oscar/result_templates/dict.html
@@ -1,0 +1,17 @@
+{% from 'oscar/macros.html' import result_header, result_footer, result_footer_rtl, icon %}
+
+{{ result_header(result, favicons, loop.index) }}
+
+<div class="panel panel-default">
+{%- if result.content %}<p class="result-content">
+  {% for line in result.content.split('\n') %}
+  {{ line | safe }}<br />
+  {% endfor %} 
+</p>{% endif -%}
+</div>
+
+{% if rtl %}
+{{ result_footer_rtl(result, loop.index) }}
+{% else %}
+{{ result_footer(result, loop.index) }}
+{% endif %}

--- a/searx/templates/simple/result_templates/dict.html
+++ b/searx/templates/simple/result_templates/dict.html
@@ -1,0 +1,11 @@
+{% from 'simple/macros.html' import result_header, result_sub_footer, result_footer, result_footer_rtl, result_link %}
+
+{{ result_header(result, favicons, image_proxify) -}}
+{%- if result.content %}<p class="content">
+  {% for line in result.content.split('\n') %}
+  {{ line | safe }}<br />
+  {% endfor %} 
+</p>{% endif -%}
+
+{{- result_sub_footer(result, proxify) -}}
+{{- result_footer(result) }}


### PR DESCRIPTION
This adds support for [DICT protocol](https://en.wikipedia.org/wiki/DICT).

DICT is very simple to use, so on average linux distro this should work like `sudo apt install dictd dict-freedict-eng-jpn` which allows you to query your localhost dictd server. You can also use remote DICT server, like dict.org.

As DICT is not HTTP, this requires more changes than usual for a new engine. In current state it works for me, but I probably missed something in implementation, so I ask for additional feedback.

![searx_dict cleaned](https://user-images.githubusercontent.com/1848785/99884432-253bfd80-2c26-11eb-8058-3a69b8089f74.png)


## Checklist

- [ ] : add unit tests
