### PR TITLE
Display if an engine does not support HTTPS requests

### DIFF
--- a/searx/engines/acgsou.py
+++ b/searx/engines/acgsou.py
@@ -18,7 +18,7 @@ categories = ['files', 'images', 'videos', 'music']
 paging = True
 
 # search-url
-base_url = 'http://www.acgsou.com/'
+base_url = 'https://www.acgsou.com/'
 search_url = base_url + 'search.php?{query}&page={offset}'
 # xpath queries
 xpath_results = '//table[contains(@class, "list_style table_fixed")]//tr[not(th)]'
@@ -40,7 +40,7 @@ def response(resp):
     for result in eval_xpath_list(dom, xpath_results):
         # defaults
         filesize = 0
-        magnet_link = "magnet:?xt=urn:btih:{}&tr=http://tracker.acgsou.com:2710/announce"
+        magnet_link = "magnet:?xt=urn:btih:{}&tr=https://tracker.acgsou.com:2710/announce"
 
         category = extract_text(eval_xpath_getindex(result, xpath_category, 0, default=[]))
         page_a = eval_xpath_getindex(result, xpath_title, 0)

--- a/searx/engines/arxiv.py
+++ b/searx/engines/arxiv.py
@@ -19,7 +19,7 @@ from searx.utils import eval_xpath_list, eval_xpath_getindex
 categories = ['science']
 paging = True
 
-base_url = 'http://export.arxiv.org/api/query?search_query=all:'\
+base_url = 'https://export.arxiv.org/api/query?search_query=all:'\
            + '{query}&start={offset}&max_results={number_of_results}'
 
 # engine dependent config

--- a/searx/engines/currency_convert.py
+++ b/searx/engines/currency_convert.py
@@ -9,6 +9,7 @@ url = 'https://duckduckgo.com/js/spice/currency/1/{0}/{1}'
 weight = 100
 
 parser_re = re.compile('.*?(\\d+(?:\\.\\d+)?) ([^.0-9]+) (?:in|to) ([^.0-9]+)', re.I)
+https_support = True
 
 
 def normalize_name(name):

--- a/searx/engines/dictzone.py
+++ b/searx/engines/dictzone.py
@@ -20,6 +20,7 @@ weight = 100
 
 parser_re = re.compile('.*?([a-z]+)-([a-z]+) ([^ ]+)$', re.I)
 results_xpath = './/table[@id="r"]/tr'
+https_support = True
 
 
 def request(query, params):

--- a/searx/engines/translated.py
+++ b/searx/engines/translated.py
@@ -15,6 +15,7 @@ categories = ['general']
 url = 'https://api.mymemory.translated.net/get?q={query}&langpair={from_lang}|{to_lang}{key}'
 web_url = 'https://mymemory.translated.net/en/{from_lang}/{to_lang}/{query}'
 weight = 100
+https_support = True
 
 parser_re = re.compile('.*?([a-z]+)-([a-z]+) (.{2,})$', re.I)
 api_key = ''

--- a/searx/templates/oscar/macros.html
+++ b/searx/templates/oscar/macros.html
@@ -1,6 +1,6 @@
 <!-- Draw glyphicon icon from bootstrap-theme -->
-{% macro icon(action) -%}
-    <span class="glyphicon glyphicon-{{ action }}"></span>
+{% macro icon(action, alt) -%}
+    <span title="{{ alt }}" class="glyphicon glyphicon-{{ action }}"></span>
 {%- endmacro %}
 
 <!-- Draw favicon -->

--- a/searx/templates/oscar/preferences.html
+++ b/searx/templates/oscar/preferences.html
@@ -230,8 +230,8 @@
                                     <td class="onoff-checkbox">
                                         {{ checkbox_toggle('engine_' + search_engine.name|replace(' ', '_') + '__' + categ|replace(' ', '_'), (search_engine.name, categ) in disabled_engines) }}
                                     </td>
-                                    <th scope="row">{{ search_engine.name }}</th>
-                                    <td class="name">{{ shortcuts[search_engine.name] }}</td>
+                                    <th scope="row">{% if not search_engine.https_support %}{{ icon('exclamation-sign', 'No HTTPS') }}{% endif %} {{ search_engine.name }}</td></th>
+                                    <td class="name">{{ shortcuts[search_engine.name] }}
                                         <td>{{ support_toggle(stats[search_engine.name].supports_selected_language) }}</td>
                                         <td>{{ support_toggle(search_engine.safesearch==True) }}</td>
                                         <td>{{ support_toggle(search_engine.time_range_support==True) }}</td>

--- a/searx/templates/simple/macros.html
+++ b/searx/templates/simple/macros.html
@@ -1,6 +1,6 @@
 <!-- Draw glyphicon icon from bootstrap-theme -->
-{% macro icon(action) -%}
-    <span class="ion-icon-big ion-{{ action }}"></span>
+{% macro icon(action, alt) -%}
+    <span title="{{ alt }}" class="ion-icon-big ion-{{ action }}"></span>
 {%- endmacro %}
 
 {% macro icon_small(action) -%}

--- a/searx/templates/simple/preferences.html
+++ b/searx/templates/simple/preferences.html
@@ -1,4 +1,4 @@
-{% from 'simple/macros.html' import tabs_open, tabs_close, tab_header, tab_footer, checkbox_onoff, checkbox %}
+{% from 'simple/macros.html' import icon, tabs_open, tabs_close, tab_header, tab_footer, checkbox_onoff, checkbox %}
 
 {% extends "simple/base.html" %}
 
@@ -121,7 +121,7 @@
       {% set engine_id = 'engine_' + search_engine.name|replace(' ', '_') + '__' + categ|replace(' ', '_') %}
       <tr>
         <td class="engine_checkbox">{{ checkbox_onoff(engine_id, (search_engine.name, categ) in disabled_engines) }}</td>
-        <th class="name">{{ search_engine.name }}</th>
+        <th class="name">{% if not search_engine.https_support %}{{ icon('warning', 'No HTTPS') }}{% endif %} {{ search_engine.name }}</th>
         <td class="shortcut">{{ shortcuts[search_engine.name] }}</td>
         <td>{{ checkbox(engine_id + '_supported_languages', current_language == 'all' or current_language in search_engine.supported_languages or current_language.split('-')[0] in search_engine.supported_languages, true, true) }}</td>
         <td>{{ checkbox(engine_id + '_safesearch', search_engine.safesearch==True, true, true) }}</td>


### PR DESCRIPTION
## What does this PR do?

From now on engines have a new attribute named `https_support`. The engine developer can set it to either `True` or `False` whether the engine is queried using HTTPS. It only has to be set if the `request` function call would take to long. Otherwise, searx sets the attribute automatically.

## Why is this change important?

Now, this information is displayed in the engines list on the Preferences page. Given that we only have 2-4 engines which do not support HTTPS, it might not be the biggest change. :D

## Related issues

Closes #302
