### PR TITLE
Update pyenv pyenvinstall Make targets

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -34,7 +34,7 @@ jobs:
         make V=1 install
         make V=1 gecko.driver
     - name: Run tests
-      run: make V=1 test
+      run: make V=1 ci.test
     - name: Test coverage
       run: make V=1 test.coverage
     - name: Store coverage result

--- a/Makefile
+++ b/Makefile
@@ -251,6 +251,11 @@ test.clean:
 # travis
 # ------
 
+PHONY += ci.test
+ci.test:
+	$(PY_ENV_BIN)/python -c "import yaml"  || make clean
+	$(MAKE) test
+
 travis.codecov:
 	$(Q)$(PY_ENV_BIN)/python -m pip install codecov
 

--- a/utils/makefile.python
+++ b/utils/makefile.python
@@ -99,7 +99,8 @@ quiet_cmd_pyinstall = INSTALL   $2
 quiet_cmd_pyenvinstall = PYENV     install $2
       cmd_pyenvinstall = \
 	if ! cat $(PY_ENV)/requirements.sha256 2>/dev/null | sha256sum --check --status 2>/dev/null; then \
-		$(PY_ENV_BIN)/python -m pip $(PIP_VERBOSE) install -e $2$(PY_SETUP_EXTRAS) ;\
+		rm -f $(PY_ENV)/requirements.sha256; \
+		$(PY_ENV_BIN)/python -m pip $(PIP_VERBOSE) install -e $2$(PY_SETUP_EXTRAS) &&\
 		sha256sum requirements*.txt > $(PY_ENV)/requirements.sha256 ;\
 	else \
 		echo "PYENV     $2 already installed"; \
@@ -119,13 +120,13 @@ quiet_cmd_pyenvuninstall = PYENV     uninstall   $2
 # $2 path to folder where virtualenv take place
 quiet_cmd_virtualenv  = PYENV     usage: $ source ./$@/bin/activate
       cmd_virtualenv  = \
-	if [ ! -d "./$(PY_ENV)" ];then                                  \
-		$(PYTHON) -m venv $(VTENV_OPTS) $2;                     \
+	if [ -d "./$(PY_ENV)" -a -x "./$(PY_ENV_BIN)/python" ]; then \
+		echo "PYENV     using virtualenv from $2"; \
+	else \
+		$(PYTHON) -m venv $(VTENV_OPTS) $2; \
 		$(PY_ENV_BIN)/python -m pip install $(PIP_VERBOSE) -U pip wheel setuptools; \
-		$(PY_ENV_BIN)/python -m pip install $(PIP_VERBOSE) -r requirements.txt;     \
-	else                                                            \
-		echo "PYENV     using virtualenv from $2";              \
-        fi
+		$(PY_ENV_BIN)/python -m pip install $(PIP_VERBOSE) -r requirements.txt; \
+	fi
 
 # $2 path to lint
 quiet_cmd_pylint      = LINT      $@

--- a/utils/makefile.python
+++ b/utils/makefile.python
@@ -87,6 +87,22 @@ python-exe:
 	@:
 endif
 
+msg-pip-exe:
+	@echo "\n  $(PIP) is required\n\n\
+  Make sure you have updated pip installed, grab it from\n\
+  https://pip.pypa.io or install it from your package\n\
+  manager. On debian based OS these requirements are\n\
+  installed by::\n\n\
+    sudo -H apt-get install python$(PY)-pip\n" | $(FMT)
+
+ifeq ($(shell which $(PIP) >/dev/null 2>&1; echo $$?), 1)
+pip-exe: msg-pip-exe
+	$(error The '$(PIP)' command was not found)
+else
+pip-exe:
+	@:
+endif
+
 # ------------------------------------------------------------------------------
 # commands
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Change about utils/makefile.python: 
* `make pyenv` makes sure that there is a python executable in the virtualenv, if not the virtualenv is installed again.
* `make pyenvinstall` makes to install `pyyaml` before running setup.py (setup.py requires pyyml to read searx/settings.yml)

## Why is this change important?

* github action workflow caches the ./local directory : 
https://github.com/searx/searx/blob/71d66979c2935312e0aed7fc7c3cf6199fbe88a2/.github/workflows/integration.yml#L25-L32
* sometimes this cache can be corrupted (it is not clear how the cache gets corrupted).
* this PR ensure that `make test` works as expected even if
    * the python interpreter is missing
    * the virtualenv exists but pyyaml is missing

## How to test this PR locally?

```
make pyenvinstall
rm ./local/py3/bin/python
make test
source ./local/py3/bin/activate
pip uninstall pyyaml
make pyenvinstall
```

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
