### PR TITLE
[fix] setup.py requires pyyaml installed

### DIFF
--- a/docs/build-templates/searx.rst
+++ b/docs/build-templates/searx.rst
@@ -116,6 +116,7 @@ ${fedora_build}
        pip install -U pip
        pip install -U setuptools
        pip install -U wheel
+       pip install -U pyyaml
 
        # jump to searx's working tree and install searx into virtualenv
        (${SERVICE_USER})$ cd \"$SEARX_SRC\"

--- a/utils/searx.sh
+++ b/utils/searx.sh
@@ -333,6 +333,7 @@ git pull
 pip install -U pip
 pip install -U setuptools
 pip install -U wheel
+pip install -U pyyaml
 pip install -U -e .
 EOF
     install_settings
@@ -503,6 +504,7 @@ EOF
 pip install -U pip
 pip install -U setuptools
 pip install -U wheel
+pip install -U pyyaml
 pip install -U -e .
 cd ${SEARX_SRC}
 pip install -e .


### PR DESCRIPTION
```
pip install -e .
...
Obtaining file:///usr/local/searx/searx-src
    ERROR: Command errored out with exit status 1:
     command: /usr/local/searx/searx-pyenv/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/usr/local/searx/searx-src/setup.py'"'"'; __file__='"'"'/usr/local/searx/searx-src/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'rn'"'"', '"'"'n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-vzer91m2
         cwd: /usr/local/searx/searx-src/
    Complete output (9 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/usr/local/searx/searx-src/setup.py", line 10, in <module>
        from searx.version import VERSION_STRING
      File "/usr/local/searx/searx-src/searx/__init__.py", line 19, in <module>
        import searx.settings_loader
      File "/usr/local/searx/searx-src/searx/settings_loader.py", line 8, in <module>
        import yaml
    ModuleNotFoundError: No module named 'yaml'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```