### PR TITLE
[fix] wikidata: fix crash when the item has no description at all and…

### DIFF
--- a/searx/engines/wikidata.py
+++ b/searx/engines/wikidata.py
@@ -190,7 +190,7 @@ def get_results(attribute_result, attributes, language):
     infobox_id_lang = None
     infobox_urls = []
     infobox_attributes = []
-    infobox_content = attribute_result.get('itemDescription')
+    infobox_content = attribute_result.get('itemDescription', [])
     img_src = None
     img_src_priority = 100
 


### PR DESCRIPTION
## What does this PR do?

Fix a crash when a wikidata item has:
* no description at all (whatever the language)
* at least one URL

In this case and without this PR, `infobox_content` is None function, later `len(infobox_content)` raises an exception.

## Why is this change important?

Bug fix.

## How to test this PR locally?

I can't a wikidata item that match these criteria, but reading the code the `len(None)` makes sense (spotted with /stats/errors ).

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
