### PR TITLE
Fix error recording and checker

### DIFF
--- a/searx/metrology/error_recorder.py
+++ b/searx/metrology/error_recorder.py
@@ -51,15 +51,12 @@ def add_error_context(engine_name: str, error_context: ErrorContext) -> None:
 
 
 def get_trace(traces):
-    previous_trace = traces[-1]
     for trace in reversed(traces):
-        if trace.filename.endswith('searx/search.py'):
-            if previous_trace.filename.endswith('searx/poolrequests.py'):
-                return trace
-            if previous_trace.filename.endswith('requests/models.py'):
-                return trace
-            return previous_trace
-        previous_trace = trace
+        split_filename = trace.filename.split('/')
+        if len(split_filename) > 3 and '/'.join(split_filename[-3:-1]) == 'searx/engines':
+            return trace
+        if len(split_filename) > 3 and '/'.join(split_filename[-4:-1]) == 'searx/search/processors':
+            return trace
     return traces[-1]
 
 

--- a/searx/metrology/error_recorder.py
+++ b/searx/metrology/error_recorder.py
@@ -53,9 +53,9 @@ def add_error_context(engine_name: str, error_context: ErrorContext) -> None:
 def get_trace(traces):
     for trace in reversed(traces):
         split_filename = trace.filename.split('/')
-        if len(split_filename) > 3 and '/'.join(split_filename[-3:-1]) == 'searx/engines':
+        if '/'.join(split_filename[-3:-1]) == 'searx/engines':
             return trace
-        if len(split_filename) > 3 and '/'.join(split_filename[-4:-1]) == 'searx/search/processors':
+        if '/'.join(split_filename[-4:-1]) == 'searx/search/processors':
             return trace
     return traces[-1]
 

--- a/searx/search/checker/background.py
+++ b/searx/search/checker/background.py
@@ -98,7 +98,7 @@ def initialize():
     signal.signal(signal.SIGUSR1, _signal_handler)
 
     # disabled by default
-    _set_result({'status': 'disabled'})
+    _set_result({'status': 'disabled'}, include_timestamp=False)
 
     # special case when debug is activate
     if searx_debug and settings.get('checker', {}).get('off_when_debug', True):

--- a/searx/search/checker/impl.py
+++ b/searx/search/checker/impl.py
@@ -4,6 +4,7 @@ import typing
 import types
 import functools
 import itertools
+import threading
 from time import time
 from urllib.parse import urlparse
 
@@ -377,6 +378,8 @@ class Checker:
         engineref_category = search_query.engineref_list[0].category
         params = self.processor.get_params(search_query, engineref_category)
         if params is not None:
+            with threading.RLock():
+                self.processor.engine.stats['sent_search_count'] += 1
             self.processor.search(search_query.query, params, result_container, time(), 5)
         return result_container
 

--- a/searx/search/processors/abstract.py
+++ b/searx/search/processors/abstract.py
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-from abc import abstractmethod
+from abc import abstractmethod, ABC
 from searx import logger
 
 
 logger = logger.getChild('searx.search.processor')
 
 
-class EngineProcessor:
+class EngineProcessor(ABC):
 
     def __init__(self, engine, engine_name):
         self.engine = engine


### PR DESCRIPTION
## What does this PR do?

Two bug fixes that make `/stats/errors` reliable:
* accurate percentage after the checker has run
* `code` and `lineno` reference the engine code rather some meaningless code (for the error context).
* `/stats/checker` : the field `timestamp` shows when searx has started. This PR removes this field to keep only the status field.

## Why is this change important?

Reliable statistics ( `/stats/errors` ) help to fix the engines.

## How to test this PR locally?

* `make run`
* `kill -SIGUSR1 <searx pid>` (see log)
* wait for the checker to finish.
* check `/stats/errors` :
    * `code`, `lineno` should reference the engine code (it was not the case before)
    * `percentage` should not be above 100

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

* Fix PR #2225 and #2419
