### PR TITLE
[fix] make books/user.pdf

### DIFF
--- a/docs/user/conf.py
+++ b/docs/user/conf.py
@@ -4,7 +4,7 @@
 project   = 'Searx User-HB'
 version   = release = VERSION_STRING
 
-intersphinx_mapping['searx'] = (DOCS_URL, None)
+intersphinx_mapping['searx'] = (brand.DOCS_URL, None)
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,


### PR DESCRIPTION
## What does this PR do?

Fix error:

    $ make books/user.pdf
    Configuration error:
    There is a programmable error in your configuration file:
    ...
    NameError: name 'DOCS_URL' is not defined
    make: *** [utils/makefile.sphinx:156: books/user.latex] Fehler 2

## How to test this PR locally?

    $ sudo -H ./utils/searx.sh install buildhost  # install Tex and more to build PDF
    $ make books/user.pdf
