### PR TITLE
Fix empty colon in query from selecting Chinese

### DIFF
--- a/searx/query.py
+++ b/searx/query.py
@@ -77,7 +77,7 @@ class RawTextQuery:
                     pass
 
             # this force a language
-            if query_part[0] == ':':
+            if query_part[0] == ':' and len(query_part) > 1:
                 lang = query_part[1:].lower().replace('_', '-')
 
                 # check if any language-code is equal with

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -59,6 +59,15 @@ class TestQuery(SearxTestCase):
         self.assertEqual(len(query.languages), 0)
         self.assertFalse(query.specific)
 
+    def test_empty_colon_in_query(self):
+        query_text = 'the : query'
+        query = RawTextQuery(query_text, [])
+
+        self.assertEqual(query.getFullQuery(), query_text)
+        self.assertEqual(len(query.query_parts), 0)
+        self.assertEqual(len(query.languages), 0)
+        self.assertFalse(query.specific)
+
     def test_timeout_below100(self):
         query_text = '<3 the query'
         query = RawTextQuery(query_text, [])


### PR DESCRIPTION
Fixes  #2453.

An empty `:` bang matches every entry in [languages.py](https://github.com/searx/searx/blob/master/searx/languages.py) with an empty string (every row without a country), so any query with a space separated colon will mistakenly match with Chinese.