### PR TITLE
[fix] lxc.sh - SC2034: ubu2010_boilerplate appears unused.

### DIFF
--- a/utils/lxc.sh
+++ b/utils/lxc.sh
@@ -39,6 +39,7 @@ $ubu1904_boilerplate
 echo 'Set disable_coredump false' >> /etc/sudo.conf
 "
 
+# shellcheck disable=SC2034
 ubu2010_boilerplate="$ubu1904_boilerplate"
 
 # shellcheck disable=SC2034


### PR DESCRIPTION
    $ make test.sh
    In utils/lxc.sh line 42:
    ubu2010_boilerplate="$ubu1904_boilerplate"
    ^-----------------^ SC2034: ubu2010_boilerplate appears unused. Verify use (or export if used externally).

## How to test this PR locally?

    make test.sh

## Author's checklist

Should we add Makefile target 'test.sh' to 'test'? ..  needs [Shellcheck to be installed](https://searx.github.io/searx/admin/installation-searx.html?highlight=shellchecker#install-packages).

