### PR TITLE
Improve peertube searching

### DIFF
--- a/searx/engines/peertube.py
+++ b/searx/engines/peertube.py
@@ -21,14 +21,15 @@ about = {
 # engine dependent config
 categories = ["videos"]
 paging = True
-base_url = "https://peer.tube/"
-supported_languages_url = base_url + "api/v1/videos/languages"
+base_url = "https://peer.tube"
+supported_languages_url = base_url + "/api/v1/videos/languages"
 
 
 # do search-request
 def request(query, params):
+    sanitized_url = base_url.rstrip("/")
     pageno = (params["pageno"] - 1) * 15
-    search_url = base_url + "api/v1/search/videos/?pageno={pageno}&{query}"
+    search_url = sanitized_url + "/api/v1/search/videos/?pageno={pageno}&{query}"
     query_dict = {"search": query}
     language = params["language"].split("-")[0]
     # pylint: disable=undefined-variable
@@ -46,6 +47,7 @@ def _get_offset_from_pageno(pageno):
 
 # get response from search-request
 def response(resp):
+    sanitized_url = base_url.rstrip("/")
     results = []
 
     search_res = loads(resp.text)
@@ -53,7 +55,7 @@ def response(resp):
     embedded_url = (
         '<iframe width="560" height="315" sandbox="allow-same-origin allow-scripts allow-popups" '
         + 'src="'
-        + base_url
+        + sanitized_url
         + '{embed_path}" frameborder="0" allowfullscreen></iframe>'
     )
     # return empty array if there are no results
@@ -63,15 +65,15 @@ def response(resp):
     # parse results
     for res in search_res["data"]:
         title = res["name"]
-        url = base_url + "/videos/watch/" + res["uuid"]
+        url = sanitized_url + "/videos/watch/" + res["uuid"]
         description = res["description"]
         if description:
             content = html_to_text(res["description"])
         else:
-            content = None
-        thumbnail = base_url + res["thumbnailPath"]
+            content = ""
+        thumbnail = sanitized_url + res["thumbnailPath"]
         publishedDate = datetime.strptime(res["publishedAt"], "%Y-%m-%dT%H:%M:%S.%fZ")
-        embedded = embedded_url.format(embed_path=res["embedPath"][1:])
+        embedded = embedded_url.format(embed_path=res["embedPath"])
 
         results.append(
             {


### PR DESCRIPTION
## What does this PR do?
At the moment videos without a description are not shown - setting
default content to "" fixes this.
Another current bug is that thumbnails are not displayed. This is caused
by a double slash in the url. For this every trailing slash is now
stripped (for backwards compatibility) and the API response is correctly
parsed.

## Why is this change important?
Currently peertube searching has a few bugs (no shown thumbnails).

## Commentary
There is another annoying thing that I did not fix in this pullrequest: Unless I set the engine language
to default no videos are displayed for me.