### PR TITLE
[fix] use SEARX_SETTINGS_TEMPLATE from .config environment

### DIFF
--- a/.config.sh
+++ b/.config.sh
@@ -28,7 +28,10 @@ fi
 # SEARX_INTERNAL_URL="127.0.0.1:8888"
 # SEARX_SETTINGS_TEMPLATE="${REPO_ROOT}/utils/templates/etc/searx/use_default_settings.yml"
 
-# Only change, if you maintain a searx brand in your searx fork.
+# Only change, if you maintain a searx brand in your searx fork (GIT_URL) which
+# is not hold by branch 'master'.  The branch has to be a local branch, in the
+# repository from which you install (which is most often the case).  If you want
+# to install branch 'foo', don't forget to run 'git branch foo origin/foo' once.
 # GIT_BRANCH="${GIT_BRANCH:-master}"
 
 # filtron.sh

--- a/utils/searx.sh
+++ b/utils/searx.sh
@@ -388,6 +388,14 @@ clone_searx() {
         err_msg "to clone searx sources, user $SERVICE_USER hast to be created first"
         return 42
     fi
+    if [[ ! $(git show-ref "refs/heads/${GIT_BRANCH}") ]]; then
+        warn_msg "missing local branch ${GIT_BRANCH}"
+        info_msg "create local branch ${GIT_BRANCH} from start point: origin/${GIT_BRANCH}"
+        git branch "${GIT_BRANCH}" "origin/${GIT_BRANCH}"
+    fi
+    if [[ ! $(git branch --show-current) == "${GIT_BRANCH}" ]]; then
+        warn_msg "take into account, installing branch $GIT_BRANCH while current branch is $(git branch --show-current)"
+    fi
     export SERVICE_HOME
     git_clone "$REPO_ROOT" "$SEARX_SRC" \
               "$GIT_BRANCH" "$SERVICE_USER"

--- a/utils/searx.sh
+++ b/utils/searx.sh
@@ -36,7 +36,7 @@ GIT_BRANCH="${GIT_BRANCH:-master}"
 SEARX_PYENV="${SERVICE_HOME}/searx-pyenv"
 SEARX_SRC="${SERVICE_HOME}/searx-src"
 SEARX_SETTINGS_PATH="/etc/searx/settings.yml"
-SEARX_SETTINGS_TEMPLATE="${REPO_ROOT}/utils/templates/etc/searx/use_default_settings.yml"
+SEARX_SETTINGS_TEMPLATE="${SEARX_SETTINGS_TEMPLATE:-${REPO_ROOT}/utils/templates/etc/searx/use_default_settings.yml}"
 SEARX_UWSGI_APP="searx.ini"
 # shellcheck disable=SC2034
 SEARX_UWSGI_SOCKET="/run/uwsgi/app/searx/socket"
@@ -157,7 +157,7 @@ install / remove
   :searx-src:  clone $GIT_URL
   :pyenv:      create/remove virtualenv (python) in $SEARX_PYENV
   :uwsgi:      install searx uWSGI application
-  :settings:   reinstall settings from ${REPO_ROOT}/searx/settings.yml
+  :settings:   reinstall settings from ${SEARX_SETTINGS_TEMPLATE}
   :packages:   install needed packages from OS package manager
   :buildhost:  install packages from OS package manager needed by buildhosts
 update searx
@@ -412,7 +412,7 @@ install_settings() {
     mkdir -p "$(dirname ${SEARX_SETTINGS_PATH})"
 
     if [[ ! -f ${SEARX_SETTINGS_PATH} ]]; then
-        info_msg "install settings ${REPO_ROOT}/searx/settings.yml"
+        info_msg "install settings ${SEARX_SETTINGS_TEMPLATE}"
         info_msg "  --> ${SEARX_SETTINGS_PATH}"
         cp "${SEARX_SETTINGS_TEMPLATE}" "${SEARX_SETTINGS_PATH}"
         configure_searx


### PR DESCRIPTION
In commit a70b9b9f the SEARX_SETTINGS_TEMPLATE environment was added to the `.config` file, but was not use in `utils/searx.sh`.

BTW: there is a second commit, which handles cases, where the local branch is different from the branch to install.

## How to test this PR locally?

Create your own settings file ...

```bash
cp utils/templates/etc/searx/use_default_settings.yml ./my_settings.yml
edit my_settings.yml
```

Edit `.config` to point to your settings file:

```diff
diff --git a/.config.sh b/.config.sh
index f9bac738..4a1db45f 100644
--- a/.config.sh
+++ b/.config.sh
@@ -26,7 +26,7 @@ fi
 # ---------
 
 # SEARX_INTERNAL_URL="127.0.0.1:8888"
-# SEARX_SETTINGS_TEMPLATE="${REPO_ROOT}/utils/templates/etc/searx/use_default_settings.yml"
+SEARX_SETTINGS_TEMPLATE="${REPO_ROOT}/my_settings.yml"
 
 # Only change, if you maintain a searx brand in your searx fork.
 # GIT_BRANCH="${GIT_BRANCH:-master}"
````

To test, it needs to run the installation procedure, I recommend to test this PR in [LXC (or any other container)](https://searx.github.io/searx/blog/lxcdev-202006.html#gentlemen-start-your-engines).

```bash
sudo -H ./utils/lxc.sh remove searx-ubu2004 # drop if already exists
sudo -H ./utils/lxc.sh build searx-ubu2004
sudo -H ./utils/lxc.sh cmd searx-ubu2004 bash
root@searx-ubu2004:/share/searx# ./utils/searx.sh install all
...
/etc/searx/settings.yml
-----------------------
INFO:  install settings /share/searx/my_settings.yml
INFO:    --> /etc/searx/settings.yml
...
```

Double check, that the `my_settings.yml` template has been installed:

```bash
root@searx-ubu2004:/share/searx# cat /etc/searx/settings.yml
...
```
