### PR TITLE
[fix] github actions: use ubuntu-20.04 instead of ubuntu-latest

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,10 +5,10 @@ on: [push, pull_request]
 jobs:
   python:
     name: Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
     - name: Checkout
@@ -46,7 +46,7 @@ jobs:
 
   themes:
     name: Themes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -59,7 +59,7 @@ jobs:
 
   documentation:
     name: Documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -92,7 +92,7 @@ jobs:
       - documentation
     env:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         if: env.DOCKERHUB_USERNAME != null


### PR DESCRIPTION
## What does this PR do?

Github actions: use `ubuntu-20.04` instead of `ubuntu-latest`.

Side effect:
* `make local/py3`  does nothing because the github action cache already contains some data
* it seems the cache was corrupted
* so the `yaml` dependency was found, and CI was crashing

This PR doesn't fix the root cause: it just change the cache entry name.

## Why is this change important?

Green is better than red, at least for the CI.

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

The CI broke with this PR: https://github.com/searx/searx/pull/2460 
A commit to disable the cache fixed the build (but without cache).
