### PR TITLE
[fix] duckduckgo_definitions: fix relative image URL

### DIFF
--- a/searx/engines/duckduckgo_definitions.py
+++ b/searx/engines/duckduckgo_definitions.py
@@ -10,7 +10,7 @@ DuckDuckGo (definitions)
 """
 
 import json
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse, urljoin
 from lxml import html
 
 from searx import logger
@@ -102,6 +102,8 @@ def response(resp):
     # image
     image = search_res.get('Image')
     image = None if image == '' else image
+    if image is not None and urlparse(image).netloc == '':
+        image = urljoin('https://duckduckgo.com', image)
 
     # urls
     # Official website, Wikipedia page


### PR DESCRIPTION
## What does this PR do?

since few days (weeks ?), duckduckgo_definition returns relative URL to https://duckduckgo.com/

## Why is this change important?

without this PR, images are not found.

## How to test this PR locally?

search for `!ddd searx`.

## Author's checklist

N/A

## Related issues

N/A
