### PR TITLE
[mod] dynamically set language_support variable

### DIFF
--- a/docs/dev/engine_overview.rst
+++ b/docs/dev/engine_overview.rst
@@ -42,7 +42,6 @@ argument                type        information
 ======================= =========== ========================================================
 categories              list        pages, in which the engine is working
 paging                  boolean     support multible pages
-language_support        boolean     support language choosing
 time_range_support      boolean     support search time range
 engine_type             str         ``online`` by default, other possibles values are 
                                     ``offline``, ``online_dictionnary``, ``online_currency``
@@ -97,7 +96,6 @@ example code
    # engine dependent config
    categories = ['general']
    paging = True
-   language_support = True
 
 
 making a request

--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -44,7 +44,6 @@ babel_langs = [lang_parts[0] + '-' + lang_parts[-1] if len(lang_parts) > 1 else 
 engine_shortcuts = {}
 engine_default_args = {'paging': False,
                        'categories': ['general'],
-                       'language_support': True,
                        'supported_languages': [],
                        'safesearch': False,
                        'timeout': settings['outgoing']['request_timeout'],
@@ -126,6 +125,9 @@ def load_engine(engine_data):
                 language_aliases[iso_lang] = engine_lang
 
         setattr(engine, 'language_aliases', language_aliases)
+
+    # language_support
+    setattr(engine, 'language_support', len(getattr(engine, 'supported_languages', [])) > 0)
 
     # assign language fetching method if auxiliary method exists
     if hasattr(engine, '_fetch_supported_languages'):

--- a/searx/engines/archlinux.py
+++ b/searx/engines/archlinux.py
@@ -21,7 +21,6 @@ about = {
 
 # engine dependent config
 categories = ['it']
-language_support = True
 paging = True
 base_url = 'https://wiki.archlinux.org'
 

--- a/searx/engines/bing.py
+++ b/searx/engines/bing.py
@@ -24,7 +24,6 @@ about = {
 # engine dependent config
 categories = ['general']
 paging = True
-language_support = True
 supported_languages_url = 'https://www.bing.com/account/general'
 language_aliases = {'zh-CN': 'zh-CHS', 'zh-TW': 'zh-CHT', 'zh-HK': 'zh-CHT'}
 

--- a/searx/engines/bing_images.py
+++ b/searx/engines/bing_images.py
@@ -26,7 +26,6 @@ categories = ['images']
 paging = True
 safesearch = True
 time_range_support = True
-language_support = True
 supported_languages_url = 'https://www.bing.com/account/general'
 number_of_results = 28
 

--- a/searx/engines/bing_news.py
+++ b/searx/engines/bing_news.py
@@ -25,7 +25,6 @@ about = {
 # engine dependent config
 categories = ['news']
 paging = True
-language_support = True
 time_range_support = True
 
 # search-url

--- a/searx/engines/bing_videos.py
+++ b/searx/engines/bing_videos.py
@@ -26,7 +26,6 @@ paging = True
 safesearch = True
 time_range_support = True
 number_of_results = 28
-language_support = True
 
 base_url = 'https://www.bing.com/'
 search_string = 'videos/search'\

--- a/searx/engines/dailymotion.py
+++ b/searx/engines/dailymotion.py
@@ -21,7 +21,6 @@ about = {
 # engine dependent config
 categories = ['videos']
 paging = True
-language_support = True
 
 # search-url
 # see http://www.dailymotion.com/doc/api/obj-video.html

--- a/searx/engines/doku.py
+++ b/searx/engines/doku.py
@@ -20,7 +20,6 @@ about = {
 # engine dependent config
 categories = ['general']  # TODO , 'images', 'music', 'videos', 'files'
 paging = False
-language_support = False
 number_of_results = 5
 
 # search-url

--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -20,7 +20,6 @@ about = {
 # engine dependent config
 categories = ['general']
 paging = False
-language_support = True
 supported_languages_url = 'https://duckduckgo.com/util/u172.js'
 time_range_support = True
 

--- a/searx/engines/duckduckgo_images.py
+++ b/searx/engines/duckduckgo_images.py
@@ -26,7 +26,6 @@ about = {
 # engine dependent config
 categories = ['images']
 paging = True
-language_support = True
 safesearch = True
 
 # search-url

--- a/searx/engines/duden.py
+++ b/searx/engines/duden.py
@@ -20,7 +20,6 @@ about = {
 
 categories = ['general']
 paging = True
-language_support = False
 
 # search-url
 base_url = 'https://www.duden.de/'

--- a/searx/engines/etools.py
+++ b/searx/engines/etools.py
@@ -19,7 +19,6 @@ about = {
 
 categories = ['general']
 paging = False
-language_support = False
 safesearch = True
 
 base_url = 'https://www.etools.ch'

--- a/searx/engines/genius.py
+++ b/searx/engines/genius.py
@@ -20,7 +20,6 @@ about = {
 # engine dependent config
 categories = ['music']
 paging = True
-language_support = False
 page_size = 5
 
 url = 'https://genius.com/api/'

--- a/searx/engines/gentoo.py
+++ b/searx/engines/gentoo.py
@@ -19,7 +19,6 @@ about = {
 
 # engine dependent config
 categories = ['it']
-language_support = True
 paging = True
 base_url = 'https://wiki.gentoo.org'
 

--- a/searx/engines/gigablast.py
+++ b/searx/engines/gigablast.py
@@ -24,7 +24,6 @@ about = {
 categories = ['general']
 # gigablast's pagination is totally damaged, don't use it
 paging = False
-language_support = True
 safesearch = True
 
 # search-url

--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -31,7 +31,6 @@ about = {
 # engine dependent config
 categories = ['general']
 paging = True
-language_support = True
 time_range_support = True
 safesearch = True
 supported_languages_url = 'https://www.google.com/preferences?#languages'

--- a/searx/engines/google_images.py
+++ b/searx/engines/google_images.py
@@ -56,7 +56,6 @@ about = {
 # engine dependent config
 categories = ['images']
 paging = False
-language_support = True
 use_locale_domain = True
 time_range_support = True
 safesearch = True

--- a/searx/engines/google_news.py
+++ b/searx/engines/google_news.py
@@ -68,7 +68,6 @@ time_range_dict = {
 
 categories = ['news']
 paging = False
-language_support = True
 use_locale_domain = True
 time_range_support = True
 

--- a/searx/engines/invidious.py
+++ b/searx/engines/invidious.py
@@ -21,7 +21,6 @@ about = {
 # engine dependent config
 categories = ["videos", "music"]
 paging = True
-language_support = True
 time_range_support = True
 
 

--- a/searx/engines/mediawiki.py
+++ b/searx/engines/mediawiki.py
@@ -19,7 +19,6 @@ about = {
 
 # engine dependent config
 categories = ['general']
-language_support = True
 paging = True
 number_of_results = 1
 search_type = 'nearmatch'  # possible values: title, text, nearmatch

--- a/searx/engines/peertube.py
+++ b/searx/engines/peertube.py
@@ -21,7 +21,6 @@ about = {
 # engine dependent config
 categories = ["videos"]
 paging = True
-language_support = True
 base_url = "https://peer.tube/"
 supported_languages_url = base_url + "api/v1/videos/languages"
 

--- a/searx/engines/photon.py
+++ b/searx/engines/photon.py
@@ -20,7 +20,6 @@ about = {
 # engine dependent config
 categories = ['map']
 paging = False
-language_support = True
 number_of_results = 10
 
 # search-url

--- a/searx/engines/qwant.py
+++ b/searx/engines/qwant.py
@@ -23,7 +23,6 @@ about = {
 # engine dependent config
 categories = []
 paging = True
-language_support = True
 supported_languages_url = 'https://qwant.com/region'
 
 category_to_keyword = {'general': 'web',

--- a/searx/engines/sepiasearch.py
+++ b/searx/engines/sepiasearch.py
@@ -20,7 +20,6 @@ about = {
 
 categories = ['videos']
 paging = True
-language_support = True
 time_range_support = True
 safesearch = True
 supported_languages = [

--- a/searx/engines/startpage.py
+++ b/searx/engines/startpage.py
@@ -29,7 +29,6 @@ categories = ['general']
 # storing of qid's between mulitble search-calls
 
 paging = True
-language_support = True
 supported_languages_url = 'https://www.startpage.com/do/settings'
 
 # search-url

--- a/searx/engines/yacy.py
+++ b/searx/engines/yacy.py
@@ -24,7 +24,6 @@ about = {
 # engine dependent config
 categories = ['general', 'images']  # TODO , 'music', 'videos', 'files'
 paging = True
-language_support = True
 number_of_results = 5
 http_digest_auth_user = ""
 http_digest_auth_pass = ""

--- a/searx/engines/yahoo.py
+++ b/searx/engines/yahoo.py
@@ -20,7 +20,6 @@ about = {
 # engine dependent config
 categories = ['general']
 paging = True
-language_support = True
 time_range_support = True
 
 # search-url

--- a/searx/engines/yahoo_news.py
+++ b/searx/engines/yahoo_news.py
@@ -25,7 +25,6 @@ about = {
 # engine dependent config
 categories = ['news']
 paging = True
-language_support = True
 
 # search-url
 search_url = 'https://news.search.yahoo.com/search?{query}&b={offset}&{lang}=uh3_news_web_gs_1&pz=10&xargs=0&vl=lang_{lang}'  # noqa

--- a/searx/engines/yandex.py
+++ b/searx/engines/yandex.py
@@ -23,7 +23,6 @@ about = {
 # engine dependent config
 categories = ['general']
 paging = True
-language_support = True  # TODO
 
 default_tld = 'com'
 language_map = {'ru': 'ru',

--- a/searx/engines/youtube_api.py
+++ b/searx/engines/youtube_api.py
@@ -21,7 +21,6 @@ about = {
 # engine dependent config
 categories = ['videos', 'music']
 paging = False
-language_support = True
 api_key = None
 
 # search-url

--- a/searx/engines/youtube_noapi.py
+++ b/searx/engines/youtube_noapi.py
@@ -20,7 +20,6 @@ about = {
 # engine dependent config
 categories = ['videos', 'music']
 paging = True
-language_support = False
 time_range_support = True
 
 # search-url


### PR DESCRIPTION
## What does this PR do?

The language_support variable is set to True by default,
and set to False in only 5 engines.

Except the documentation and the /config URL, this variable is not used.

This commit remove the variable definition in the engines, and
set value according to supported_languages length: False when the length is 0,
True otherwise.

## Why is this change important?

This variable is misleading: 
* from the user point of view, it does nothing, since https://github.com/searx/searx/commit/fd65c1292179fb082e965a1ee6a88b9298a54fc1#diff-f5962794ee51e4631700f577aa174f19623c87377130020dba94bd55410f5420L376 (committed 4 years ago)
* in https://searx.github.io/searx/admin/engines.html  the "Language support" column is wrong.

## How to test this PR locally?

* `make docs` : check the documentation.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Close #2485