### PR TITLE
[fix] determine path to makefile.lxc in a LXC

### DIFF
--- a/utils/lxc.sh
+++ b/utils/lxc.sh
@@ -20,7 +20,7 @@ lxc_set_suite_env
 
 LXC_HOST_PREFIX="${LXC_HOST_PREFIX:-test}"
 
-# where all folders from HOST are mounted
+# Location in the container where all folders from HOST are mounted
 LXC_SHARE_FOLDER="/share"
 LXC_REPO_ROOT="${LXC_SHARE_FOLDER}/$(basename "${REPO_ROOT}")"
 

--- a/utils/makefile.include
+++ b/utils/makefile.include
@@ -3,7 +3,7 @@
 ifeq (,$(wildcard /.lxcenv.mk))
 PHONY += lxc-activate lxc-purge
 lxc-activate:
-	@$(MAKE) -s -f  /share/searx/utils/makefile.lxc lxc-activate
+	@$(MAKE) -s -f "$$(dirname $(abspath $(lastword $(MAKEFILE_LIST))))/makefile.lxc" lxc-activate
 lxc-purge:
 	$(Q)rm -rf ./lxc
 else


### PR DESCRIPTION
The path to the makefile.lxc is not always static and `/share/searx/utils/makefile.lxc` can be wrong.

When target `lxc.activate` is called within the LXC container the path to `makefile.lxc` depends on `LXC_SHARE_FOLDER` and the `basename` of the folder where searx was cloned initial on the HOST system.

This patch determines the path of `makefile.lxc` next to `makefile.include` itself.