### PR TITLE
[upd] remove google_play_music engine

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -583,25 +583,6 @@ engines:
       require_api_key: false
       results: HTML
 
-  - name : google play music
-    engine : xpath
-    search_url : https://play.google.com/store/search?q={query}&c=music
-    results_xpath : '//div[@class="WHE7ib mpg5gc"]'
-    title_xpath : './/div[@class="RZEgze"]//div[@title and not(@title="")]/a'
-    url_xpath : './/div[@class="RZEgze"]//div[@title and not(@title="")]/a/@href'
-    content_xpath : './/div[@class="RZEgze"]//a[@class="mnKHRc"]'
-    thumbnail_xpath : './/div[@class="uzcko"]/div/span[1]//img/@data-src'
-    categories : music
-    shortcut : gps
-    disabled : True
-    about:
-      website: https://play.google.com/
-      wikidata_id: Q79576
-      official_api_documentation:
-      use_official_api: false
-      require_api_key: false
-      results: HTML
-
   - name : geektimes
     engine : xpath
     paging : True


### PR DESCRIPTION
## What does this PR do?

Google Play Music has been replaced by Youtube music : 
https://en.wikipedia.org/wiki/Google_Play_Music

> Discontinued : December 3, 2020; 2 months ago

## Why is this change important?

Avoid disappointing user experience.

## How to test this PR locally?

N/A

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
