### PR TITLE
Update secret key check

### DIFF
--- a/docs/admin/engines.rst
+++ b/docs/admin/engines.rst
@@ -46,7 +46,7 @@ Show errors   **DE**
 
 .. _configured engines:
 
-.. jinja:: webapp
+.. jinja:: searx
 
    .. flat-table:: Engines configured at built time (defaults)
       :header-rows: 1

--- a/docs/admin/plugins.rst
+++ b/docs/admin/plugins.rst
@@ -14,7 +14,7 @@ Configuration defaults (at built time):
 
 .. _configured plugins:
 
-.. jinja:: webapp
+.. jinja:: searx
 
    .. flat-table:: Plugins configured at built time (defaults)
       :header-rows: 1

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,9 +27,15 @@ numfig = True
 
 exclude_patterns = ['build-templates/*.rst']
 
-from searx import webapp
+import searx.search
+import searx.engines
+import searx.plugins
+searx.search.initialize()
 jinja_contexts = {
-    'webapp': dict(**webapp.__dict__),
+    'searx': {
+        'engines': searx.engines.engines,
+        'plugins': searx.plugins.plugins
+    },
 }
 
 # usage::   lorem :patch:`f373169` ipsum

--- a/docs/dev/reST.rst
+++ b/docs/dev/reST.rst
@@ -1289,15 +1289,21 @@ build chapter: :ref:`engines generic`.  Below the jinja directive from the
    :language: reST
    :start-after: .. _configured engines:
 
-The context for the template is selected in the line ``.. jinja:: webapp``.  In
-sphinx's build configuration (:origin:`docs/conf.py`) the ``webapp`` context
-points to the name space of the python module: ``webapp``.
+The context for the template is selected in the line ``.. jinja:: searx``.  In
+sphinx's build configuration (:origin:`docs/conf.py`) the ``searx`` context
+contains the ``engines`` and ``plugins``.
 
 .. code:: py
 
-   from searx import webapp
+   import searx.search
+   import searx.engines
+   import searx.plugins
+   searx.search.initialize()
    jinja_contexts = {
-       'webapp': dict(**webapp.__dict__)
+      'searx': {
+         'engines': searx.engines.engines,
+         'plugins': searx.plugins.plugins
+      },
    }
 
 

--- a/searx/__init__.py
+++ b/searx/__init__.py
@@ -60,7 +60,3 @@ if 'SEARX_SECRET' in environ:
     settings['server']['secret_key'] = environ['SEARX_SECRET']
 if 'SEARX_BIND_ADDRESS' in environ:
     settings['server']['bind_address'] = environ['SEARX_BIND_ADDRESS']
-
-if not searx_debug and settings['server']['secret_key'] == 'ultrasecretkey':
-    logger.error('server.secret_key is not changed. Please use something else instead of ultrasecretkey.')
-    exit(1)

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -86,6 +86,11 @@ from searx.metrology.error_recorder import errors_per_engines
 from werkzeug.serving import WSGIRequestHandler
 WSGIRequestHandler.protocol_version = "HTTP/{}".format(settings['server'].get('http_protocol_version', '1.0'))
 
+# check secret_key
+if not searx_debug and settings['server']['secret_key'] == 'ultrasecretkey':
+    logger.error('server.secret_key is not changed. Please use something else instead of ultrasecretkey.')
+    exit(1)
+
 # about static
 static_path = get_resources_directory(searx_dir, 'static', settings['ui']['static_path'])
 logger.debug('static directory is %s', static_path)

--- a/utils/standalone_searx.py
+++ b/utils/standalone_searx.py
@@ -15,7 +15,7 @@ Example to use this script:
 
 .. code::  bash
 
-    $ SEARX_DEBUG=1 python3 utils/standalone_searx.py rain
+    $ python3 utils/standalone_searx.py rain
 
 Example to run it from python:
 


### PR DESCRIPTION
## What does this PR do?

See the commit messages for the details.

Second version of https://github.com/searx/searx/pull/2386

## Why is this change important?

searx don't check for the secret_key with `utils/standalone.py` and `make docs`.
   
https://github.com/searx/searx/blob/59217bb5bed86926b2bbd84f406ed022b0762c6e/tests/__init__.py#L2
is still there

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

* `make test`
* `make run`
* `make docs` : check the engines and plugins pages.
* start the application using uwsgi.

## Related issues

* https://github.com/searx/searx/pull/2386
* https://github.com/searx/searx/issues/2252
