### PR TITLE
[fix] Library Genesis links shifted by 1 #1998

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -492,7 +492,7 @@ engines:
   - name : library genesis
     engine : xpath
     search_url : http://libgen.rs/search.php?req={query}
-    url_xpath : //a[contains(@href,"bookfi.net")]/@href
+    url_xpath : //a[contains(@href,"bookfi.net/md5")]/@href
     title_xpath : //a[contains(@href,"book/")]/text()[1]
     content_xpath : //td/a[1][contains(@href,"=author")]/text()
     categories : general


### PR DESCRIPTION
Fixes: #1998
Suggested-by: @linuxmue
Signed-off-by: Markus Heiser <markus.heiser@darmarit.de>

## How to test this PR locally?

see https://github.com/searx/searx/issues/1998#issue-638153578