### PR TITLE
[fix] google_news: avoid one HTTP redirect except for the English results

### DIFF
--- a/searx/engines/google_news.py
+++ b/searx/engines/google_news.py
@@ -85,7 +85,7 @@ def request(query, params):
 
     query_url = 'https://'+ subdomain + '/search' + "?" + urlencode({
         'q': query,
-        'hl': lang_country,
+        'hl': language,
         'lr': "lang_" + language,
         'ie': "utf8",
         'oe': "utf8",
@@ -108,6 +108,10 @@ def request(query, params):
     params['headers']['Accept'] = (
         'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8'
         )
+
+    # hl=en redirect to hl=en-US / en-CA ...
+    params['soft_max_redirects'] = 1
+
     #params['google_subdomain'] = subdomain
 
     return params


### PR DESCRIPTION
## What does this PR do?

See https://github.com/searx/searx/pull/2483#issuecomment-766087712 and comments above.

* avoid one HTTP redirect except for the English results
* add `params['soft_max_redirects'] = 1` to avoid false error reporting in `/stats/errors`

## Why is this change important?

* HTTP redirects slow down response times (debatable choice since this PR add one HTTP direct for the English language results).
* keep clean up error report in `/stats/errors` 

## How to test this PR locally?

* search for `!google_news :en time` : check there is one HTTP redirect, but no ErrorContext report
* search for `!google_news :de time`: check there is no HTTP redirect, and no ErrorContext report.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

* see https://github.com/searx/searx/pull/2483#issuecomment-766087712
