### PR TITLE
[doc] recommend to use 'use_default_settings=True'

### DIFF
--- a/.config.sh
+++ b/.config.sh
@@ -26,6 +26,7 @@ fi
 # ---------
 
 # SEARX_INTERNAL_URL="127.0.0.1:8888"
+# SEARX_SETTINGS_TEMPLATE="${REPO_ROOT}/utils/templates/etc/searx/use_default_settings.yml"
 
 # Only change, if you maintain a searx brand in your searx fork.
 # GIT_BRANCH="${GIT_BRANCH:-master}"

--- a/docs/admin/installation-searx.rst
+++ b/docs/admin/installation-searx.rst
@@ -64,16 +64,37 @@ from the login (*~/.profile*):
    Open a second terminal for the configuration tasks and left the ``(searx)$``
    terminal open for the tasks below.
 
-Configuration
-==============
 
-Create a copy of the :origin:`searx/settings.yml` configuration file in system's
-*/etc* folder.  Configure like shown below -- replace ``searx@\$(uname -n)`` with
-a name of your choice -- *and/or* edit ``/etc/searx/settings.yml`` if necessary.
+.. _use_default_settings.yml:
+
+Configuration
+=============
+
+To create a initial ``/etc/searx/settings.yml`` you can start with a copy of the
+file :origin:`utils/templates/etc/searx/use_default_settings.yml`.  This setup
+:option:ref:`use default settings <settings use_default_settings>` from
+:origin:`searx/settings.yml` and is recommended since :pull:`2291` is merged.
+
+For minimal Setup, configure like shown below – replace ``searx@\$(uname -n)``
+with a name of your choice, set ``ultrasecretkey`` -- *and/or* edit
+``/etc/searx/settings.yml`` to your needs.
 
 .. kernel-include:: $DOCS_BUILD/includes/searx.rst
    :start-after: START searx config
    :end-before: END searx config
+
+.. tabs::
+
+  .. group-tab:: Use default settings
+
+    .. literalinclude:: ../../utils/templates/etc/searx/use_default_settings.yml
+       :language: yaml
+
+  .. group-tab:: searx/settings.yml
+
+    .. literalinclude:: ../../searx/settings.yml
+       :language: yaml
+
 
 Check
 =====

--- a/docs/build-templates/searx.rst
+++ b/docs/build-templates/searx.rst
@@ -128,12 +128,28 @@ ${fedora_build}
 
 .. tabs::
 
-  .. group-tab:: bash
+  .. group-tab:: Use default settings
 
     .. code-block:: sh
 
        $ sudo -H mkdir -p \"$(dirname ${SEARX_SETTINGS_PATH})\"
-       $ sudo -H cp \"$SEARX_SRC/searx/settings.yml\" \"${SEARX_SETTINGS_PATH}\"
+       $ sudo -H cp \"$SEARX_SRC/utils/templates/etc/searx/use_default_settings.yml\" \\
+                    \"${SEARX_SETTINGS_PATH}\"
+
+  .. group-tab:: searx/settings.yml
+
+    .. code-block:: sh
+
+       $ sudo -H mkdir -p \"$(dirname ${SEARX_SETTINGS_PATH})\"
+       $ sudo -H cp \"$SEARX_SRC/searx/settings.yml\" \\
+                    \"${SEARX_SETTINGS_PATH}\"
+
+.. tabs::
+
+  .. group-tab:: minimal setup
+
+    .. code-block:: sh
+
        $ sudo -H sed -i -e \"s/ultrasecretkey/\$(openssl rand -hex 16)/g\" \"$SEARX_SETTINGS_PATH\"
        $ sudo -H sed -i -e \"s/{instance_name}/searx@\$(uname -n)/g\" \"$SEARX_SETTINGS_PATH\"
 

--- a/utils/searx.sh
+++ b/utils/searx.sh
@@ -36,6 +36,7 @@ GIT_BRANCH="${GIT_BRANCH:-master}"
 SEARX_PYENV="${SERVICE_HOME}/searx-pyenv"
 SEARX_SRC="${SERVICE_HOME}/searx-src"
 SEARX_SETTINGS_PATH="/etc/searx/settings.yml"
+SEARX_SETTINGS_TEMPLATE="${REPO_ROOT}/utils/templates/etc/searx/use_default_settings.yml"
 SEARX_UWSGI_APP="searx.ini"
 # shellcheck disable=SC2034
 SEARX_UWSGI_SOCKET="/run/uwsgi/app/searx/socket"
@@ -139,7 +140,7 @@ usage() {
     cat <<EOF
 usage::
   $(basename "$0") shell
-  $(basename "$0") install    [all|user|searx-src|pyenv|uwsgi|packages|buildhost]
+  $(basename "$0") install    [all|user|searx-src|pyenv|uwsgi|packages|settings|buildhost]
   $(basename "$0") update     [searx]
   $(basename "$0") remove     [all|user|pyenv|searx-src]
   $(basename "$0") activate   [service]
@@ -413,14 +414,14 @@ install_settings() {
     if [[ ! -f ${SEARX_SETTINGS_PATH} ]]; then
         info_msg "install settings ${REPO_ROOT}/searx/settings.yml"
         info_msg "  --> ${SEARX_SETTINGS_PATH}"
-        cp "${REPO_ROOT}/searx/settings.yml" "${SEARX_SETTINGS_PATH}"
+        cp "${SEARX_SETTINGS_TEMPLATE}" "${SEARX_SETTINGS_PATH}"
         configure_searx
         return
     fi
 
     rst_para "Diff between origin's setting file (+) and current (-):"
-    echo
-    $DIFF_CMD "${SEARX_SETTINGS_PATH}" "${SEARX_SRC}/searx/settings.yml"
+    echo "${SEARX_SETTINGS_PATH}" "${SEARX_SETTINGS_TEMPLATE}"
+    $DIFF_CMD "${SEARX_SETTINGS_PATH}" "${SEARX_SETTINGS_TEMPLATE}"
 
     local action
     choose_one action "What should happen to the settings file? " \
@@ -434,7 +435,7 @@ install_settings() {
         "use origin settings")
             backup_file "${SEARX_SETTINGS_PATH}"
             info_msg "install origin settings"
-            cp "${SEARX_SRC}/searx/settings.yml" "${SEARX_SETTINGS_PATH}"
+            cp "${SEARX_SETTINGS_TEMPLATE}" "${SEARX_SETTINGS_PATH}"
             ;;
         "start interactiv shell")
             backup_file "${SEARX_SETTINGS_PATH}"
@@ -442,7 +443,7 @@ install_settings() {
             sudo -H -i
             rst_para 'Diff between new setting file (-) and current (+):'
             echo
-            $DIFF_CMD "${SEARX_SRC}/searx/settings.yml" "${SEARX_SETTINGS_PATH}"
+            $DIFF_CMD "${SEARX_SETTINGS_TEMPLATE}" "${SEARX_SETTINGS_PATH}"
             wait_key
             ;;
     esac

--- a/utils/templates/etc/searx/use_default_settings.yml
+++ b/utils/templates/etc/searx/use_default_settings.yml
@@ -1,0 +1,22 @@
+use_default_settings: True
+
+general:
+    debug : False # Debug mode, only for development
+    instance_name : "searx" # displayed name
+
+search:
+    safe_search : 0 # Filter results. 0: None, 1: Moderate, 2: Strict
+    autocomplete : "" # Existing autocomplete backends: "dbpedia", "duckduckgo", "google", "startpage", "swisscows", "qwant", "wikipedia" - leave blank to turn it off by default
+    default_lang : "" # Default search language - leave blank to detect from browser information or use codes from 'languages.py'
+
+server:
+    port : 8888
+    bind_address : "127.0.0.1" # address to listen on
+    secret_key : "ultrasecretkey" # change this!
+    base_url : False # Set custom base_url. Possible values: False or "https://your.custom.host/location/"
+    image_proxy : False # Proxying image results through searx
+
+# uncomment below section if you have running morty proxy
+#result_proxy:
+#    url : http://127.0.0.1:3000/
+#    key : !!binary "your_morty_proxy_key"


### PR DESCRIPTION
## What does this PR do?

Since #2291 is merged, it is recommend to use::

    use_default_settings=True

1. Add a template file use_default_settings.yml::

    SEARX_SETTINGS_TEMPLATE="${REPO_ROOT}/utils/templates/etc/searx/use_default_settings.yml"

2. In Chapter "Configuration" recommend to make use of
   'use_default_settings=True' and describe it

3. Rewrite of docs/admin/settings.rst
   - move chapter 'settings.yml location' to the top
   - update and split chapter 'Global Settings'

4. Add environment SEARX_SETTINGS_TEMPLATE to .config.sh

5. Use environment $SEARX_SETTINGS_TEMPLATE in the utils/searx.sh script

## How to test this PR locally?

To build the patched documentation:

    make clean docs-live

To test `utils/templates/etc/searx/use_default_settings.yml` template you need to set the branch of the PR:

```diff
index 4a873f0c..38475a45 100644
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@

 # START Makefile setup
 export GIT_URL=https://github.com/searx/searx
-export GIT_BRANCH=master
+export GIT_BRANCH=use_default_settings
 export SEARX_URL=https://searx.me
 export DOCS_URL=https://searx.github.io/searx
 # END Makefile setup
```

Install into LXC and open URL of searx instance from container:

```sh
$ make clean buildenv
$ sudo -H ./utils/lxc.sh remove searx-archlinux
$ sudo -H ./utils/lxc.sh build searx-archlinux
$ sudo -H ./utils/lxc.sh install suite searx-archlinux
$ sudo -H ./utils/lxc.sh cmd searx-archlinux   ./utils/filtron.sh nginx install
...
INFO:  installed nginx app: searx.conf
INFO:  testing public url ..
INFO:  got 429 from http://10.174.184.240/searx # open URL in your browser

$sudo -H ./utils/lxc.sh cmd searx-archlinux   ./utils/morty.sh nginx install
...
```

Check `/etc/searx/settings.yml` which is used by the instance running inside the container:

```sh
$ sudo -H ./utils/lxc.sh cmd searx-archlinux  cat /etc/searx/settings.yml
use_default_settings: True

general:
    debug : False # Debug mode, only for development
    instance_name : "searx" # displayed name
...
```
