### PR TITLE
Fix: activate raise_for_error by default

### DIFF
--- a/searx/search/processors/online.py
+++ b/searx/search/processors/online.py
@@ -77,7 +77,7 @@ class OnlineProcessor(EngineProcessor):
         soft_max_redirects = params.get('soft_max_redirects', max_redirects or 0)
 
         # raise_for_status
-        request_args['raise_for_httperror'] = params.get('raise_for_httperror', False)
+        request_args['raise_for_httperror'] = params.get('raise_for_httperror', True)
 
         # specific type of request (GET or POST)
         if params['method'] == 'GET':


### PR DESCRIPTION
## What does this PR do?

Fix commit d703119d3a313a406482b121ee94c6afee3bc307 :
Some engines need to parse the HTTP error but
raise_for_error is always set to False in the "request" function.

## Why is this change important?

Return a clear error message to the user instead of `No result`.

## How to test this PR locally?

For `!archive_is time` , searx returns an error `archive is (too many requests)` instead of `No result`.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
