### PR TITLE
[fix] makefile.python: remove duplicate pyenv-(un)install targets

### DIFF
--- a/utils/makefile.python
+++ b/utils/makefile.python
@@ -220,16 +220,8 @@ PHONY += pydebug
 pydebug: $(PY_ENV)
 	DEBUG=$(DEBUG) $(PY_ENV_BIN)/pytest $(DEBUG) -v $(TEST_FOLDER)/$(TEST)
 
-# install / uninstall python objects into virtualenv (PYENV)
-pyenv-install: $(PY_ENV)
-	@$(PY_ENV_BIN)/python -m pip $(PIP_VERBOSE) install -e .
-	@echo "ACTIVATE  $(call normpath,$(PY_ENV_ACT)) "
-
-pyenv-uninstall: $(PY_ENV)
-	@$(PY_ENV_BIN)/python -m pip $(PIP_VERBOSE) uninstall --yes .
-
 # runs python interpreter from ./local/py<N>/bin/python
-pyenv-python: pyenv-install
+pyenv-python: pyenvinstall
 	$(PY_ENV_BIN)/python -i
 
 # With 'dependency_links=' setuptools supports dependencies on packages hosted


### PR DESCRIPTION
## What does this PR do?

Makefile targets 'pyenv-install' and 'pyenv-uninstall' are unused duplicates of 'pyenvinstall' and 'pyenvuninstall'.

## How to test this PR locally?

no test needed / PR drops unused code duplications
