### PR TITLE
add notice for the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -6,6 +6,8 @@ labels: bug
 assignees: ''
 
 ---
+<!-- PLEASE FILL THESE FIELDS, IT REALLY HELPS THE MAINTAINERS OF SEARX -->
+
 **Version of Searx, commit number if you are using on master branch and stipulate if you forked Searx**
 <!-- If you are running on master branch using git execute this command
 in order to fetch the latest commit ID:

--- a/.github/ISSUE_TEMPLATE/engine-request.md
+++ b/.github/ISSUE_TEMPLATE/engine-request.md
@@ -6,6 +6,8 @@ labels: enhancement, engine request
 assignees: ''
 
 ---
+<!-- PLEASE FILL THESE FIELDS, IT REALLY HELPS THE MAINTAINERS OF SEARX -->
+
 **Working URL to the engine**
 <!-- Please check if the engine is responding correctly before submitting it. -->
 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -6,6 +6,8 @@ labels: enhancement
 assignees: ''
 
 ---
+<!-- PLEASE FILL THESE FIELDS, IT REALLY HELPS THE MAINTAINERS OF SEARX -->
+
 **Is your feature request related to a problem? Please describe.**
 <!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 


### PR DESCRIPTION
## What does this PR do?

It adds a notice for the people that don't fill the issue template. I don't know if that's a good idea to have the sentence is all capital letters though.

## Why is this change important?

A lot of people don't fill the issue template and just straight remove them.

Proof:
- https://github.com/searx/searx/issues/2446
- https://github.com/searx/searx/issues/2440
- More, but I asked the author of the issue to correct the case.

## How to test this PR locally?

N/A

## Author's checklist

N/A

## Related issues

N/A
