### PR TITLE
update yggtorrent url + add it back

### DIFF
--- a/searx/engines/yggtorrent.py
+++ b/searx/engines/yggtorrent.py
@@ -12,7 +12,7 @@ from searx.poolrequests import get as http_get
 
 # about
 about = {
-    "website": 'https://www2.yggtorrent.si',
+    "website": 'https://www4.yggtorrent.li/',
     "wikidata_id": None,
     "official_api_documentation": None,
     "use_official_api": False,
@@ -25,7 +25,7 @@ categories = ['videos', 'music', 'files']
 paging = True
 
 # search-url
-url = 'https://www2.yggtorrent.si/'
+url = 'https://www4.yggtorrent.li/'
 search_url = url + 'engine/search?name={search_term}&do=search&page={pageno}&category={search_type}'
 
 # yggtorrent specific type-definitions

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1022,13 +1022,12 @@ engines:
     # Or you can use the html non-stable engine, activated by default
     engine : youtube_noapi
 
-  # tmp suspended: Cloudflare CAPTCHA
-  #- name : yggtorrent
-  #  engine : yggtorrent
-  #  shortcut : ygg
-  #  url: https://www2.yggtorrent.si/
-  #  disabled : True
-  #  timeout : 4.0
+  - name : yggtorrent
+    engine : yggtorrent
+    shortcut : ygg
+    url: https://www4.yggtorrent.li/
+    disabled : True
+    timeout : 4.0
 
   - name : dailymotion
     engine : dailymotion


### PR DESCRIPTION
## What does this PR do?

This update the base URL of the engine Yggtorrent because Yggtorrent is not using Cloudflare anti bot anymore.

## Why is this change important?

This adds Yggtorrent back.

## How to test this PR locally?

1. Launch Searx
2. `!ygg ubuntu`

## Author's checklist

[x] I tested that the engine works great.

## Related issues

N/A
