### PR TITLE
Add preference for displaying advanced settings

### DIFF
--- a/searx/preferences.py
+++ b/searx/preferences.py
@@ -395,6 +395,15 @@ class Preferences:
                 settings['ui'].get('theme_args', {}).get('oscar_style', 'logicodev'),
                 is_locked('oscar-style'),
                 choices=['', 'logicodev', 'logicodev-dark', 'pointhi']),
+            'advanced_search': MapSetting(
+                settings['ui'].get('advanced_search', False),
+                map={
+                    '0': False,
+                    '1': True,
+                    'False': False,
+                    'True': True
+                }
+            ),
         }
 
         self.engines = EnginesSetting('engines', choices=engines)

--- a/searx/preferences.py
+++ b/searx/preferences.py
@@ -397,11 +397,13 @@ class Preferences:
                 choices=['', 'logicodev', 'logicodev-dark', 'pointhi']),
             'advanced_search': MapSetting(
                 settings['ui'].get('advanced_search', False),
+                is_locked('advanced_search'),
                 map={
                     '0': False,
                     '1': True,
                     'False': False,
-                    'True': True
+                    'True': True,
+                    'on': True,
                 }
             ),
         }

--- a/searx/templates/oscar/preferences.html
+++ b/searx/templates/oscar/preferences.html
@@ -140,6 +140,15 @@
                     {{ preferences_item_footer(info, label, rtl) }}
                     {% endif %}
 
+                    {% set label = _('Show advanced settings') %}
+                    {% set info = _('Show advanced settings panel in the home page by default') %}
+                    {{ preferences_item_header(info, label, rtl, 'advanced_search') }}
+                        <select class="form-control {{ custom_select_class(rtl) }}" name="advanced_search" id="advanced_search">
+                            <option value="1" {% if preferences.get_value('advanced_search')%}selected="selected"{% endif %}>{{ _('On') }}</option>
+                            <option value="0" {% if not preferences.get_value('advanced_search')%}selected="selected"{% endif %}>{{ _('Off')}}</option>
+                        </select>
+                    {{ preferences_item_footer(info, label, rtl) }}
+
                     {% if 'doi_resolver' not in locked_preferences %}
                     {% set label = _('Open Access DOI resolver') %}
                     {% set info = _('Redirect to open-access versions of publications when available (plugin required)') %}

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -545,6 +545,9 @@ def index_error(output_format, error_message):
 def index():
     """Render index page."""
 
+    # UI
+    advanced_search = request.form.get('advanced_search', request.preferences.get_value('advanced_search'))
+
     # redirect to search if there's a query in the request
     if request.form.get('q'):
         query = ('?' + request.query_string.decode()) if request.query_string else ''
@@ -553,6 +556,7 @@ def index():
     return render(
         'index.html',
         selected_categories=get_selected_categories(request.preferences, request.form),
+        advanced_search=advanced_search,
     )
 
 

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -546,7 +546,7 @@ def index():
     """Render index page."""
 
     # UI
-    advanced_search = request.form.get('advanced_search', request.preferences.get_value('advanced_search'))
+    advanced_search = request.preferences.get_value('advanced_search')
 
     # redirect to search if there's a query in the request
     if request.form.get('q'):
@@ -611,7 +611,7 @@ def search():
         return redirect(result_container.redirect_url)
 
     # UI
-    advanced_search = request.form.get('advanced_search', None)
+    advanced_search = request.preferences.get_value('advanced_search')
 
     # Server-Timing header
     request.timings = result_container.get_timings()

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -577,6 +577,7 @@ def search():
         if output_format == 'html':
             return render(
                 'index.html',
+                advanced_search=request.preferences.get_value('advanced_search')
                 selected_categories=get_selected_categories(request.preferences, request.form),
             )
         else:
@@ -611,7 +612,10 @@ def search():
         return redirect(result_container.redirect_url)
 
     # UI
-    advanced_search = request.preferences.get_value('advanced_search')
+    # 'q' in request.from, possible value from request.form.get('advanced_search'):
+    # * 'on': the checkbox is checked
+    # * None: the checkbox is unchecked or request is sent from opensearch.xml
+    advanced_search = request.form.get('advanced_search')
 
     # Server-Timing header
     request.timings = result_container.get_timings()

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -577,7 +577,7 @@ def search():
         if output_format == 'html':
             return render(
                 'index.html',
-                advanced_search=request.preferences.get_value('advanced_search')
+                advanced_search=request.preferences.get_value('advanced_search'),
                 selected_categories=get_selected_categories(request.preferences, request.form),
             )
         else:

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -611,12 +611,6 @@ def search():
     if result_container.redirect_url:
         return redirect(result_container.redirect_url)
 
-    # UI
-    # 'q' in request.from, possible value from request.form.get('advanced_search'):
-    # * 'on': the checkbox is checked
-    # * None: the checkbox is unchecked or request is sent from opensearch.xml
-    advanced_search = request.form.get('advanced_search')
-
     # Server-Timing header
     request.timings = result_container.get_timings()
 
@@ -725,7 +719,6 @@ def search():
         pageno=search_query.pageno,
         time_range=search_query.time_range,
         number_of_results=format_decimal(number_of_results),
-        advanced_search=advanced_search,
         suggestions=suggestion_urls,
         answers=result_container.answers,
         corrections=correction_urls,


### PR DESCRIPTION
## What does this PR do?

Fix #696, as suggested by a [comment](https://github.com/searx/searx/issues/696#issuecomment-713047361) there

## Why is this change important?

See #696 

## How to test this PR locally?

Just pull, then open preferences, set Show Advanced Settings to On, then reopen the index page

## Author's checklist

I simply executed the changes as stated in the comment, but I don't fully understand them, so there needs to be a review.

Also, if I add a `advanced_search : True` line under `ui:` in `/etc/searx/settings.yml`, whenever I make a search I get a banner saying "Error: invalid preferences". I don't know if that's intentional; it would be nice anyway if the default setting could be set in `/etc/searx/settings.yml` (which is what I was trying to do), and if this PR does not do that, or does in a broken way, I am willing to make the required changes, provided that I get a little bit of help on how to do that :)

## Related issues

Closes #696 

