### PR TITLE
Ignore double-quotes when highlighting query parts

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -154,6 +154,6 @@ generally made searx better:
 - @mrwormo
 - Xiaoyu WEI @xywei
 - @joshu9h
-
+- Daniel Hones
 
 

--- a/searx/webutils.py
+++ b/searx/webutils.py
@@ -119,7 +119,10 @@ def highlight_content(content, query):
     else:
         regex_parts = []
         for chunk in query.split():
-            if len(chunk) == 1:
+            chunk = chunk.replace('"', '')
+            if len(chunk) == 0:
+                continue
+            elif len(chunk) == 1:
                 regex_parts.append('\\W+{0}\\W+'.format(re.escape(chunk)))
             else:
                 regex_parts.append('{0}'.format(re.escape(chunk)))

--- a/tests/unit/test_webutils.py
+++ b/tests/unit/test_webutils.py
@@ -34,6 +34,28 @@ class TestWebUtils(SearxTestCase):
         query = 'a test'
         self.assertEqual(webutils.highlight_content(content, query), content)
 
+        data = (
+            ('" test "',
+             'a test string',
+             'a <span class="highlight">test</span> string'),
+            ('"a"',
+             'this is a test string',
+             'this is<span class="highlight"> a </span>test string'),
+            ('a test',
+             'this is a test string that matches entire query',
+             'this is <span class="highlight">a test</span> string that matches entire query'),
+            ('this a test',
+             'this is a string to test.',
+             ('<span class="highlight">this</span> is<span class="highlight"> a </span>'
+              'string to <span class="highlight">test</span>.')),
+            ('match this "exact phrase"',
+             'this string contains the exact phrase we want to match',
+             ('<span class="highlight">this</span> string contains the <span class="highlight">exact</span>'
+              ' <span class="highlight">phrase</span> we want to <span class="highlight">match</span>'))
+        )
+        for query, content, expected in data:
+            self.assertEqual(webutils.highlight_content(content, query), expected)
+
 
 class TestUnicodeWriter(SearxTestCase):
 


### PR DESCRIPTION
## What does this PR do?

This is to fix a minor UI bug where using a search with an exact phrase in quotes wouldn't highlight the matching phrase in the search results.  This replaces #901 which I'll close.

For example:

search: `master of none`
result: **master of none**

search: `"master of none"`
result: master **of** none
 
The cause of this bug is that a query like `"master of none"` gets split into `['"master', 'of', 'none"']`, and the code tries to highlight strings like `none"` which aren't typically in the text.  This change works by ignoring double quotes in the query.  I added test coverage for other paths through the `webutils.highlight_content` function.  Currently there are no tests that cover the scenario where there needs to be `span` elements inserted in the result.

## Why is this change important?

Without this change, only the interior parts of a phrase in quotes will be highlighted.  In many cases that might be the least important words of the phrase and it's surprising behavior to a user.

## How to test this PR locally?

The unit tests for this function pass and to test manually, you can search for several queries, first without quotation marks, and then with them, and the highlighted words in the results should be the same.

## Author's checklist

I considered pulling the existing test cases in to the new `data` tuple in the unit test, but I decided it was useful to keep them separate because they're all testing edge cases or cases where no highlights would be inserted.