### PR TITLE
[perf] optimize creation of the virtualenv & pyenvinstal targets

### DIFF
--- a/utils/lib.sh
+++ b/utils/lib.sh
@@ -1381,7 +1381,7 @@ in_container() {
 LXC_ENV_FOLDER=
 if in_container; then
     # shellcheck disable=SC2034
-    LXC_ENV_FOLDER="lxc/$(hostname)/"
+    LXC_ENV_FOLDER="lxc-env/$(hostname)/"
 fi
 
 lxc_init_container_env() {
@@ -1413,8 +1413,8 @@ LXC_BASE_PACKAGES_centos="bash git python3"
 case $DIST_ID in
     ubuntu|debian) LXC_BASE_PACKAGES="${LXC_BASE_PACKAGES_debian}" ;;
     arch)          LXC_BASE_PACKAGES="${LXC_BASE_PACKAGES_arch}" ;;
-    fedora) LXC_BASE_PACKAGES="${LXC_BASE_PACKAGES_fedora}" ;;
-    centos) LXC_BASE_PACKAGES="${LXC_BASE_PACKAGES_centos}" ;;
+    fedora)        LXC_BASE_PACKAGES="${LXC_BASE_PACKAGES_fedora}" ;;
+    centos)        LXC_BASE_PACKAGES="${LXC_BASE_PACKAGES_centos}" ;;
     *) err_msg "$DIST_ID-$DIST_VERS: pkg_install LXC_BASE_PACKAGES not yet implemented" ;;
 esac
 

--- a/utils/lib.sh
+++ b/utils/lib.sh
@@ -41,7 +41,7 @@ DOT_CONFIG="${DOT_CONFIG:-${REPO_ROOT}/.config.sh}"
 
 source_dot_config() {
     if [[ ! -e "${DOT_CONFIG}" ]]; then
-        err_msg "configuration does not extsts at: ${DOT_CONFIG}"
+        err_msg "configuration does not exists at: ${DOT_CONFIG}"
         return 42
     fi
     # shellcheck disable=SC1090
@@ -159,7 +159,7 @@ clean_stdin() {
 }
 
 wait_key(){
-    # usage: waitKEY [<timeout in sec>]
+    # usage: wait_key [<timeout in sec>]
 
     clean_stdin
     local _t=$1
@@ -639,7 +639,7 @@ nginx_distro_setup() {
     NGINX_DEFAULT_SERVER=/etc/nginx/nginx.conf
 
     # Including *location* directives from a dedicated config-folder into the
-    # server directive is, what what fedora and centos (already) does.
+    # server directive is, what fedora and centos (already) does.
     NGINX_APPS_ENABLED="/etc/nginx/default.d"
 
     # We add a apps-available folder and linking configurations into the
@@ -692,7 +692,7 @@ nginx_reload() {
 
 nginx_install_app() {
 
-    # usage:  nginx_install_app [<template option> ...] <myapp>
+    # usage:  nginx_install_app [<template option> ...] <myapp.conf>
     #
     # <template option>:   see install_template
 

--- a/utils/makefile.include
+++ b/utils/makefile.include
@@ -5,7 +5,7 @@ PHONY += lxc-activate lxc-purge
 lxc-activate:
 	@$(MAKE) -s -f "$$(dirname $(abspath $(lastword $(MAKEFILE_LIST))))/makefile.lxc" lxc-activate
 lxc-purge:
-	$(Q)rm -rf ./lxc
+	$(Q)rm -rf ./lxc-env
 else
 	include /.lxcenv.mk
 endif

--- a/utils/makefile.lxc
+++ b/utils/makefile.lxc
@@ -9,10 +9,10 @@
 #   sudo make ./utils/makefile.lxc lxc-activate
 #   sudo make ./utils/makefile.lxc lxc-deactivate
 
-LXC_ENV_FOLDER=lxc/$(shell hostname)/
+LXC_ENV_FOLDER=lxc-env/$(shell hostname)/
 
 lxc-help::
-	@echo  'LXC: running in container LXC_ENV_FOLDER=$(LXC_ENV_FOLDER)'
+	@echo  '  LXC: running in container LXC_ENV_FOLDER=$(LXC_ENV_FOLDER)'
 
 # If not activated, serve target 'lxc-activate' ..
 ifeq (,$(wildcard /.lxcenv.mk))
@@ -24,6 +24,9 @@ else
 PHONY += lxc-deactivate
 lxc-deactivate:
 	rm /.lxcenv.mk
+$(LXC_ENV_FOLDER):
+	$(Q)mkdir -p $(LXC_ENV_FOLDER)
+	$(Q)echo placeholder > $(LXC_ENV_FOLDER).placeholder
 endif
 
 .PHONY: $(PHONY)

--- a/utils/makefile.python
+++ b/utils/makefile.python
@@ -113,6 +113,8 @@ quiet_cmd_virtualenv  = PYENV     usage: $ source ./$@/bin/activate
       cmd_virtualenv  = \
 	if [ ! -d "./$(PY_ENV)" ];then                                  \
 		$(PYTHON) -m venv $(VTENV_OPTS) $2;                     \
+		$(PY_ENV_BIN)/python -m pip install $(PIP_VERBOSE) -U pip wheel setuptools; \
+		$(PY_ENV_BIN)/python -m pip install $(PIP_VERBOSE) -r requirements.txt;     \
 	else                                                            \
 		echo "PYENV     using virtualenv from $2";              \
         fi
@@ -193,8 +195,6 @@ pyclean:
 pyenv: $(PY_ENV)
 $(PY_ENV): python-exe
 	$(call cmd,virtualenv,$(PY_ENV))
-	$(Q)$(PY_ENV_BIN)/python -m pip install $(PIP_VERBOSE) -U pip wheel pip setuptools
-	$(Q)$(PY_ENV_BIN)/python -m pip install $(PIP_VERBOSE) -r requirements.txt
 
 PHONY += pylint-exe
 pylint-exe: $(PY_ENV)

--- a/utils/makefile.python
+++ b/utils/makefile.python
@@ -75,7 +75,9 @@ msg-python-exe:
   https://www.python.org or install it from your package\n\
   manager. On debian based OS these requirements are\n\
   installed by::\n\n\
-    sudo -H apt-get install $(PYTHON)\n" | $(FMT)
+    sudo -H add-apt-repository ppa:deadsnakes/ppa\n\
+    sudo -H apt update\n\
+    sudo -H apt-get install $(PYTHON) $(PYTHON)-venv\n"
 
 ifeq ($(shell which $(PYTHON) >/dev/null 2>&1; echo $$?), 1)
 python-exe: msg-python-exe

--- a/utils/makefile.python
+++ b/utils/makefile.python
@@ -95,7 +95,13 @@ quiet_cmd_pyinstall = INSTALL   $2
 
 # $2 path to folder with setup.py, this uses pip from pyenv (not OS!)
 quiet_cmd_pyenvinstall = PYENV     install $2
-      cmd_pyenvinstall = $(PY_ENV_BIN)/python -m pip $(PIP_VERBOSE) install -e $2$(PY_SETUP_EXTRAS)
+      cmd_pyenvinstall = \
+	if ! cat $(PY_ENV)/requirements.sha256 2>/dev/null | sha256sum --check --status 2>/dev/null; then \
+		$(PY_ENV_BIN)/python -m pip $(PIP_VERBOSE) install -e $2$(PY_SETUP_EXTRAS) ;\
+		sha256sum requirements*.txt > $(PY_ENV)/requirements.sha256 ;\
+	else \
+		echo "PYENV     $2 already installed"; \
+	fi
 
 # Uninstall the package.  Since pip does not uninstall the no longer needed
 # depencies (something like autoremove) the depencies remain.


### PR DESCRIPTION
## What does this PR do?

Nearly all makefile targets have virtualenv and pipenvinstall in their chain of prerequisite.  This patch series optimize creation of the virtualenv & pyenvinstal targets.  By this all targets based on these targets will speed up significantly.

The third patch fix the message when you call `make PY=3.7`

## How to test this PR locally?

Make a first build of pyenv like usual ..

```
$ make clean pyenvinstall
PYENV     usage: source ./local/py3/bin/activate
Collecting pip
...
PYENV     install .
Obtaining file:///share/searx
...
Successfully installed  ...
```

If you build the same target again  ...


```
make pyenv
$ make pyenvinstall
PYENV     usage: source ./local/py3/bin/activate
PYENV     using virtualenv from ./local/py3
PYENV     install .
PYENV     . already installed

```