### PR TITLE
Remove voat due to its shutdown

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -906,17 +906,6 @@ engines:
     # See : http://mymemory.translated.net/doc/usagelimits.php
     # api_key : ''
 
-  - name : voat
-    engine: xpath
-    shortcut: vo
-    categories: social media
-    search_url : https://searchvoat.co/?t={query}
-    url_xpath : //div[@class="entry"]//p[@class="title"]/a/@href
-    title_xpath : //div[@class="entry"]//p[@class="title"]/a/text()
-    content_xpath : //div[@class="entry"]//span[@class="domain"]/a/text()
-    timeout : 10.0
-    disabled : True
-
   - name : 1337x
     engine : 1337x
     shortcut : 1337x


### PR DESCRIPTION
Voat shutted down on December 25th, 2020 at 12 noon PST: https://voat.co/host/voat/static/inactive.min.html?ReturnUrl=/

## What does this PR do?

Remove voat.co engine

## Why is this change important?

The engine is now shutdown since December 25th, 2020 at 12 noon PST: https://voat.co/host/voat/static/inactive.min.html?ReturnUrl=/

## How to test this PR locally?

1. Run Searx normally and except no engine related to voat in the preferences

## Author's checklist

N/A

## Related issues

Closes #2444
