### PR TITLE
Fix the StartPage result title is showing the url

### DIFF
--- a/searx/engines/startpage.py
+++ b/searx/engines/startpage.py
@@ -37,7 +37,7 @@ search_url = base_url + 'do/search'
 # ads xpath //div[@id="results"]/div[@id="sponsored"]//div[@class="result"]
 # not ads: div[@class="result"] are the direct childs of div[@id="results"]
 results_xpath = '//div[@class="w-gl__result__main"]'
-link_xpath = './/a[@class="w-gl__result-url result-link"]'
+link_xpath = './/a[@class="w-gl__result-title result-link"]'
 content_xpath = './/p[@class="w-gl__description"]'
 
 


### PR DESCRIPTION
## What does this PR do?

Change the link variable in the startpage.py, so it will contains both the url and the title. Then the result page can show the tile instead of the url in the title section. 

## Why is this change important?

The StartPage will be useful again. 

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

## Related issues
Closes #2395 
