### PR TITLE
[fix] command engine: SearchQuery.query is str not bytes

### DIFF
--- a/searx/engines/command.py
+++ b/searx/engines/command.py
@@ -80,7 +80,7 @@ def search(query, params):
 
 
 def _get_command_to_run(query):
-    params = shlex_split(query.decode('utf-8'))
+    params = shlex_split(query)
     __check_query_params(params)
 
     cmd = []


### PR DESCRIPTION


## What does this PR do?

Close #2355

see c225db45c8a4ab466bff049216f7e0189dc1b067 (drop Python 2 PR #2137)

## Why is this change important?

The command engine doesn't work without this PR.

## How to test this PR locally?

As described in #2355 (or example provides in settings.yml):

```yaml
  - name: locate
    engine: command
    command: ['locate', '--existing', '--ignore-case', '{{QUERY}}']
    shortcut: locate
    tokens: []
    disabled: False
    delimiter:
        chars: ' '
        keys: ['line']
```

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Close #2355
