### PR TITLE
[mod] stackoverflow & yandex: detect CAPTCHA response

### DIFF
--- a/searx/engines/stackoverflow.py
+++ b/searx/engines/stackoverflow.py
@@ -10,9 +10,10 @@
  @parse       url, title, content
 """
 
-from urllib.parse import urlencode, urljoin
+from urllib.parse import urlencode, urljoin, urlparse
 from lxml import html
 from searx.utils import extract_text
+from searx.exceptions import SearxEngineCaptchaException
 
 # engine dependent config
 categories = ['it']
@@ -37,6 +38,10 @@ def request(query, params):
 
 # get response from search-request
 def response(resp):
+    resp_url = urlparse(resp.url)
+    if resp_url.path.startswith('/nocaptcha'):
+        raise SearxEngineCaptchaException()
+
     results = []
 
     dom = html.fromstring(resp.text)

--- a/searx/engines/yandex.py
+++ b/searx/engines/yandex.py
@@ -9,9 +9,10 @@
  @parse       url, title, content
 """
 
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 from lxml import html
 from searx import logger
+from searx.exceptions import SearxEngineCaptchaException
 
 logger = logger.getChild('yandex engine')
 
@@ -47,6 +48,10 @@ def request(query, params):
 
 # get response from search-request
 def response(resp):
+    resp_url = urlparse(resp.url)
+    if resp_url.path.startswith('/showcaptcha'):
+        raise SearxEngineCaptchaException()
+
     dom = html.fromstring(resp.text)
     results = []
 


### PR DESCRIPTION
## What does this PR do?

yandex & stackoverflow engines raise `searx.exceptions.SearxEngineCaptchaException` when the response is CAPTCHA

## Why is this change important?

* report the right error message to the user
* record the error message (see #2332)

## How to test this PR locally?

* repeat some search using yandex and stackoverflow.

## Author's checklist

N/A

## Related issues

Related to #2332
