### PR TITLE
Document workaround for using 2 languages simultaneously #1508

### DIFF
--- a/docs/user/search_syntax.rst
+++ b/docs/user/search_syntax.rst
@@ -40,3 +40,27 @@ Image search:
 Custom language in wikipedia:
 
 - :search:`:hu !wp hackerspace <?q=%3Ahu%20%21wp%20hackerspace>`
+
+Multilingual Search
+===================
+
+Searx does not support true multilingual search.
+You have to use the language prefix in your search query when searching in a different language.
+
+But there is a workaround:
+By adding a new search engine with a different language, Searx will search in your default and other language.
+
+Example configuration in settings.yml for a German and English speaker:
+ .. code-block:: yaml
+
+    search:
+        language : "de"
+        ...
+
+    engines:
+      - name : google english
+        engine : google
+        language : english
+        ...
+
+When searching, the default google engine will return German results and "google english" will return English results.


### PR DESCRIPTION
## What does this PR do?

Extend documentation on how to search in two languages simultaneously.

## Why is this change important?

As a German native speaker, I use English and German search queries.

And @unixfox has motivated my to create this pull request:
https://github.com/searx/searx/issues/1508#issuecomment-751836672

## How to test this PR locally?

Check if documentation page `user/search_syntax.html` still works.

## Author's checklist

I'm not sure if this page (`user/search_syntax.html`) is the right one for adding this information. But I haven't found a better page.

## Related issues

Fixes https://github.com/searx/searx/issues/1508
