### PR TITLE
Photon API Link Update

### DIFF
--- a/searx/engines/photon.py
+++ b/searx/engines/photon.py
@@ -21,7 +21,7 @@ language_support = True
 number_of_results = 10
 
 # search-url
-base_url = 'https://photon.komoot.de/'
+base_url = 'https://photon.komoot.io/'
 search_string = 'api/?{query}&limit={limit}'
 result_base_url = 'https://openstreetmap.org/{osm_type}/{osm_id}'
 


### PR DESCRIPTION
**Until October 2020 the API was available under photon.komoot.de. Requests still work as they redirected to photon.komoot.io but please update your apps accordingly.**

**Via:** https://photon.komoot.io/
