### PR TITLE
[fix] settings_loader: don't crash when a key exists only in the user settings

### DIFF
--- a/searx/settings_loader.py
+++ b/searx/settings_loader.py
@@ -57,7 +57,10 @@ def update_settings(default_settings, user_settings):
     # merge everything except the engines
     for k, v in user_settings.items():
         if k not in ('use_default_settings', 'engines'):
-            update_dict(default_settings[k], v)
+            if k in default_settings:
+                update_dict(default_settings[k], v)
+            else:
+                default_settings[k] = v
 
     # parse the engines
     remove_engines = None

--- a/tests/unit/settings/user_settings_simple.yml
+++ b/tests/unit/settings/user_settings_simple.yml
@@ -4,3 +4,6 @@ server:
     bind_address: "0.0.0.0"
     default_http_headers:
         Custom-Header: Custom-Value
+result_proxy:
+   url : https://localhost/morty
+   key : "$ecretKey"


### PR DESCRIPTION
## What does this PR do?

typical use case: result_proxy can be defined in the user settings,
but are not defined the default settings.yml

## Why is this change important?

Don't crash when using this settings:
```yaml
use_default_settings: True
result_proxy:
   url : https://localhost/morty
   key : "$ecretKey"
```

`result_proxy` is not define in settings.yml:
https://github.com/searx/searx/blob/89fbb85d454959be725cd4ca19c36c31d05d3289/searx/settings.yml#L55-L57

## How to test this PR locally?

* `make test`: `tests/unit/settings/user_settings_simple.yml` is modified to test this use case.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Related to #2291
