### PR TITLE
[fix] wikipedia: minor fix: return no result instead of crash in some very few cases.

### DIFF
--- a/searx/engines/wikipedia.py
+++ b/searx/engines/wikipedia.py
@@ -52,7 +52,7 @@ def response(resp):
     api_result = loads(resp.text)
 
     # skip disambiguation pages
-    if api_result['type'] != 'standard':
+    if api_result.get('type') != 'standard':
         return []
 
     title = api_result['title']


### PR DESCRIPTION

## What does this PR do?

In few cases, the JSON results doesn't contains the key 'type'.

See line:
https://github.com/searx/searx/blob/a458451d20bf45baf62d79a1e4ea2151e176f1d4/searx/engines/wikipedia.py#L55

## Why is this change important?

Return no result instead of crashing.

## How to test this PR locally?

Detected using `/stats/errors` on public searx instances.

I don't know how to reproduce the bug, nevertheless, the change is small enough to be reviewed.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
