### PR TITLE
[fix] wikipedia engine: don't raise an error when the query is not found

### DIFF
--- a/docs/dev/engine_overview.rst
+++ b/docs/dev/engine_overview.rst
@@ -134,9 +134,9 @@ The function ``def request(query, params):`` always returns the ``params``
 variable.  Inside searx, the following paramters can be used to specify a search
 request:
 
-================== =========== ========================================================================
+================== =========== ==========================================================================
 argument           type        information
-================== =========== ========================================================================
+================== =========== ==========================================================================
 url                string      requested url
 method             string      HTTP request method
 headers            set         HTTP header information
@@ -145,7 +145,8 @@ cookies            set         HTTP cookies
 verify             boolean     Performing SSL-Validity check
 max_redirects      int         maximum redirects, hard limit
 soft_max_redirects int         maximum redirects, soft limit. Record an error but don't stop the engine
-================== =========== ========================================================================
+raise_for_status   bool        True by default: raise an exception if the HTTP code of response is >= 300
+================== =========== ==========================================================================
 
 
 example code

--- a/searx/engines/wikipedia.py
+++ b/searx/engines/wikipedia.py
@@ -37,13 +37,15 @@ def request(query, params):
                                       language=url_lang(params['language']))
 
     params['headers']['User-Agent'] = searx_useragent()
+    params['raise_for_status'] = False
+    params['soft_max_redirects'] = 2
 
     return params
 
 
 # get response from search-request
 def response(resp):
-    if not resp.ok:
+    if resp.status_code == 404:
         return []
 
     results = []

--- a/searx/search.py
+++ b/searx/search.py
@@ -143,7 +143,8 @@ def send_http_request(engine, request_params):
     response = req(request_params['url'], **request_args)
 
     # check HTTP status
-    response.raise_for_status()
+    if request_params.get('raise_for_status'):
+        response.raise_for_status()
 
     # check soft limit of the redirect count
     if len(response.history) > soft_max_redirects:
@@ -340,7 +341,8 @@ def default_request_params():
         'url': '',
         'cookies': {},
         'verify': True,
-        'auth': None
+        'auth': None,
+        'raise_for_status': True
     }
 
 


### PR DESCRIPTION
## What does this PR do?

Add a new [parsed parameter](https://searx.github.io/searx/dev/engine_overview.html#parsed-arguments): `raise_for_status`, set by default to True.
When True, any HTTP status code >= 300 raise an exception ( it is the case since #2332 )
When False, the engine can manage the HTTP status code by itself (as it was the case before #2332 )

## Why is this change important?

Since  #2332 , each time an query is not found by the wikipedia engine, there is this error message:
![image](https://user-images.githubusercontent.com/1594191/101204371-67286300-366c-11eb-878f-ed8f09d28b6e.png)

There is actually not error. This PR fix this problem.

## How to test this PR locally?

* search for `!wp gfdgdf`

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
