### PR TITLE
[mod] libgen: update the URL to http://libgen.rs/

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -490,7 +490,7 @@ engines:
 
   - name : library genesis
     engine : xpath
-    search_url : https://libgen.is/search.php?req={query}
+    search_url : http://libgen.rs/search.php?req={query}
     url_xpath : //a[contains(@href,"bookfi.net")]/@href
     title_xpath : //a[contains(@href,"book/")]/text()[1]
     content_xpath : //td/a[1][contains(@href,"=author")]/text()


### PR DESCRIPTION
## What does this PR do?

https://libgen.is actually redirect to http://libgen.rs/

It seems there is no HTTPS version:
* https://www.wikidata.org/wiki/Q22017206
* https://librarygenesis.net/

## Why is this change important?

* avoid one redirect
* misleading HTTPS, it is actually an HTTP website.

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
