### PR TITLE
[fix] Makefile target gh-pages & flatten history of branch gh.pages

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -80,7 +80,7 @@ jobs:
       with:
         GITHUB_TOKEN: ${{ github.token }}
         BRANCH: gh-pages
-        FOLDER: gh-pages
+        FOLDER: build/gh-pages
         CLEAN: true # Automatically remove deleted files from the deploy branch
 
   dockers:

--- a/utils/makefile.sphinx
+++ b/utils/makefile.sphinx
@@ -10,7 +10,7 @@ SPHINX_CONF ?= conf.py
 DOCS_FOLDER = ./docs
 DOCS_BUILD  = ./$(LXC_ENV_FOLDER)build/docs
 DOCS_DIST   = ./$(LXC_ENV_FOLDER)dist/docs
-GH_PAGES    ?= gh-pages
+GH_PAGES    ?= build/gh-pages
 
 BOOKS_FOLDER = ./docs
 BOOKS_DIST   = ./$(LXC_ENV_FOLDER)dist/books
@@ -172,24 +172,22 @@ PHONY += prepare-gh-pages
 prepare-gh-pages:
 	cp -r $(DOCS_DIST)/* $(GH_PAGES)/
 	touch $(GH_PAGES)/.nojekyll
-	echo "<html><head><META http-equiv='refresh' content='0;URL=index.html'></head></html>" > $(GH_PAGES)/404.html	
+	echo "<html><head><META http-equiv='refresh' content='0;URL=index.html'></head></html>" > $(GH_PAGES)/404.html
 
-PHONY += $(GH_PAGES)
-$(GH_PAGES)::
-	$(MAKE) docs
-	[ -d "gh-pages/.git" ] || git clone $(GIT_URL) gh-pages
-	-cd $(GH_PAGES); git checkout gh-pages >/dev/null
-	-cd $(GH_PAGES); git pull
-	-cd $(GH_PAGES); ls -A | grep -v '.git$$' | xargs rm -rf
+PHONY += gh-pages
+gh-pages: docs-clean docs
+	- git worktree remove -f $(GH_PAGES) || exit 0
+	- git branch -D gh-pages || exit 0
+	git worktree add --no-checkout $(GH_PAGES) master
+	cd $(GH_PAGES); git checkout --orphan gh-pages && git rm -rfq .
 	$(MAKE) prepare-gh-pages
 	cd $(GH_PAGES);\
 		git add --all . ;\
-		git commit -m "gh-pages: updated" ;\
-		git push origin gh-pages
+		git commit -q -m "make gh-pages: from $(shell git config --get remote.origin.url)@$(shell git rev-parse HEAD)" ;\
+		git push -f origin gh-pages
 
 PHONY += travis-gh-pages
-travis-gh-pages:
-	$(MAKE) docs
+travis-gh-pages: docs-clean docs
 	rm -Rf $(GH_PAGES)
 	mkdir -p $(GH_PAGES)
 	$(MAKE) prepare-gh-pages


### PR DESCRIPTION
 [fix] Makefile target gh-pages & flatten history of branch gh.pages

1. This patch fixes error:

        rm -rf gh-pages/
        make V=1 gh-pages
            make[1]: Leaving directory '/800GBPCIex4/share/searx'
        [ -d "gh-pages/.git" ] || git clone  gh-pages
        fatal: repository 'gh-pages' does not exist

2. The gh-page build has been moved to ./build/gh-pages this also affects
   'travis-gh-pages'

3. The gh-pages commit messages now includes a ref to the repository and commit

4. Since a gh-pages history has only the drawback that the reposetory grows
   fast, this patch also flattens the history:

        cd build/gh-pages/; git log --oneline
        bash: cd: build/gh-pages/: Datei oder Verzeichnis nicht gefunden
        026126b (HEAD -> gh-pages, origin/gh-pages) make gh-pages: from https://github.com/return42/searx.git@71d66979c2935312e0aed7fc7c3cf6199fbe88a2

## Related issues

Remove cryptic fly dirt from the commit message: https://github.com/JamesIves/github-pages-deploy-action/pull/576
