### PR TITLE
[fix] Get correct locale with country from browser

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -142,6 +142,7 @@ babel = Babel(app)
 
 rtl_locales = ['ar', 'arc', 'bcc', 'bqi', 'ckb', 'dv', 'fa', 'fa_IR', 'glk', 'he',
                'ku', 'mzn', 'pnb', 'ps', 'sd', 'ug', 'ur', 'yi']
+ui_locale_codes = [l.replace('_', '-') for l in settings['locales'].keys()]
 
 # used when translating category names
 _category_names = (gettext('files'),
@@ -175,6 +176,9 @@ def _get_browser_or_settings_language(request, lang_list):
     for lang in request.headers.get("Accept-Language", "en").split(","):
         if ';' in lang:
             lang = lang.split(';')[0]
+        if '-' in lang:
+            lang_parts = lang.split('-')
+            lang = "{}-{}".format(lang_parts[0], lang_parts[-1].upper())
         locale = match_language(lang, lang_list, fallback=None)
         if locale is not None:
             return locale
@@ -194,12 +198,9 @@ def get_locale():
         locale_source = 'preferences'
     else:
         # use local from the browser
-        locale = _get_browser_or_settings_language(request, settings['locales'].keys())
+        locale = _get_browser_or_settings_language(request, ui_locale_codes)
+        locale = locale.replace('-', '_')
         locale_source = 'browser'
-
-    #
-    if locale == 'zh_TW':
-        locale = 'zh_Hant_TW'
 
     # see _get_translations function
     # and https://github.com/searx/searx/pull/1863

--- a/tests/unit/test_webapp.py
+++ b/tests/unit/test_webapp.py
@@ -198,6 +198,20 @@ class ViewsTestCase(SearxTestCase):
             result.data
         )
 
+    def test_browser_locale(self):
+        result = self.app.get('/preferences', headers={'Accept-Language': 'zh-tw;q=0.8'})
+        self.assertEqual(result.status_code, 200)
+        self.assertIn(
+            b'<option value="zh_TW" selected="selected">',
+            result.data,
+            'Interface locale ignored browser preference.'
+        )
+        self.assertIn(
+            b'<option value="zh-TW" selected="selected">',
+            result.data,
+            'Search language ignored browser preference.'
+        )
+
     def test_stats(self):
         result = self.app.get('/stats')
         self.assertEqual(result.status_code, 200)


### PR DESCRIPTION
## What does this PR do?

Some of our interface locales include uppercase country codes, which are separated by `_` instead of the more common `-`.
Also, a browser's `Accept-Language` header could be in lowercase.

This commit attempts to normalize those cases so a browser's language+country codes can better match with our locales.

## How to test this PR locally?

1. Change your browser's `Accept-Language` header to add a country specific locale that we support (such as `pt-BR`, `nl-BE` or `zh-TW`). Note: This locale has to be the first one in the `Accept-Language` list.
2. Go to preferences.

Expected result: Correct locale is selected (`pt_BR` rather than `pt` and so on).

I also added a unit test to automate this.

## Author's checklist
This solution assumes that our UI locales have nothing more than language and optionally a country.
If we ever add a script specific locale like `zh_Hant_TW`* this would have to change to accommodate that, but the idea would be pretty much the same as this fix.

*By the way, in [our Transifex page](https://www.transifex.com/asciimoo/searx/languages/) it looks like `zh_Hant_TW` was removed (I assume it was merged with `zh_TW` which is already in traditional Chinese). Should we remove [this directory](https://github.com/searx/searx/tree/master/searx/translations/zh_Hant_TW/LC_MESSAGES) or am I making a wrong assumption here?

## Related issues
Closes #2525
