### PR TITLE
RFC: add searx/settings_default.py

### DIFF
--- a/searx/__init__.py
+++ b/searx/__init__.py
@@ -16,37 +16,17 @@ along with searx. If not, see < http://www.gnu.org/licenses/ >.
 '''
 
 import logging
+
 import searx.settings_loader
-from os import environ
-from os.path import realpath, dirname, join, abspath, isfile
+from searx.settings_defaults import searx_dir, settings_set_defaults
 
 
-searx_dir = abspath(dirname(__file__))
-engine_dir = dirname(realpath(__file__))
-static_path = abspath(join(dirname(__file__), 'static'))
 settings, settings_load_message = searx.settings_loader.load_settings()
+if settings is not None:
+    settings = settings_set_defaults(settings)
 
-if settings['ui']['static_path']:
-    static_path = settings['ui']['static_path']
 
-'''
-enable debug if
-the environnement variable SEARX_DEBUG is 1 or true
-(whatever the value in settings.yml)
-or general.debug=True in settings.yml
-disable debug if
-the environnement variable SEARX_DEBUG is 0 or false
-(whatever the value in settings.yml)
-or general.debug=False in settings.yml
-'''
-searx_debug_env = environ.get('SEARX_DEBUG', '').lower()
-if searx_debug_env == 'true' or searx_debug_env == '1':
-    searx_debug = True
-elif searx_debug_env == 'false' or searx_debug_env == '0':
-    searx_debug = False
-else:
-    searx_debug = settings.get('general', {}).get('debug')
-
+searx_debug = settings['general']['debug']
 if searx_debug:
     logging.basicConfig(level=logging.DEBUG)
 else:
@@ -55,11 +35,6 @@ else:
 logger = logging.getLogger('searx')
 logger.info(settings_load_message)
 logger.info('Initialisation done')
-
-if 'SEARX_SECRET' in environ:
-    settings['server']['secret_key'] = environ['SEARX_SECRET']
-if 'SEARX_BIND_ADDRESS' in environ:
-    settings['server']['bind_address'] = environ['SEARX_BIND_ADDRESS']
 
 
 class _brand_namespace:

--- a/searx/plugins/__init__.py
+++ b/searx/plugins/__init__.py
@@ -21,7 +21,7 @@ from os import listdir, makedirs, remove, stat, utime
 from os.path import abspath, basename, dirname, exists, join
 from shutil import copyfile
 
-from searx import logger, settings, static_path
+from searx import logger, settings
 
 
 logger = logger.getChild('plugins')
@@ -124,7 +124,7 @@ def sync_resource(base_path, resource_path, name, target_dir, plugin_dir):
 
 def prepare_package_resources(pkg, name):
     plugin_dir = 'plugin_' + name
-    target_dir = join(static_path, 'plugins/external_plugins', plugin_dir)
+    target_dir = join(settings['ui']['static_path'], 'plugins/external_plugins', plugin_dir)
     try:
         makedirs(target_dir, exist_ok=True)
     except:

--- a/searx/poolrequests.py
+++ b/searx/poolrequests.py
@@ -68,8 +68,8 @@ class HTTPAdapterWithConnParams(requests.adapters.HTTPAdapter):
 
 
 threadLocal = local()
-connect = settings['outgoing'].get('pool_connections', 100)  # Magic number kept from previous code
-maxsize = settings['outgoing'].get('pool_maxsize', requests.adapters.DEFAULT_POOLSIZE)  # Picked from constructor
+connect = settings['outgoing']['pool_connections']  # Magic number kept from previous code
+maxsize = settings['outgoing']['pool_maxsize']  # Picked from constructor
 if settings['outgoing'].get('source_ips'):
     http_adapters = cycle(HTTPAdapterWithConnParams(pool_connections=connect, pool_maxsize=maxsize,
                                                     source_address=(source_ip, 0))

--- a/searx/search/__init__.py
+++ b/searx/search/__init__.py
@@ -35,17 +35,6 @@ from searx.search.checker import initialize as initialize_checker
 
 logger = logger.getChild('search')
 
-max_request_timeout = settings.get('outgoing', {}).get('max_request_timeout' or None)
-if max_request_timeout is None:
-    logger.info('max_request_timeout={0}'.format(max_request_timeout))
-else:
-    if isinstance(max_request_timeout, float):
-        logger.info('max_request_timeout={0} second(s)'.format(max_request_timeout))
-    else:
-        logger.critical('outgoing.max_request_timeout if defined has to be float')
-        import sys
-        sys.exit(1)
-
 
 def initialize(settings_engines=None, enable_checker=False):
     settings_engines = settings_engines or settings['engines']
@@ -124,6 +113,7 @@ class Search:
         actual_timeout = default_timeout
         query_timeout = self.search_query.timeout_limit
 
+        max_request_timeout = settings['outgoing']['max_request_timeout']
         if max_request_timeout is None and query_timeout is None:
             # No max, no user query: default_timeout
             pass

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+import os
+import sys
+import requests
+import logging
+from os.path import dirname, abspath
+
+searx_dir = abspath(dirname(__file__))
+
+logger = logging.getLogger('searx')
+
+
+def default(value):
+    def f(existing, path):
+        if not existing:
+            return value
+        return value
+    return f
+
+
+def is_instance(types):
+    def f(existing, path):
+        nonlocal types
+        if None in types and existing is None:
+            return existing
+        else:
+            types = tuple(filter(lambda t: t is not None, types))
+        if not isinstance(existing, types):
+            types_str = list(map(lambda t: t.__name__ if t is not None else 'None', types))
+            logger.critical('%s has to be one of these types: %s', '.'.join(path), ', '.join(types_str))
+            sys.exit(1)
+        return existing
+    return f
+
+
+def override_by_environ(environ_name):
+    def f(existing, path):
+        if environ_name in os.environ:
+            return os.environ[environ_name]
+        return existing
+    return f
+
+
+def override_by_bool_envriron(environ_name):
+    def f(existing, path):
+        if environ_name in os.environ:
+            v = os.environ[environ_name].lower()
+            if v == 'true' or v == '1':
+                return True
+            elif v == 'false' or v == '0':
+                return False
+            else:
+                logger.warning('%s : ignore value from %s environment variable', '.'.join(path), environ_name)
+        return existing
+    return f
+
+
+def get_resources_directory(searx_directory, subdirectory):
+    resources_directory = os.path.join(searx_directory, subdirectory)
+    if not os.path.isdir(resources_directory):
+        raise Exception(resources_directory + " is not a directory")
+    return resources_directory
+
+
+def apply_schema(settings, schema, path):
+    for key, value in schema.items():
+        if isinstance(value, dict):
+            apply_schema(settings.setdefault(key, {}), schema[key], [*path, key])
+        else:
+            if callable(value):
+                value = (value,)
+            if isinstance(value, tuple):
+                for f in value:
+                    if callable(f):
+                        settings[key] = f(settings.get(key), [*path, key])
+                    else:
+                        raise Exception()
+            else:
+                settings.setdefault(key, value)
+
+
+def settings_set_defaults(settings):
+    '''
+    enable debug if
+    the environnement variable SEARX_DEBUG is 1 or true
+    (whatever the value in settings.yml)
+    or general.debug=True in settings.yml
+    disable debug if
+    the environnement variable SEARX_DEBUG is 0 or false
+    (whatever the value in settings.yml)
+    or general.debug=False in settings.yml
+    '''
+    schema = {
+        'general': {
+            'debug': (default(False), override_by_bool_envriron('SEARX_DEBUG'))
+        },
+        'brand': {
+
+        },
+        'search': {
+
+        },
+        'server': {
+            'secret_key': override_by_environ('SEARX_SECRET'),
+            'bind_address': override_by_environ('SEARX_BIND_ADDRESS'),
+            'default_http_headers': default({})
+        },
+        'ui': {
+            'templates_path': default(get_resources_directory(searx_dir, 'templates')),
+            'static_path': default(get_resources_directory(searx_dir, 'static'))
+        },
+        'outgoing': {
+            'max_request_timeout': is_instance((None, float)),
+            'pool_connections': default(100),
+            'pool_maxsize': default(requests.adapters.DEFAULT_POOLSIZE)
+        },
+        'checker': {
+            'off_when_debug': default(True)
+        },
+        'engines': {
+
+        },
+        'doi_resolvers': {
+
+        }
+    }
+
+    apply_schema(settings, schema, [])
+
+    max_request_timeout = settings['outgoing']['max_request_timeout']
+    if max_request_timeout is None:
+        logger.info('max_request_timeout=%s', repr(max_request_timeout))
+    else:
+        logger.info('max_request_timeout=%i second(s)', max_request_timeout)
+
+    return settings

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -56,14 +56,14 @@ import flask_babel
 from flask_babel import Babel, gettext, format_date, format_decimal
 from flask.ctx import has_request_context
 from flask.json import jsonify
-from searx import brand, static_path
-from searx import settings, searx_dir, searx_debug
+from searx import brand
+from searx import settings, searx_debug
 from searx.exceptions import SearxParameterException
 from searx.engines import (
     categories, engines, engine_shortcuts, get_engines_stats
 )
 from searx.webutils import (
-    UnicodeWriter, highlight_content, get_resources_directory,
+    UnicodeWriter, highlight_content,
     get_static_files, get_result_templates, get_themes,
     prettify_url, new_hmac, is_flask_run_cmdline
 )
@@ -92,27 +92,26 @@ if not searx_debug and settings['server']['secret_key'] == 'ultrasecretkey':
     exit(1)
 
 # about static
-static_path = get_resources_directory(searx_dir, 'static', settings['ui']['static_path'])
-logger.debug('static directory is %s', static_path)
-static_files = get_static_files(static_path)
+logger.debug('static directory is %s', settings['ui']['static_path'])
+static_files = get_static_files(settings['ui']['static_path'])
 
 # about templates
 default_theme = settings['ui']['default_theme']
-templates_path = get_resources_directory(searx_dir, 'templates', settings['ui']['templates_path'])
+templates_path = settings['ui']['templates_path']
 logger.debug('templates directory is %s', templates_path)
 themes = get_themes(templates_path)
 result_templates = get_result_templates(templates_path)
 global_favicons = []
 for indice, theme in enumerate(themes):
     global_favicons.append([])
-    theme_img_path = os.path.join(static_path, 'themes', theme, 'img', 'icons')
+    theme_img_path = os.path.join(settings['ui']['static_path'], 'themes', theme, 'img', 'icons')
     for (dirpath, dirnames, filenames) in os.walk(theme_img_path):
         global_favicons[indice].extend(filenames)
 
 # Flask app
 app = Flask(
     __name__,
-    static_folder=static_path,
+    static_folder=settings['ui']['static_path'],
     template_folder=templates_path
 )
 
@@ -495,7 +494,7 @@ def pre_request():
 @app.after_request
 def add_default_headers(response):
     # set default http headers
-    for header, value in settings['server'].get('default_http_headers', {}).items():
+    for header, value in settings['server']['default_http_headers'].items():
         if header in response.headers:
             continue
         response.headers[header] = value
@@ -1020,7 +1019,7 @@ def opensearch():
 @app.route('/favicon.ico')
 def favicon():
     return send_from_directory(os.path.join(app.root_path,
-                                            static_path,
+                                            settings['ui']['static_path'],
                                             'themes',
                                             get_current_theme_name(),
                                             'img'),

--- a/searx/webutils.py
+++ b/searx/webutils.py
@@ -47,14 +47,6 @@ class UnicodeWriter:
             self.writerow(row)
 
 
-def get_resources_directory(searx_directory, subdirectory, resources_directory):
-    if not resources_directory:
-        resources_directory = os.path.join(searx_directory, subdirectory)
-    if not os.path.isdir(resources_directory):
-        raise Exception(resources_directory + " is not a directory")
-    return resources_directory
-
-
 def get_themes(templates_path):
     """Returns available themes list."""
     themes = os.listdir(templates_path)

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -2,6 +2,7 @@
 
 from searx.testing import SearxTestCase
 from searx.search import SearchQuery, EngineRef
+from searx import settings
 import searx.search
 
 
@@ -41,7 +42,7 @@ class SearchTestCase(SearxTestCase):
         searx.search.initialize(TEST_ENGINES)
 
     def test_timeout_simple(self):
-        searx.search.max_request_timeout = None
+        settings['outgoing']['max_request_timeout'] = None
         search_query = SearchQuery('test', [EngineRef(PUBLIC_ENGINE_NAME, 'general')],
                                    'en-US', SAFESEARCH, PAGENO, None, None)
         search = searx.search.Search(search_query)
@@ -49,7 +50,7 @@ class SearchTestCase(SearxTestCase):
         self.assertEqual(search.actual_timeout, 3.0)
 
     def test_timeout_query_above_default_nomax(self):
-        searx.search.max_request_timeout = None
+        settings['outgoing']['max_request_timeout'] = None
         search_query = SearchQuery('test', [EngineRef(PUBLIC_ENGINE_NAME, 'general')],
                                    'en-US', SAFESEARCH, PAGENO, None, 5.0)
         search = searx.search.Search(search_query)
@@ -57,7 +58,7 @@ class SearchTestCase(SearxTestCase):
         self.assertEqual(search.actual_timeout, 3.0)
 
     def test_timeout_query_below_default_nomax(self):
-        searx.search.max_request_timeout = None
+        settings['outgoing']['max_request_timeout'] = None
         search_query = SearchQuery('test', [EngineRef(PUBLIC_ENGINE_NAME, 'general')],
                                    'en-US', SAFESEARCH, PAGENO, None, 1.0)
         search = searx.search.Search(search_query)
@@ -65,7 +66,7 @@ class SearchTestCase(SearxTestCase):
         self.assertEqual(search.actual_timeout, 1.0)
 
     def test_timeout_query_below_max(self):
-        searx.search.max_request_timeout = 10.0
+        settings['outgoing']['max_request_timeout'] = 10.0
         search_query = SearchQuery('test', [EngineRef(PUBLIC_ENGINE_NAME, 'general')],
                                    'en-US', SAFESEARCH, PAGENO, None, 5.0)
         search = searx.search.Search(search_query)
@@ -73,7 +74,7 @@ class SearchTestCase(SearxTestCase):
         self.assertEqual(search.actual_timeout, 5.0)
 
     def test_timeout_query_above_max(self):
-        searx.search.max_request_timeout = 10.0
+        settings['outgoing']['max_request_timeout'] = 10.0
         search_query = SearchQuery('test', [EngineRef(PUBLIC_ENGINE_NAME, 'general')],
                                    'en-US', SAFESEARCH, PAGENO, None, 15.0)
         search = searx.search.Search(search_query)


### PR DESCRIPTION
## What does this PR do?

* searx loads `searx/settings.yml` into the `settings` variable.
* then, the default values are defined usually using this pattern similar to `settings[....].get('aVariable', default)` 
* it fails for `settings['ui']['static_path']`, see https://github.com/searx/searx/issues/2252#issuecomment-764755567

This PR adds a new function `searx.settings_set_defaults.settings_set_defaults` to set all the default values in one place.

Then instead of 
```
static_path = get_resources_directory(searx_dir, 'static', settings['ui']['static_path'])
```

It is possible to write ```settings['ui']['static_path']```


## Why is this change important?

See https://github.com/searx/searx/issues/2252#issuecomment-764755567 (more precisely the `static_path` definition)

This PR is request for comment / for archive : most probably a better solution is to create some classes in similar way to the `*Settings` classes.

## How to test this PR locally?

The various defaults work as before.
https://github.com/dalf/searx/blob/d82185ad52e042db9d506bc952f5fbf8b8138b99/searx/settings_defaults.py#L93-L126

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
