### PR TITLE
Hardening travis 'Run tests' workflow when git-workflow caching fails

### DIFF
--- a/docs/dev/makefile.rst
+++ b/docs/dev/makefile.rst
@@ -36,27 +36,33 @@ Python environment
 
    ``source ./local/py3/bin/activate``
 
-With Makefile we do no longer need to build up the virtualenv manually (as
-described in the :ref:`devquickstart` guide).  Jump into your git working tree
-and release a ``make pyenv``:
+With Makefile we do no longer need to build up the virtualenv manually. Jump
+into your git working tree and release a ``make pyenv``:
 
 .. code:: sh
 
    $ cd ~/searx-clone
    $ make pyenv
-   PYENV     usage: source ./local/py3/bin/activate
+   PYENV     [virtualenv] usage: source ./local/py3/bin/activate
+   PYENV     [virtualenv] installing requirements*.txt into ./local/py3
    ...
+   Successfully installed ...
 
 With target ``pyenv`` a development environment (aka virtualenv) was build up in
 ``./local/py3/``.  To make a *developer install* of searx (:origin:`setup.py`)
 into this environment, use make target ``install``:
 
-.. code:: sh
+.. code:: text
 
    $ make install
-   PYENV     usage: source ./local/py3/bin/activate
-   PYENV     using virtualenv from ./local/py3
-   PYENV     install .
+   PYENV     [virtualenv] usage: source ./local/py3/bin/activate
+   PYENV     [virtualenv] using ./local/py3 // glob pattern requirements*.txt --> sha256 OK
+   ...
+   ModuleNotFoundError: No module named 'searx'
+   PYENV     [pyenvinstall]  pip install -e .\[test\]
+   ...
+     Running setup.py develop for searx
+   Successfully installed ... searx ...
 
 You have never to think about intermediate targets like ``pyenv`` or
 ``install``, the ``Makefile`` chains them as requisites.  Just run your main
@@ -64,13 +70,26 @@ target.
 
 .. sidebar:: drop environment
 
-   To get rid of the existing environment before re-build use :ref:`clean target
-   <make clean>` first.
+   To get rid of the existing environment before re-build use: :ref:`make clean`
 
-If you think, something goes wrong with your ./local environment or you change
-the :origin:`setup.py` file (or the requirements listed in
+If you think, something goes wrong with your ``./local`` environment or you
+change the :origin:`setup.py` file (or the requirements listed in
 :origin:`requirements-dev.txt` and :origin:`requirements.txt`), you have to call
 :ref:`make clean`.
+
+``PYENV_REQ``: requirement files (glob pattern: ``requirements*.txt``)
+  For ever reasons, if you want to install only ``requirements.txt``
+
+  .. code:: text
+
+     $ make PYENV_REQ=requirements.txt clean pyenv
+     make PYENV_REQ=requirements.txt clean pyenv
+     CLEAN     ...
+     ...
+     PYENV     [virtualenv] usage: source ./local/py3/bin/activate
+     PYENV     [virtualenv] installing requirements.txt into ./local/py3
+     ...
+     Successfully installed ...
 
 
 .. _make run:
@@ -86,9 +105,15 @@ browser (:man:`xdg-open`):
 .. code:: sh
 
   $ make run
-  PYENV     usage: source ./local/py3/bin/activate
-  PYENV     install .
-  ./local/py3/bin/python ./searx/webapp.py
+  PYENV     [virtualenv] usage: source ./local/py3/bin/activate
+  PYENV     [virtualenv] installing requirements*.txt into ./local/py3
+  ...
+  PYENV     [pyenvinstall] pip install -e .\[test\]
+  ...
+    Running setup.py develop for searx
+  Successfully installed searx
+  ...
+  SEARX_DEBUG=1 ./local/py3/bin/python ./searx/webapp.py
   ...
   INFO:werkzeug: * Running on http://127.0.0.1:8888/ (Press CTRL+C to quit)
   ...
@@ -102,10 +127,13 @@ Drop all intermediate files, all builds, but keep sources untouched.  Includes
 target ``pyclean`` which drops ./local environment.  Before calling ``make
 clean`` stop all processes using :ref:`make pyenv`.
 
-.. code:: sh
+.. code:: text
 
-   $ make clean
+   make clean
    CLEAN     pyclean
+   CLEAN     docs-clean
+   CLEAN     locally installed npm dependencies
+   CLEAN     intermediate test stuff
    CLEAN     clean
 
 .. _make docs:

--- a/utils/makefile.python
+++ b/utils/makefile.python
@@ -19,6 +19,7 @@ PY       ?=3
 PYTHON   ?= python$(PY)
 PIP      ?= pip$(PY)
 PIP_INST ?= --user
+PYENV_REQ ?= requirements*.txt
 
 # https://www.python.org/dev/peps/pep-0508/#extras
 #PY_SETUP_EXTRAS ?= \[develop,test\]
@@ -45,7 +46,7 @@ VTENV_OPTS ?=
 python-help::
 	@echo  'makefile.python:'
 	@echo  '  pyenv | pyenv[un]install'
-	@echo  '     build $(PY_ENV) & [un]install python objects'
+	@echo  '     build $(PY_ENV) & [un]install python objects (editable)'
 	@echo  '  targts using pyenv $(PY_ENV):'
 	@echo  '    pylint    - run pylint *linting*'
 	@echo  '    pytest    - run *tox* test on python objects'
@@ -61,6 +62,7 @@ python-help::
 	@echo  '  make TEST=.           => choose test from $(TEST_FOLDER) (default "." runs all)'
 	@echo  '  make DEBUG=           => target "debug": do not invoke PDB on errors'
 	@echo  '  make PY_SETUP_EXTRAS  => also install extras_require from setup.py \[develop,test\]'
+	@echo  '  make PYENV_REQ=...    => target pyenv: requirement files (glob pattern $(PYENV_REQ))'
 	@echo  '  when using target "pydebug", set breakpoints within py-source by adding::'
 	@echo  '    DEBUG()'
 
@@ -112,15 +114,18 @@ quiet_cmd_pyinstall = INSTALL   $2
       cmd_pyinstall = $(PIP) $(PIP_VERBOSE) install $(PIP_INST) -e $2$(PY_SETUP_EXTRAS)
 
 # $2 path to folder with setup.py, this uses pip from pyenv (not OS!)
-quiet_cmd_pyenvinstall = PYENV     install $2
+quiet_cmd_pyenvinstall = PYENV     [pyenvinstall] $(PY_ENV): install $2
       cmd_pyenvinstall = \
-	if ! cat $(PY_ENV)/requirements.sha256 2>/dev/null | sha256sum --check --status 2>/dev/null; then \
-		rm -f $(PY_ENV)/requirements.sha256; \
-		$(PY_ENV_BIN)/python -m pip $(PIP_VERBOSE) install -e $2$(PY_SETUP_EXTRAS) &&\
-		sha256sum requirements*.txt > $(PY_ENV)/requirements.sha256 ;\
+	_IMP_STATEMENT="import $(foreach var,$(wildcard $(PYOBJECTS)),$(var), ) pkg_resources"; \
+	if ! $(PY_ENV_BIN)/python -c \
+		"import sys; sys.path.pop(0); $$_IMP_STATEMENT;" 2>/dev/null;\
+	then \
+		echo "PYENV     [pyenvinstall] $2 not installed: '$$_IMP_STATEMENT' --> failed"; \
+		echo "PYENV     [pyenvinstall] pip install -e $2$(PY_SETUP_EXTRAS)"; \
+		$(PY_ENV_BIN)/python -m pip $(PIP_VERBOSE) install -e $2$(PY_SETUP_EXTRAS); \
 	else \
-		echo "PYENV     $2 already installed"; \
-	fi
+		echo "PYENV     [pyenvinstall] $2 already installed // '$$_IMP_STATEMENT' --> OK"; \
+        fi
 
 # Uninstall the package.  Since pip does not uninstall the no longer needed
 # depencies (something like autoremove) the depencies remain.
@@ -130,19 +135,28 @@ quiet_cmd_pyuninstall = UNINSTALL $2
       cmd_pyuninstall = $(PIP) $(PIP_VERBOSE) uninstall --yes $2
 
 # $2 path to folder with setup.py, this uses pip from pyenv (not OS!)
-quiet_cmd_pyenvuninstall = PYENV     uninstall   $2
-      cmd_pyenvuninstall = $(PY_ENV_BIN)/python -m pip $(PIP_VERBOSE) uninstall --yes $2
+quiet_cmd_pyenvuninstall = PYENV     [pyenvuninstall] uninstall packages: $2
+      cmd_pyenvuninstall = \
+	if [ "." = "$2" ]; then \
+		$(PY_ENV_BIN)/python setup.py develop --uninstall; \
+	else \
+		$(PY_ENV_BIN)/python -m pip $(PIP_VERBOSE) uninstall --yes $2; \
+	fi
 
 # $2 path to folder where virtualenv take place
-quiet_cmd_virtualenv  = PYENV     usage: $ source ./$@/bin/activate
+quiet_cmd_virtualenv  = PYENV     [virtualenv] usage: $ source ./$@/bin/activate
       cmd_virtualenv  = \
-	if [ -d "./$(PY_ENV)" -a -x "./$(PY_ENV_BIN)/python" ]; then \
-		echo "PYENV     using virtualenv from $2"; \
-	else \
+	if ! cat $(PY_ENV)/requirements.sha256 2>/dev/null | sha256sum --check --status 2>/dev/null; then \
+		echo "PYENV     [virtualenv] installing $(PYENV_REQ) into $2"; \
+		rm -f $(PY_ENV)/$(PYENV_REQ).sha256; \
 		$(PYTHON) -m venv $(VTENV_OPTS) $2; \
 		$(PY_ENV_BIN)/python -m pip install $(PIP_VERBOSE) -U pip wheel setuptools; \
-		$(PY_ENV_BIN)/python -m pip install $(PIP_VERBOSE) -r requirements.txt; \
-	fi
+		$(PY_ENV_BIN)/python -m pip install $(PIP_VERBOSE) $(foreach var,$(wildcard $(PYENV_REQ)),-r '$(var)') \
+		&& sha256sum $(wildcard $(PYENV_REQ)) > $(PY_ENV)/requirements.sha256 ; \
+	else \
+		echo "PYENV     [virtualenv] using $2 // glob pattern $(PYENV_REQ) --> sha256 OK"; \
+		cat $(PY_ENV)/requirements.sha256 | sed 's/^/          [virtualenv] - /'; \
+        fi
 
 # $2 path to lint
 quiet_cmd_pylint      = LINT      $@
@@ -201,7 +215,7 @@ pyinstall: pip-exe
 
 PHONY += pyuninstall
 pyuninstall: pip-exe
-	$(call cmd,pyuninstall,$(PYOBJECTS))
+	$(call cmd,pyuninstall,.)
 
 # for installation use the pip from PY_ENV (not the OS)!
 PHONY += pyenvinstall
@@ -210,7 +224,7 @@ pyenvinstall: $(PY_ENV)
 
 PHONY += pyenvuninstall
 pyenvuninstall: $(PY_ENV)
-	$(call cmd,pyenvuninstall,$(PYOBJECTS))
+	$(call cmd,pyenvuninstall,.)
 
 PHONY += pyclean
 pyclean:


### PR DESCRIPTION
## What does this PR do?

Hardening travis 'Run tests' workflow. This PR is a alternative to #2517.  I recommend to read along the git comments.  First the makefile.python is polished and the requirement files are organzied.  The last commit [ensures that `make test` works as expected](https://github.com/searx/searx/pull/2517#discussion_r567240235) even if

- the python interpreter is missing
- the virtualenv exists but pyyaml is missing

## Why is this change important?

github action workflow caches the ./local directory.  Sometimes this cache can be corrupted (it is not clear how the cache gets corrupted).

- https://github.com/searx/searx/pull/2514#issuecomment-769731867
- #2517

## How to test this PR locally?

1. initial run `make travis.test`
2. manipulate the virtualenv, e.g. delete the files from the yaml module

now you have _a coroupted cache_ ....

3. run `make travis.test` again

The tests should run without fail.