### PR TITLE
[fix] soundclound: accept result without content

### DIFF
--- a/searx/engines/soundcloud.py
+++ b/searx/engines/soundcloud.py
@@ -91,7 +91,7 @@ def response(resp):
     for result in search_res.get('collection', []):
         if result['kind'] in ('track', 'playlist'):
             title = result['title']
-            content = result['description']
+            content = result['description'] or ''
             publishedDate = parser.parse(result['last_modified'])
             uri = quote_plus(result['uri'])
             embedded = embedded_url.format(uri=uri)


### PR DESCRIPTION
## What does this PR do?

Sometimes, the `result['description']` is `None`: 
https://github.com/searx/searx/blob/a458451d20bf45baf62d79a1e4ea2151e176f1d4/searx/engines/soundcloud.py#L94

The result is still perfectly valid (there is actually no description).

## Why is this change important?

Without this PR, some results are missing.

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

 check for `!soundcloud time` with and without this PR.

## Related issues

<!--
Closes #234
-->
