### PR TITLE
Add support for Chinese variants in Wikipedia

### DIFF
--- a/searx/engines/wikipedia.py
+++ b/searx/engines/wikipedia.py
@@ -22,6 +22,7 @@ about = {
 # search-url
 search_url = 'https://{language}.wikipedia.org/api/rest_v1/page/summary/{title}'
 supported_languages_url = 'https://meta.wikimedia.org/wiki/List_of_Wikipedias'
+language_variants = {"zh": ("zh-cn", "zh-hk", "zh-mo", "zh-my", "zh-sg", "zh-tw")}
 
 
 # set language in base_url
@@ -37,8 +38,12 @@ def request(query, params):
     if query.islower():
         query = query.title()
 
+    language = url_lang(params['language'])
     params['url'] = search_url.format(title=quote(query),
-                                      language=url_lang(params['language']))
+                                      language=language)
+
+    if params['language'].lower() in language_variants.get(language, []):
+        params['headers']['Accept-Language'] = params['language'].lower()
 
     params['headers']['User-Agent'] = searx_useragent()
     params['raise_for_httperror'] = False
@@ -60,7 +65,7 @@ def response(resp):
     if api_result.get('type') != 'standard':
         return []
 
-    title = api_result['title']
+    title = api_result['displaytitle']
     wikipedia_link = api_result['content_urls']['desktop']['page']
 
     results.append({'url': wikipedia_link, 'title': title})


### PR DESCRIPTION
## What does this PR do?

Show Wikipedia's infobox in the regional Chinese script specified in the query.

## How to test this PR locally?
Search for `!wp 出租車` with each of the available Chinese options either from the language dropdown or with a `:` bang.

Expected results:
* `中文 - zh` should show 出租車.
* `中文 (中国) - zh-CN` should show 出租车.
* `中文 (台灣) - zh-TW` should show 計程車.
* `:zh-HK` should show 的士.
* `:zh-SG` should show 德士.

The Wikipedia link returned by the API is still the same in all cases (https://zh.wikipedia.org/wiki/%E5%87%BA%E7%A7%9F%E8%BB%8A) but if your browser's `Accept-Language` is set to any of the above, Wikipedia automatically returns the desired script in their webpage.

## Note

Actually, this problem affects other languages like Serbian as well (see: https://sr.wikipedia.org/sr-ec/Аутомобил vs. https://sr.wikipedia.org/sr-el/Automobil) but in that case the difference can't be determined by a country code but only by a script code and we currently don't support those anyway.

## Related issues
#2537
