### PR TITLE
[upd] wikipedia engine: return an empty result on query with illegal characters

### DIFF
--- a/searx/engines/wikipedia.py
+++ b/searx/engines/wikipedia.py
@@ -56,6 +56,17 @@ def request(query, params):
 def response(resp):
     if resp.status_code == 404:
         return []
+
+    if resp.status_code == 400:
+        try:
+            api_result = loads(resp.text)
+        except:
+            pass
+        else:
+            if api_result['type'] == 'https://mediawiki.org/wiki/HyperSwitch/errors/bad_request' \
+               and api_result['detail'] == 'title-invalid-characters':
+                return []
+
     raise_for_httperror(resp)
 
     results = []


### PR DESCRIPTION
## What does this PR do?

On some queries (like an IT error message), wikipedia returns an HTTP error 400.
this commit returns an empty result list instead of showing an error to the user.

## Why is this change important?

Wikipedia won't have a result this query ` '--default-pip']' died with <Signals.SIGABRT: 6>` .
For the user point of view, it is better to return an empty result list rather than an error message.

## How to test this PR locally?

* `!wp --default-pip']' died with <Signals.SIGABRT: 6>`

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
