### PR TITLE
Add ARM64 support

### DIFF
--- a/.config.sh
+++ b/.config.sh
@@ -22,6 +22,14 @@ if [[ ${PUBLIC_URL} == "https://searx.me" ]]; then
     PUBLIC_URL="http://$(primary_ip)/searx"
 fi
 
+# Architecture detection
+
+if [[ $(uname -m) == x86_64* ]]; then
+    export ARCH="amd64"
+elif  [[ $(uname -m) == aarch64* ]]; then
+   export  ARCH="arm64"
+fi
+
 # searx.sh
 # ---------
 

--- a/utils/filtron.sh
+++ b/utils/filtron.sh
@@ -41,7 +41,7 @@ SERVICE_GROUP="${SERVICE_USER}"
 SERVICE_GROUP="${SERVICE_USER}"
 
 GO_ENV="${SERVICE_HOME}/.go_env"
-GO_PKG_URL="https://dl.google.com/go/go1.13.5.linux-amd64.tar.gz"
+GO_PKG_URL="https://dl.google.com/go/go1.13.5.linux-$ARCH.tar.gz"
 GO_TAR=$(basename "$GO_PKG_URL")
 
 APACHE_FILTRON_SITE="searx.conf"

--- a/utils/morty.sh
+++ b/utils/morty.sh
@@ -34,7 +34,7 @@ SERVICE_GROUP="${SERVICE_USER}"
 SERVICE_ENV_DEBUG=false
 
 GO_ENV="${SERVICE_HOME}/.go_env"
-GO_PKG_URL="https://dl.google.com/go/go1.13.5.linux-amd64.tar.gz"
+GO_PKG_URL="https://dl.google.com/go/go1.13.5.linux-$ARCH.tar.gz"
 GO_TAR=$(basename "$GO_PKG_URL")
 
 # shellcheck disable=SC2034


### PR DESCRIPTION
## What does this PR do?
Adds support for ARM64 devices.

## Why is this change important?
Because it adds the ability to be able to install searx on a Raspberry Pi 3 or 4 using the Installation Scripts.

## How to test this PR locally?
Run `sudo -H ./utils/filtron.sh install all` and `sudo -H ./utils/morty.sh install all` on a ARM64 device.