### PR TITLE
[drop] metager - xpath engine won't work anymore

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -717,24 +717,6 @@ engines:
       require_api_key: false
       results: HTML
 
-  - name : metager
-    engine : xpath
-    paging : False
-    search_url : https://metager.org/meta/meta.ger3?eingabe={query}
-    url_xpath : //div[@class="result-subheadline"]/a/@href
-    title_xpath : //div[@class="result-headline"]/h2/@title
-    content_xpath : //div[@class="result-description"]/text()
-    categories : general
-    shortcut : mg
-    disabled : True
-    about:
-      website: https://metager.org/
-      wikidata_id: Q1924645
-      official_api_documentation:
-      use_official_api: false
-      require_api_key: false
-      results: HTML
-
   - name : microsoft academic
     engine : microsoft_academic
     categories : science


### PR DESCRIPTION
## What does this PR do?

drop metager (xpath) engine

## Why is this change important?

The new version of MetaGer needs to reload the reults (into a iframe) with a
unique tag (see HTML response below).

This is the first response, the id (b82679980656899ba5a17ffd02a56846) is unique
for each query:

    $ curl "https://metager.org/meta/meta.ger3?eingabe=foo&submit-query=&focus=web"
    <!DOCTYPE html>
    <html lang="en">
    <head>
        <meta charset="UTF-8">
        <link rel="stylesheet" href="/index.css?id=b82679980656899ba5a17ffd02a56846">
        <script src="/index.js?id=b82679980656899ba5a17ffd02a56846"></script>
    <title>foo - MetaGer</title>
    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
    </head>
    <body>
        <iframe id="mg-framed" src="https://metager.org/meta/meta.ger3?eingabe=foo&amp;submit-query=&amp;focus=web&amp;mgv=b82679980656899ba5a17ffd02a56846" autofocus="true" onload="this.contentWindow.focus();"></iframe>
     </body>


## Author's checklist

Implementing a dedicated metager-engine for searx makes no sense to me. The
great days of MetaGer seems to be ended.  I remember the good old days this
project started in the 90's of the last century.  But in the last few years it
becomes more and more crap.  As the name suggested, MetaGer was made for
germans in the first place.  They have added a english and spain translation but
the i18n is very poor compared to what searx offers.

It's a pity, lets drop MetaGer.
