### PR TITLE
[mod] update currencies.json and fetch_currencies.py

### DIFF
--- a/.github/workflows/data-update.yml
+++ b/.github/workflows/data-update.yml
@@ -41,7 +41,7 @@ jobs:
           python utils/fetch_languages.py
           python utils/fetch_ahmia_blacklist.py
           python utils/fetch_wikidata_units.py
-          # python utils/fetch_currencies.py
+          python utils/fetch_currencies.py
 
       - name: Create Pull Request
         id: cpr

--- a/searx/data/currencies.json
+++ b/searx/data/currencies.json
@@ -1,7667 +1,14947 @@
 {
     "names": {
-        "francos franceses": [
-            "FRF"
-        ], 
-        "bulgarischer lew": [
-            "BGN"
-        ], 
-        "o\u0308rme\u0301ny dram": [
-            "AMD"
-        ], 
-        "oekrai\u0308ense hryvnja": [
-            "UAH"
-        ], 
-        "guatemalan quetzal": [
-            "GTQ"
-        ], 
-        "ghana cedi": [
-            "GHS"
-        ], 
-        "livre de sainte helene": [
-            "SHP"
-        ], 
-        "papua new guinean kina": [
-            "PGK"
-        ], 
-        "aud": [
-            "AUD"
-        ], 
-        "\u20ab": [
-            "VND"
-        ], 
-        "olasz li\u0301ra": [
-            "ITL"
-        ], 
-        "aserbaidschan manat": [
-            "AZN"
-        ], 
-        "ethiopian dollar": [
-            "ETB"
-        ], 
-        "norwegische krone": [
-            "NOK"
-        ], 
-        "papoea nieuw guinese kina": [
-            "PGK"
-        ], 
-        "som uzbeko": [
-            "UZS"
-        ], 
-        "yuan chino": [
-            "CNY"
-        ], 
-        "nuevo dolar de taiwan": [
-            "TWD"
-        ], 
-        "zweedse kronen": [
-            "SEK"
-        ], 
-        "dollar des i\u0302les cai\u0308mans": [
-            "KYD"
-        ], 
-        "do\u0301lar de singapur": [
-            "SGD"
-        ], 
-        "gru\u0301z lari": [
-            "GEL"
-        ], 
-        "escudo mozambiquen\u0303o": [
-            "MZE"
-        ], 
-        "peso filipino": [
-            "PHP"
-        ], 
-        "grivnia ucraniana": [
-            "UAH"
-        ], 
-        "salamon szigeteki dolla\u0301r": [
-            "SBD"
-        ], 
-        "barbados dollar": [
-            "BBD"
-        ], 
-        "fuang": [
-            "THB"
-        ], 
-        "dirham marroqui": [
-            "MAD"
-        ], 
-        "sri lankan rupees": [
-            "LKR"
-        ], 
-        "qindarka": [
-            "ALL"
-        ], 
-        "dinaro macedone": [
-            "MKD"
-        ], 
-        "togrog": [
-            "MNT"
-        ], 
-        "q\u0259pik": [
-            "AZN"
-        ], 
-        "special drawing rights": [
-            "XDR"
-        ], 
-        "gibralta\u0301ri font": [
-            "GIP"
-        ], 
-        "dinar bahraini": [
-            "BHD"
-        ], 
-        "marokkaanse dirham": [
-            "MAD"
-        ], 
-        "rouble sovie\u0301tique": [
-            "SUR"
-        ], 
-        "tanzanian shilling": [
-            "TZS"
-        ], 
-        "libra de siria": [
-            "SYP"
-        ], 
-        "rand sudafricano": [
-            "ZAR"
-        ], 
-        "seychelse roepie": [
-            "SCR"
-        ], 
-        "seychelse roepia": [
-            "SCR"
-        ], 
-        "forint": [
-            "HUF"
-        ], 
-        "dinar algerino": [
-            "DZD"
-        ], 
-        "roupie du sri lanka": [
-            "LKR"
-        ], 
-        "katar riyal": [
-            "QAR"
-        ], 
-        "schekalim": [
-            "ILS"
-        ], 
-        "corona checoslovaca": [
-            "CSK"
-        ], 
-        "baht tailande\u0301s": [
-            "THB"
-        ], 
-        "nuevo peso": [
-            "ARS", 
-            "UYU"
-        ], 
-        "cuna croata": [
-            "HRK"
-        ], 
-        "nieuwe israe\u0308lische shekel": [
-            "ILS"
-        ], 
-        "nieuwe israelische shekel": [
-            "ILS"
-        ], 
-        "dollar des i\u0302les fidji": [
-            "FJD"
-        ], 
-        "nieuw zeelandse dollar": [
-            "NZD"
-        ], 
-        "tanza\u0301niai shilling": [
-            "TZS"
-        ], 
-        "gold franc": [
-            "XFO"
-        ], 
-        "tongan pa`anga": [
-            "TOP"
-        ], 
-        "francia frank": [
-            "FRF"
-        ], 
-        "brl": [
-            "BRL"
-        ], 
-        "isla\u0308ndische wa\u0308hrung": [
-            "ISK"
-        ], 
-        "guyana dollar": [
-            "GYD"
-        ], 
-        "dollaro australiano": [
-            "AUD"
-        ], 
-        "nakfa e\u0301rythre\u0301en": [
-            "ERN"
-        ], 
-        "kap verde escudo": [
-            "CVE"
-        ], 
-        "dinar iraqui\u0301": [
-            "IQD"
-        ], 
-        "vietnamese dong": [
-            "VND"
-        ], 
-        "neuer sol": [
-            "PEN"
-        ], 
-        "peso de argentina": [
-            "ARS"
-        ], 
-        "ddr mark": [
-            "DDM"
-        ], 
-        "br$": [
-            "BND"
-        ], 
-        "e\u0301szak koreai von": [
-            "KPW"
-        ], 
-        "japanse yen": [
-            "JPY"
-        ], 
-        "franco svizzero": [
-            "CHF"
-        ], 
-        "afghani afgano": [
-            "AFN"
-        ], 
-        "lira siriana": [
-            "SYP"
-        ], 
-        "boliviano": [
-            "BOB"
-        ], 
-        "vanuatui vatu": [
-            "VUV"
-        ], 
-        "tnd": [
-            "TND"
-        ], 
-        "manat turkmene": [
-            "TMT"
-        ], 
-        "namibia dollar": [
-            "NAD"
-        ], 
-        "ern": [
-            "ERN"
-        ], 
-        "manat turkmeno": [
-            "TMT"
-        ], 
-        "bds$": [
-            "BBD"
-        ], 
-        "bhutaanse ngultrum": [
-            "BTN"
-        ], 
-        "peso chilien": [
-            "CLP"
-        ], 
-        "dolar jamaicano": [
-            "JMD"
-        ], 
-        "bahamas dollar": [
-            "BSD"
-        ], 
-        "eritrese nakfa": [
-            "ERN"
-        ], 
-        "czk": [
-            "CZK"
-        ], 
-        "engels pond": [
-            "GBP"
-        ], 
-        "dolar de bermudas": [
-            "BMD"
-        ], 
-        "taka bangladeshi\u0301": [
-            "BDT"
-        ], 
-        "riyal del qatar": [
-            "QAR"
-        ], 
-        "kuwaiti dinar": [
-            "KWD"
-        ], 
-        "seychellen rupie": [
-            "SCR"
-        ], 
-        "boli\u0301var ve\u0301ne\u0301zue\u0301lien": [
-            "VEF"
-        ], 
-        "sri lanka rupie": [
-            "LKR"
-        ], 
-        "do\u0301lar de brunei": [
-            "BND"
-        ], 
-        "do\u0301lar de las islas salomo\u0301n": [
-            "SBD"
-        ], 
-        "lak": [
-            "LAK"
-        ], 
-        "sum uzbeko": [
-            "UZS"
-        ], 
-        "kurus\u0327": [
-            "TRY"
-        ], 
-        "iraqi dinar": [
-            "IQD"
-        ], 
-        "livre sterling": [
-            "GBP"
-        ], 
-        "angolai kwanza": [
-            "AOA"
-        ], 
-        "lat": [
-            "LVL"
-        ], 
-        "lek albanais": [
-            "ALL"
-        ], 
-        "brunei dolla\u0301r": [
-            "BND"
-        ], 
-        "tetri": [
-            "GEL"
-        ], 
-        "sterlina sudsudanese": [
-            "SSP"
-        ], 
-        "mo\u0308ngo\u0308": [
-            "MNT"
-        ], 
-        "mexican un peso coinage": [
-            "MXN"
-        ], 
-        "djiboutische frank": [
-            "DJF"
-        ], 
-        "seychelle i ru\u0301pia": [
-            "SCR"
-        ], 
-        "litauischer litas": [
-            "LTL"
-        ], 
-        "zambiaanse kwacha": [
-            "ZMW"
-        ], 
-        "maldi\u0301v szigeteki ru\u0301fia": [
-            "MVR"
-        ], 
-        "dinar bahreini\u0301": [
-            "BHD"
-        ], 
-        "barbadiaanse dollar": [
-            "BBD"
-        ], 
-        "drachme": [
-            "GRD"
-        ], 
-        "emalangeni": [
-            "SZL"
-        ], 
-        "canadese dollar": [
-            "CAD"
-        ], 
-        "mx$": [
-            "MXN"
-        ], 
-        "chinesischer renminbi": [
-            "CNY"
-        ], 
-        "macedonian denar": [
-            "MKD"
-        ], 
-        "uic franc": [
-            "XFU"
-        ], 
-        "won surcoreano": [
-            "KRW"
-        ], 
-        "nuevo shekel": [
-            "ILS"
-        ], 
-        "arubaanse florin": [
-            "AWG"
-        ], 
-        "ruanda franc": [
-            "RWF"
-        ], 
-        "franco burundes": [
-            "BIF"
-        ], 
-        "makao\u0301i pataca": [
-            "MOP"
-        ], 
-        "koruna c\u030ceska\u0301": [
-            "CZK"
-        ], 
-        "dirham des e\u0301mirats": [
-            "AED"
-        ], 
-        "mozambiki metical": [
-            "MZN"
-        ], 
-        "panamanian balboa": [
-            "PAB"
-        ], 
-        "syrian pound": [
-            "SYP"
-        ], 
-        "ki\u0301nai ju\u0308an": [
-            "CNY"
-        ], 
-        "mxn": [
-            "MXN"
-        ], 
-        "dolar fijiano": [
-            "FJD"
-        ], 
-        "a\u0308thiopischer birr": [
-            "ETB"
-        ], 
-        "kirgiz szom": [
-            "KGS"
-        ], 
-        "dinar du ye\u0301men du sud": [
-            "YER"
-        ], 
-        "peso moneda nacional": [
-            "ARS"
-        ], 
-        "scellino somalo": [
-            "SOS"
-        ], 
-        "cseh korona": [
-            "CZK"
-        ], 
-        "uruguayan peso": [
-            "UYU"
-        ], 
-        "cl$": [
-            "CLP"
-        ], 
-        "convertibele peso": [
-            "CUC"
-        ], 
-        "britisches pfund": [
-            "GBP"
-        ], 
-        "tonga dollar": [
-            "TOP"
-        ], 
-        "peso cubain convertible": [
-            "CUC"
-        ], 
-        "argentin peso": [
-            "ARS"
-        ], 
-        "lira maltesa": [
-            "MTL"
-        ], 
-        "bosnische konvertibilna marka": [
-            "BAM"
-        ], 
-        "francs suisse": [
-            "CHF"
-        ], 
-        "gourde haitienne": [
-            "HTG"
-        ], 
-        "shilling somali": [
-            "SOS"
-        ], 
-        "nt$": [
-            "TWD"
-        ], 
-        "rp": [
-            "IDR"
-        ], 
-        "dolar de las bahamas": [
-            "BSD"
-        ], 
-        "rs": [
-            "BRL"
-        ], 
-        "monnaie danoise": [
-            "DKK"
-        ], 
-        "swaziland lilangeni": [
-            "SZL"
-        ], 
-        "tugrig": [
-            "MNT"
-        ], 
-        "gersh": [
-            "ETB"
-        ], 
-        "rouble russe": [
-            "RUB"
-        ], 
-        "tugrik": [
-            "MNT"
-        ], 
-        "kip": [
-            "LAK"
-        ], 
-        "dirham de los emiratos arabes unidos": [
-            "AED"
-        ], 
-        "escudo capverdien": [
-            "CVE"
-        ], 
-        "jemeni ria\u0301l": [
-            "YER"
-        ], 
-        "fcfp": [
-            "XPF"
-        ], 
-        "rwanda franc": [
-            "RWF"
-        ], 
-        "bolivar venezolano": [
-            "VEF"
-        ], 
-        "zambiai kwacha": [
-            "ZMW"
-        ], 
-        "lev bulgaro": [
-            "BGN"
-        ], 
-        "lev bulgare": [
-            "BGN"
-        ], 
-        "nakfa eritreo": [
-            "ERN"
-        ], 
-        "danish krone": [
-            "DKK"
-        ], 
-        "monnaie britannique": [
-            "GBP"
-        ], 
-        "r$": [
-            "BRL"
-        ], 
-        "di\u0301rham marroqui\u0301": [
-            "MAD"
-        ], 
-        "institut d'e\u0301mission d'outre mer": [
-            "XPF"
-        ], 
-        "manat azerbaiyano": [
-            "AZN"
-        ], 
-        "vietnami \u0111o\u0302\u0300ng": [
-            "VND"
-        ], 
-        "riyal iraniano": [
-            "IRR"
-        ], 
-        "franco guineano": [
-            "GNF"
-        ], 
-        "fiorino arubano": [
-            "AWG"
-        ], 
-        "rand": [
-            "ZAR"
-        ], 
-        "schekel": [
-            "ILS"
-        ], 
-        "sterlina di sant'elena": [
-            "SHP"
-        ], 
-        "pound sterling": [
-            "GBP"
-        ], 
-        "nacfa eritreo": [
-            "ERN"
-        ], 
-        "dolar taiwanes": [
-            "TWD"
-        ], 
-        "koruna c\u030ceska": [
-            "CZK"
-        ], 
-        "\u20ad": [
-            "LAK"
-        ], 
-        "kro\u0301na": [
-            "ISK"
-        ], 
-        "denar macedonio": [
-            "MKD"
-        ], 
-        "libra libanesa": [
-            "LBP"
-        ], 
-        "dolar belicen\u0303o": [
-            "BZD"
-        ], 
-        "lesotho\u0301i loti": [
-            "LSL"
-        ], 
-        "colombian peso": [
-            "COP"
-        ], 
-        "do\u0301lar de brune\u0301i": [
-            "BND"
-        ], 
-        "szingapu\u0301ri dolla\u0301r": [
-            "SGD"
-        ], 
-        "franc poincare": [
-            "XFO"
-        ], 
-        "metical mozambiqueno": [
-            "MZN"
-        ], 
-        "filipijnse peso": [
-            "PHP"
-        ], 
-        "somoni": [
-            "TJS"
-        ], 
-        "lempire hondurien": [
-            "HNL"
-        ], 
-        "angolan kwanza": [
-            "AOA"
-        ], 
-        "schwedenkrone": [
-            "SEK"
-        ], 
-        "lire maltaise": [
-            "MTL"
-        ], 
-        "balboa paname\u0301en": [
-            "PAB"
-        ], 
-        "israelische lire": [
-            "ILS"
-        ], 
-        "nzd": [
-            "NZD"
-        ], 
-        "hryvnia ucraina": [
-            "UAH"
-        ], 
-        "pataca": [
-            "MOP"
-        ], 
-        "coronas suecas": [
-            "SEK"
-        ], 
-        "cape verde escudo": [
-            "CVE"
-        ], 
-        "rupia pakistani": [
-            "PKR"
-        ], 
-        "hungarian forint": [
-            "HUF"
-        ], 
-        "rupia pakistana": [
-            "PKR"
-        ], 
-        "bs.": [
-            "BOB"
-        ], 
-        "kopeken": [
-            "RUB"
-        ], 
-        "dolar bahameno": [
-            "BSD"
-        ], 
-        "de\u0301l koreai von": [
-            "KRW"
-        ], 
-        "zo\u0308ld foki ko\u0308zta\u0301rsasa\u0301gi escudo": [
-            "CVE"
-        ], 
-        "romanian leu": [
-            "RON"
-        ], 
-        "etio\u0301p birr": [
-            "ETB"
-        ], 
-        "indiai ru\u0301pia": [
-            "INR"
-        ], 
-        "livre de gibraltar": [
-            "GIP"
-        ], 
-        "pa\u2019anga": [
-            "TOP"
-        ], 
-        "mexiko\u0301i pezo\u0301": [
-            "MXN"
-        ], 
-        "tansania schilling": [
-            "TZS"
-        ], 
-        "omanitische rial": [
-            "OMR"
-        ], 
-        "rial omani\u0301": [
-            "OMR"
-        ], 
-        "milandor": [
-            "RSD"
-        ], 
-        "canadischer dollar": [
-            "CAD"
-        ], 
-        "dollaro delle isole salomone": [
-            "SBD"
-        ], 
-        "noorse kronen": [
-            "NOK"
-        ], 
-        "samoan ta\u0304la\u0304": [
-            "WST"
-        ], 
-        "aruban florin": [
-            "AWG"
-        ], 
-        "iraakse dinar": [
-            "IQD"
-        ], 
-        "malaysian ringgit": [
-            "MYR"
-        ], 
-        "som usbeco": [
-            "UZS"
-        ], 
-        "ariary": [
-            "MGA"
-        ], 
-        "kyat": [
-            "MMK"
-        ], 
-        "austral (moneda de argentina)": [
-            "ARA"
-        ], 
-        "bruneise dollar": [
-            "BND"
-        ], 
-        "leu romeno": [
-            "RON"
-        ], 
-        "kolumbiai peso": [
-            "COP"
-        ], 
-        "oezbeekse sum": [
-            "UZS"
-        ], 
-        "burundese frank": [
-            "BIF"
-        ], 
-        "austral (argentina)": [
-            "ARA"
-        ], 
-        "riyal qatarien": [
-            "QAR"
-        ], 
-        "quetzal guatemalteque": [
-            "GTQ"
-        ], 
-        "taiwan dollar": [
-            "TWD"
-        ], 
-        "dolar de namibia": [
-            "NAD"
-        ], 
-        "indiase rupee": [
-            "INR"
-        ], 
-        "dollaro delle figi": [
-            "FJD"
-        ], 
-        "cfa franc beac": [
-            "XAF"
-        ], 
-        "hrk": [
-            "HRK"
-        ], 
-        "peso dominicano": [
-            "DOP"
-        ], 
-        "sh.so.": [
-            "SOS"
-        ], 
-        "kwacha zambiano": [
-            "ZMW"
-        ], 
-        "\u0441\u043e\u043c": [
-            "KGS"
-        ], 
-        "roupie nepalaise": [
-            "NPR"
-        ], 
-        "bermudian dollar": [
-            "BMD"
-        ], 
-        "cookinseln dollar": [
-            "NZD"
-        ], 
-        "bam": [
-            "BAM"
-        ], 
-        "kwanza angolen\u0303o": [
-            "AOA"
-        ], 
-        "dinaro libico": [
-            "LYD"
-        ], 
-        "malagasy ariary": [
-            "MGA"
-        ], 
-        "dolar liberiano": [
-            "LRD"
-        ], 
-        "falklandeilands pond": [
-            "FKP"
-        ], 
-        "nouvelle livre turque": [
-            "TRY"
-        ], 
-        "szovjet rubel": [
-            "SUR"
-        ], 
-        "magyar forint": [
-            "HUF"
-        ], 
-        "peso cubain": [
-            "CUP"
-        ], 
-        "xfo": [
-            "XFO"
-        ], 
-        "pakiszta\u0301ni ru\u0301pia": [
-            "PKR"
-        ], 
-        "georgische lari": [
-            "GEL"
-        ], 
-        "loti": [
-            "LSL"
-        ], 
-        "moldawischer leu": [
-            "MDL"
-        ], 
-        "dollaro statunitense": [
-            "USD"
-        ], 
-        "do\u0301lar bahame\u0301s": [
-            "BSD"
-        ], 
-        "lat leto\u0301n": [
-            "LVL"
-        ], 
-        "peso cileno": [
-            "CLP"
-        ], 
-        "dinar libio": [
-            "LYD"
-        ], 
-        "salomon dollar": [
-            "SBD"
-        ], 
-        "rupia nepali": [
-            "NPR"
-        ], 
-        "cop": [
-            "COP"
-        ], 
-        "sri\u0301 lanka i ru\u0301pia": [
-            "LKR"
-        ], 
-        "maloti": [
-            "LSL"
-        ], 
-        "drtrigonbot:exchange rate data:hrk": [
-            "HRK"
-        ], 
-        "franco ruandese": [
-            "RWF"
-        ], 
-        "ils": [
-            "ILS"
-        ], 
-        "bangladeshi taka": [
-            "BDT"
-        ], 
-        "konvertierbarer peso": [
-            "CUC"
-        ], 
-        "she\u0301kel": [
-            "ILS"
-        ], 
-        "kwd": [
-            "KWD"
-        ], 
-        "bahrain dinar": [
-            "BHD"
-        ], 
-        "sfr.": [
-            "CHF"
-        ], 
-        "livre syrienne": [
-            "SYP"
-        ], 
-        "macao pataca": [
-            "MOP"
-        ], 
-        "dolar de las islas caiman": [
-            "KYD"
-        ], 
-        "dollaro del brunei": [
-            "BND"
-        ], 
-        "chil$": [
-            "CLP"
-        ], 
-        "honduranischer lempira": [
-            "HNL"
-        ], 
-        "frf": [
-            "FRF"
-        ], 
-        "nakfa": [
-            "ERN"
-        ], 
-        "ghanese cedi": [
-            "GHS"
-        ], 
-        "dalasi gambien": [
-            "GMD"
-        ], 
-        "braziliaanse real": [
-            "BRL"
-        ], 
-        "frw": [
-            "RWF"
-        ], 
-        "libra falkland": [
-            "FKP"
-        ], 
-        "algerijnse dinar": [
-            "DZD"
-        ], 
-        "dinar du bahrei\u0308n": [
-            "BHD"
-        ], 
-        "dinar serbio": [
-            "RSD"
-        ], 
-        "rupias indias": [
-            "INR"
-        ], 
-        "lesotho loti": [
-            "LSL"
-        ], 
-        "do\u0301lar guyane\u0301s": [
-            "GYD"
-        ], 
-        "mauritanian ouguiya": [
-            "MRO"
-        ], 
-        "greek drachma": [
-            "GRD"
-        ], 
-        "east caribbean dollar": [
-            "XCD"
-        ], 
-        "dirham de emiratos a\u0301rabes unidos": [
-            "AED"
-        ], 
-        "scellino tanzaniano": [
-            "TZS"
-        ], 
-        "aurar": [
-            "ISK"
-        ], 
-        "oost duitse mark": [
-            "DDM"
-        ], 
-        "franc guine\u0301en": [
-            "GNF"
-        ], 
-        "dollaro hongkonghese": [
-            "HKD"
-        ], 
-        "sll": [
-            "SLL"
-        ], 
-        "\u09f3": [
-            "BDT"
-        ], 
-        "rial saudita": [
-            "SAR"
-        ], 
-        "tzs": [
-            "TZS"
-        ], 
-        "real bresilien": [
-            "BRL"
-        ], 
-        "irakischer dinar": [
-            "IQD"
-        ], 
-        "rupias": [
-            "INR"
-        ], 
-        "sistema u\u0301nico de compensacio\u0301n regional": [
-            "XSU"
-        ], 
-        "franco frances": [
-            "FRF"
-        ], 
-        "costaricaanse colo\u0301n": [
-            "CRC"
-        ], 
-        "lita lituano": [
-            "LTL"
-        ], 
-        "\u20ae": [
-            "MNT"
-        ], 
-        "\u0434\u043e\u043b\u0430\u0440": [
-            "MKD"
-        ], 
-        "peso filippino": [
-            "PHP"
-        ], 
-        "dolar neocelandes": [
-            "NZD"
-        ], 
-        "to\u0308gro\u0308g": [
-            "MNT"
-        ], 
-        "rupiah": [
-            "IDR"
-        ], 
-        "zersto\u0308\u00dft sterling": [
-            "GBP"
-        ], 
-        "can$": [
-            "CAD"
-        ], 
-        "pgk": [
-            "PGK"
-        ], 
-        "rupia india": [
-            "INR"
-        ], 
-        "do\u0301lar belicen\u0303o": [
-            "BZD"
-        ], 
-        "nis": [
-            "ILS"
-        ], 
-        "letse lats": [
-            "LVL"
-        ], 
-        "slrs": [
-            "LKR"
-        ], 
-        "dominikanischer peso": [
-            "DOP"
-        ], 
-        "emira\u0301tusi dirham": [
-            "AED"
-        ], 
-        "litas lituano": [
-            "LTL"
-        ], 
-        "litas lituana": [
-            "LTL"
-        ], 
-        "rupia nepali\u0301": [
-            "NPR"
-        ], 
-        "thb": [
-            "THB"
-        ], 
-        "swazi lilangeni": [
-            "SZL"
-        ], 
-        "yen": [
-            "JPY"
-        ], 
-        "flori\u0301n hungaro": [
-            "HUF"
-        ], 
-        "gourde hai\u0308tienne": [
-            "HTG"
-        ], 
-        "yer": [
-            "YER"
-        ], 
-        "argentinischer austral": [
-            "ARA"
-        ], 
-        "bolivar ve\u0301ne\u0301zue\u0301lien": [
-            "VEF"
-        ], 
-        "bolivianischer boliviano": [
-            "BOB"
-        ], 
-        "sheqalim": [
-            "ILS"
-        ], 
-        "\u20af": [
-            "GRD"
-        ], 
-        "brits pond": [
-            "GBP"
-        ], 
-        "sterlina sudanese": [
-            "SDG"
-        ], 
-        "koruna cesko slovenska": [
-            "CSK"
-        ], 
-        "argent chinois": [
-            "CNY"
-        ], 
-        "libische dinar": [
-            "LYD"
-        ], 
-        "libanese pond": [
-            "LBP"
-        ], 
-        "burundian franc": [
-            "BIF"
-        ], 
-        "nuevo sol peruano": [
-            "PEN"
-        ], 
-        "singapore dollar": [
-            "SGD"
-        ], 
-        "dollar hai\u0308tien": [
-            "HTG"
-        ], 
-        "balboa panameen": [
-            "PAB"
-        ], 
-        "aserbaidschanischer manat": [
-            "AZN"
-        ], 
-        "co\u0301rdoba": [
-            "NIO"
-        ], 
-        "sterlina delle falkland": [
-            "FKP"
-        ], 
-        "peso messicano": [
-            "MXN"
-        ], 
-        "millime": [
-            "TND"
-        ], 
-        "omaanse rial": [
-            "OMR"
-        ], 
-        "sjekel": [
-            "ILS"
-        ], 
-        "vatu": [
-            "VUV"
-        ], 
-        "colo\u0301n": [
-            "CRC"
-        ], 
-        "bosnisch herzegowinische konvertible mark": [
-            "BAM"
-        ], 
-        "dollar guyanien": [
-            "GYD"
-        ], 
-        "cedi": [
-            "GHS"
-        ], 
-        "rupia de mauricio": [
-            "MUR"
-        ], 
-        "cny": [
-            "CNY"
-        ], 
-        "pataca di macao": [
-            "MOP"
-        ], 
-        "argentine austral": [
-            "ARA"
-        ], 
-        "austral (wa\u0308hrung)": [
-            "ARA"
-        ], 
-        "nuevo do\u0301lar taiwane\u0301s": [
-            "TWD"
-        ], 
-        "dinar bahraini\u0301": [
-            "BHD"
-        ], 
-        "som kirghizo": [
-            "KGS"
-        ], 
-        "baht": [
-            "THB"
-        ], 
-        "sri lanka rupee": [
-            "LKR"
-        ], 
-        "zsenminpi": [
-            "CNY"
-        ], 
-        "ryal saoudien": [
-            "SAR"
-        ], 
-        "djibouti franc": [
-            "DJF"
-        ], 
-        "pula del botswana": [
-            "BWP"
-        ], 
-        "mauritiaanse rupee": [
-            "MUR"
-        ], 
-        "syrische lira": [
-            "SYP"
-        ], 
-        "centas": [
-            "LTL"
-        ], 
-        "dollars": [
-            "USD"
-        ], 
-        "guineai frank": [
-            "GNF"
-        ], 
-        "panamai balboa": [
-            "PAB"
-        ], 
-        "dollaro": [
-            "BBD", 
-            "BZD"
-        ], 
-        "us dollar": [
-            "USD"
-        ], 
-        "ta\u0304la\u0304": [
-            "WST"
-        ], 
-        "peso dominicain": [
-            "DOP"
-        ], 
-        "\u4eba\u6c11\u5e01": [
-            "CNY"
-        ], 
-        "libra de gibraltar": [
-            "GIP"
-        ], 
-        "mark est allemand": [
-            "DDM"
-        ], 
-        "libra jamaicana": [
-            "JMD"
-        ], 
-        "eritrean nakfa": [
-            "ERN"
-        ], 
-        "som": [
-            "KGS", 
-            "UZS"
-        ], 
-        "sol": [
-            "PEN"
-        ], 
-        "bath": [
-            "THB"
-        ], 
-        "do\u0301lar surinames": [
-            "SRD"
-        ], 
-        "srilankaanse roepie": [
-            "LKR"
-        ], 
-        "oma\u0301ni ria\u0301l": [
-            "OMR"
-        ], 
-        "dolar guyane\u0301s": [
-            "GYD"
-        ], 
-        "dollaro delle bahamas": [
-            "BSD"
-        ], 
-        "georgischer lari": [
-            "GEL"
-        ], 
-        "sa\u0303o tome\u0301 e\u0301s pri\u0301ncipe i dobra": [
-            "STD"
-        ], 
-        "namibische dollar": [
-            "NAD"
-        ], 
-        "lira turca": [
-            "TRY"
-        ], 
-        "austral": [
-            "ARA"
-        ], 
-        "tune\u0301ziai dina\u0301r": [
-            "TND"
-        ], 
-        "pyg": [
-            "PYG"
-        ], 
-        "\u060b": [
-            "AFN"
-        ], 
-        "tajikistani somoni": [
-            "TJS"
-        ], 
-        "fiji dollar": [
-            "FJD"
-        ], 
-        "south african rand": [
-            "ZAR"
-        ], 
-        "seychelse rupee": [
-            "SCR"
-        ], 
-        "anciens francs": [
-            "FRF"
-        ], 
-        "nuevo sheqel": [
-            "ILS"
-        ], 
-        "amerikai dolla\u0301r": [
-            "USD"
-        ], 
-        "do\u0301lar canadiense": [
-            "CAD"
-        ], 
-        "turkmenistan manat": [
-            "TMT"
-        ], 
-        "litas": [
-            "LTL"
-        ], 
-        "peso cubano": [
-            "CUP"
-        ], 
-        "maltese lira": [
-            "MTL"
-        ], 
-        "azn": [
-            "AZN"
-        ], 
-        "maltese lire": [
-            "MTL"
-        ], 
-        "sve\u0301d korona": [
-            "SEK"
-        ], 
-        "konvertibilna marka": [
-            "BAM"
-        ], 
+        "أبصار أبخازي": "ABA",
+        "abchazský apsar": "ABA",
+        "abchasischer apsar": "ABA",
+        "abkhazian apsar": "ABA",
+        "apsar": "ABA",
+        "آپسار آبخاز": "ABA",
+        "abhasian apsar": "ABA",
+        "apsar abkhazo": "ABA",
+        "abhaški apsar": "ABA",
+        "apsar abcaso": "ABA",
+        "abchazijos apsaras": "ABA",
+        "apsar abcásio": "ABA",
+        "абхазский апсар": "ABA",
+        "abhazya apsarı": "ABA",
+        "абхазький апсар": "ABA",
+        "阿布哈兹阿沙": "ABA",
+        "درهم إماراتي": "AED",
+        "dírham dels emirats àrabs units": "AED",
+        "dirham spojených arabských emirátů": "AED",
+        "vae dirham": "AED",
+        "ντιρχάμ ηνωμένων αραβικών εμιράτων": "AED",
+        "united arab emirates dirham": "AED",
+        "uae dirhamo": "AED",
+        "dírham de los emiratos árabes unidos": "AED",
+        "درهم امارات": "AED",
+        "yhdistyneiden arabiemiirikuntien dirhami": "AED",
+        "dirham des émirats arabes unis": "AED",
+        "dirham dos emiratos árabes unidos": "AED",
+        "דירהם איחוד האמירויות הערביות": "AED",
+        "dirham uae": "AED",
+        "emirátusi dirham": "AED",
+        "dirham degli emirati arabi uniti": "AED",
+        "uaeディルハム": "AED",
+        "jungtinių arabų emyratų dirhamas": "AED",
+        "dirham zjednoczonych emiratów arabskich": "AED",
+        "dirrã dos emirados árabes unidos": "AED",
+        "dirham eau": "AED",
+        "дирхам оаэ": "AED",
+        "уае дирхам": "AED",
+        "emiratisk dirham": "AED",
+        "ஐக்கிய அரபு அமீரக திர்கம்": "AED",
+        "birleşik arap emirlikleri dirhemi": "AED",
+        "дирхам оае": "AED",
+        "阿联酋迪拉姆": "AED",
+        "أفغاني": "AFN",
+        "афганистански афган": "AFN",
+        "afgani": "AFN",
+        "afghánský afghání": "AFN",
+        "afghani": "AFN",
+        "αφγάνι": "AFN",
+        "afghan afghani": "AFN",
+        "afgana afganio": "AFN",
+        "afgani afgano": "AFN",
+        "afganistani afgaani": "AFN",
+        "افغانی": "AFN",
+        "afganistanin afgaani": "AFN",
+        "אפגני": "AFN",
+        "afganistanski afgani": "AFN",
+        "afgán afgáni": "AFN",
+        "アフガニ": "AFN",
+        "afganis": "AFN",
+        "afghaanse afghani": "AFN",
+        "afegane": "AFN",
+        "афгани": "AFN",
+        "авганистански авгани": "AFN",
+        "афгані": "AFN",
+        "阿富汗阿富汗尼": "AFN",
+        "ليك ألباني": "ALL",
+        "албански лек": "ALL",
+        "lek": "ALL",
+        "albánský lek": "ALL",
+        "albanske lek": "ALL",
+        "albanischer lek": "ALL",
+        "λεκ": "ALL",
+        "albanian lek": "ALL",
+        "albana leko": "ALL",
+        "lek albanés": "ALL",
+        "albaania lekk": "ALL",
+        "لک آلبانی": "ALL",
+        "לק": "ALL",
+        "albanski lek": "ALL",
+        "albán lek": "ALL",
+        "lek albanese": "ALL",
+        "レク": "ALL",
+        "albanijos lekas": "ALL",
+        "albanese lek": "ALL",
+        "албанский лек": "ALL",
+        "albánsky lek": "ALL",
+        "அல்பேனிய லெக்": "ALL",
+        "arnavut leki": "ALL",
+        "албанський лек": "ALL",
+        "阿爾巴尼亞列克": "ALL",
+        "درام أرميني": "AMD",
+        "арменски драм": "AMD",
+        "dram": "AMD",
+        "arménský dram": "AMD",
+        "armenske dram": "AMD",
+        "armenischer dram": "AMD",
+        "ντραμ": "AMD",
+        "armenian dram": "AMD",
+        "armena dramo": "AMD",
+        "dram armenio": "AMD",
+        "armeenia dramm": "AMD",
+        "درام ارمنستان": "AMD",
+        "דראם ארמני": "AMD",
+        "armenski dram": "AMD",
+        "örmény dram": "AMD",
+        "dram armeno": "AMD",
+        "ドラム": "AMD",
+        "armėnijos dramas": "AMD",
+        "armeense dram": "AMD",
+        "dram arménio": "AMD",
+        "армянский драм": "AMD",
+        "arménsky dram": "AMD",
+        "јерменски драм": "AMD",
+        "ஆர்மேனிய டிராம்": "AMD",
+        "ermeni dramı": "AMD",
+        "вірменський драм": "AMD",
+        "亚美尼亚德拉姆": "AMD",
+        "غيلدر الأنتيل الهولندية": "ANG",
+        "florí de les antilles neerlandeses": "ANG",
+        "gulden nizozemských antil": "ANG",
+        "antillen gulden": "ANG",
+        "karibischer gulden": "ANG",
+        "caribbean guilder": "ANG",
+        "netherlands antillean guilder": "ANG",
+        "karibia guldeno": "ANG",
+        "nederlandantila guldeno": "ANG",
+        "florín antillano neerlandés": "ANG",
+        "florín caribeño": "ANG",
+        "holandarren antilletako florin": "ANG",
+        "گیلدر آنتیل هلند": "ANG",
+        "گیلدر کارائیب": "ANG",
+        "alankomaiden antillien guldeni": "ANG",
+        "florin des antilles néerlandaises": "ANG",
+        "florín das antillas neerlandesas": "ANG",
+        "karipski gulden": "ANG",
+        "nizozemskoantilski gulden": "ANG",
+        "holland antillákbeli forint": "ANG",
+        "karibi forint": "ANG",
+        "fiorino delle antille olandesi": "ANG",
+        "アンティル・ギルダー": "ANG",
+        "nyderlandų antilų guldenas": "ANG",
+        "antilliaanse gulden": "ANG",
+        "caribische gulden": "ANG",
+        "florin de las antilhas neerlandesas": "ANG",
+        "gulden antyli holenderskich": "ANG",
+        "florim das antilhas neerlandesas": "ANG",
+        "florim do caribe": "ANG",
+        "нидерландский антильский гульден": "ANG",
+        "antillergulden": "ANG",
+        "hollanda antilleri guldeni": "ANG",
+        "нідерландський антильський гульден": "ANG",
+        "荷屬安的列斯盾": "ANG",
+        "كوانزا أنغولي": "AOA",
+        "анголска кванза": "AOA",
+        "kwanza": "AOA",
+        "angolská kwanza": "AOA",
+        "κουάνζα": "AOA",
+        "angolan kwanza": "AOA",
+        "angola kvanzo": "AOA",
+        "kwanza angoleño": "AOA",
+        "کوانزای آنگولا": "AOA",
+        "קוואנזה": "AOA",
+        "angolska kvanza": "AOA",
+        "angolai kwanza": "AOA",
+        "kwanza angolano": "AOA",
+        "クワンザ": "AOA",
+        "kvanza": "AOA",
+        "angolese kwanza": "AOA",
+        "ангольская кванза": "AOA",
+        "ангольська кванза": "AOA",
+        "kwanza angola": "AOA",
+        "安哥拉匡撒": "AOA",
+        "peso oro sellado": "ARG",
+        "بيزو أرجنتيني": "ARS",
+        "аржентинско песо": "ARS",
+        "peso argentí": "ARS",
+        "argentinské peso": "ARS",
+        "argentinischer peso": "ARS",
+        "πέσο αργεντινής": "ARS",
+        "argentine peso": "ARS",
+        "argentina peso": "ARS",
         "peso": [
-            "COP", 
-            "DOP", 
-            "MXN"
-        ], 
-        "franse frank": [
-            "FRF"
-        ], 
-        "mexiko\u0301i peso": [
-            "MXN"
-        ], 
-        "pesos": [
-            "MXN"
-        ], 
-        "shilling kenyan": [
-            "KES"
-        ], 
-        "iqd": [
-            "IQD"
-        ], 
-        "colo\u0301n costaricain": [
-            "CRC"
-        ], 
-        "dinar soudanais": [
-            "SDG"
-        ], 
-        "peso colombien": [
-            "COP"
-        ], 
-        "renminbi cinese": [
-            "CNY"
-        ], 
-        "mark der deutschen notenbank": [
-            "DDM"
-        ], 
-        "re\u0301al": [
-            "BRL"
-        ], 
-        "mauritius rupie": [
-            "MUR"
-        ], 
-        "tongai pa'anga": [
-            "TOP"
-        ], 
-        "deutsche mark der deutschen notenbank": [
-            "DDM"
-        ], 
-        "ddr geld": [
-            "DDM"
-        ], 
-        "usbekistan som": [
-            "UZS"
-        ], 
-        "trinidad und tobago dollar": [
-            "TTD"
-        ], 
-        "guyanai dolla\u0301r": [
-            "GYD"
-        ], 
-        "do\u0301lar de bermuda": [
-            "BMD"
-        ], 
-        "peso convertible": [
-            "CUC"
-        ], 
-        "livre britannique": [
-            "GBP"
-        ], 
-        "italienische lira": [
-            "ITL"
-        ], 
-        "italienische lire": [
-            "ITL"
-        ], 
-        "kenyai shilling": [
-            "KES"
-        ], 
-        "li\u0301biai dina\u0301r": [
-            "LYD"
-        ], 
-        "nuevo dolar taiwanes": [
-            "TWD"
-        ], 
-        "fijan dollar": [
-            "FJD"
-        ], 
-        "uruguayischer peso": [
-            "UYU"
-        ], 
-        "neuseela\u0308ndischer dollar": [
-            "NZD"
-        ], 
-        "csendes o\u0301cea\u0301ni valutako\u0308zo\u0308sse\u0301gi frank": [
-            "XPF"
-        ], 
-        "poisha": [
-            "BDT"
-        ], 
-        "lat letton": [
-            "LVL"
-        ], 
-        "n$": [
-            "NAD"
-        ], 
-        "rwandan franc": [
-            "RWF"
-        ], 
-        "lempira": [
-            "HNL"
-        ], 
-        "speciale trekkingsrechten": [
-            "XDR"
-        ], 
-        "maldivian rufiyaa": [
-            "MVR"
-        ], 
-        "rwandan frank": [
-            "RWF"
-        ], 
-        "israe\u0308lische lire": [
-            "ILS"
-        ], 
-        "afgani": [
-            "AFN"
-        ], 
-        "rol": [
-            "RON"
-        ], 
-        "u+20bd": [
-            "RUB"
-        ], 
-        "s\u0192": [
-            "SRD"
-        ], 
-        "dinar bahreini": [
-            "BHD"
-        ], 
-        "tongai pa\u02bbanga": [
-            "TOP"
-        ], 
-        "franco suizo": [
-            "CHF"
-        ], 
-        "marco convertible": [
-            "BAM"
-        ], 
-        "forint hongrois": [
-            "HUF"
-        ], 
-        "som kirguis": [
-            "KGS"
-        ], 
-        "israeli new shekel": [
-            "ILS"
-        ], 
-        "som kirguiz": [
-            "KGS"
-        ], 
-        "albanischer lek": [
-            "ALL"
-        ], 
-        "vef": [
-            "VEF"
-        ], 
-        "kongo franc": [
-            "CDF"
-        ], 
-        "mexicaanse peso": [
-            "MXN"
-        ], 
-        "argentine peso": [
+            "UYU",
+            "PHP",
+            "MXN",
+            "CUP",
+            "COP",
+            "CLP",
             "ARS"
-        ], 
-        "guatemaltekischer quetzal": [
-            "GTQ"
-        ], 
-        "novo kwanza": [
-            "AOA"
-        ], 
-        "zuid soedanese pond": [
-            "SSP"
-        ], 
-        "horva\u0301t kuna": [
-            "HRK"
-        ], 
-        "dolar neozelandes": [
-            "NZD"
-        ], 
-        "tu\u0308rkme\u0301n manat": [
-            "TMT"
-        ], 
-        "lilangeni sign": [
-            "SZL"
-        ], 
-        "new taiwan dollar": [
-            "TWD"
-        ], 
-        "swazische lilangeni": [
-            "SZL"
-        ], 
-        "stotinki": [
-            "BGN"
-        ], 
-        "\u0111o\u0302\u0300ng vietnamita": [
-            "VND"
-        ], 
-        "franco burunde\u0301s": [
-            "BIF"
-        ], 
-        "stotinka": [
-            "BGN"
-        ], 
-        "cordoba nicaragu\u0308ense": [
-            "NIO"
-        ], 
-        "lebanese pound": [
-            "LBP"
-        ], 
-        "flori\u0301n aruben\u0303o": [
-            "AWG"
-        ], 
-        "algerian dinar": [
-            "DZD"
-        ], 
-        "dinar jordano": [
-            "JOD"
-        ], 
-        "rial saoudien": [
-            "SAR"
-        ], 
-        "litva\u0301n litas": [
-            "LTL"
-        ], 
-        "scellino ugandese": [
-            "UGX"
-        ], 
-        "zai\u0308re": [
-            "CDF"
-        ], 
-        "florin d\u2019aruba": [
-            "AWG"
-        ], 
-        "grivnia ucraina": [
-            "UAH"
-        ], 
-        "sambischer kwacha": [
-            "ZMW"
-        ], 
-        "filler": [
-            "HUF"
-        ], 
-        "ringgit": [
-            "MYR"
-        ], 
-        "rupia del pakistan": [
-            "PKR"
-        ], 
-        "nieuwe turkse lira": [
-            "TRY"
-        ], 
-        "chilei peso": [
-            "CLP"
-        ], 
-        "iranian rial": [
-            "IRR"
-        ], 
-        "tadzjiekse somoni": [
-            "TJS"
-        ], 
-        "metical mozambiquen\u0303o": [
-            "MZN"
-        ], 
-        "sterlina inglese": [
-            "GBP"
-        ], 
-        "mauritian rupee": [
-            "MUR"
-        ], 
-        "dinaro del bahrain": [
-            "BHD"
-        ], 
-        "venezuelai boli\u0301var": [
-            "VEF"
-        ], 
-        "ruma\u0308nischer ban": [
-            "RON"
-        ], 
-        "dolar de las islas salomo\u0301n": [
-            "SBD"
-        ], 
-        "roepiah": [
-            "IDR"
-        ], 
-        "dinaro serbo": [
-            "RSD"
-        ], 
-        "riyal catari\u0301": [
-            "QAR"
-        ], 
-        "dollaro surinamese": [
-            "SRD"
-        ], 
-        "libra sursudanesa": [
-            "SSP"
-        ], 
-        "south sudanese pound": [
-            "SSP"
-        ], 
-        "boli\u0301var venezuelano": [
-            "VEF"
-        ], 
-        "shilling ke\u0301nyan": [
-            "KES"
-        ], 
-        "dolar suriname\u0301s": [
-            "SRD"
-        ], 
-        "bolivares fuertes": [
-            "VEF"
-        ], 
-        "francos suizos": [
-            "CHF"
-        ], 
-        "botsuanischer pula": [
-            "BWP"
-        ], 
-        "nieuwe israe\u0308lische sjekel": [
-            "ILS"
-        ], 
-        "bahama dollar": [
-            "BSD"
-        ], 
-        "sierra leonischer leone": [
-            "SLL"
-        ], 
-        "bob": [
-            "BOB"
-        ], 
-        "botswana pula": [
-            "BWP"
-        ], 
-        "nepa\u0301li ru\u0301pia": [
-            "NPR"
-        ], 
-        "dollaro taiwanese": [
-            "TWD"
-        ], 
-        "dolar de belice": [
-            "BZD"
-        ], 
-        "sierra leonean leone": [
-            "SLL"
-        ], 
-        "franco gibutiano": [
-            "DJF"
-        ], 
-        "franco": [
-            "RWF", 
-            "DJF", 
-            "CDF", 
-            "XPF"
-        ], 
-        "nouveau dollar de tai\u0308wan": [
-            "TWD"
-        ], 
-        "libras esterlinas": [
-            "GBP"
-        ], 
-        "paraguayischer guarani\u0301": [
-            "PYG"
-        ], 
-        "drachme (antike)": [
-            "GRD"
-        ], 
-        "\u20b1": [
-            "PHP"
-        ], 
-        "s\u20a3": [
-            "CHF"
-        ], 
-        "csehszlova\u0301k korona": [
-            "CSK"
-        ], 
-        "lithuanian litas": [
-            "LTL"
-        ], 
-        "malagassische ariary": [
-            "MGA"
-        ], 
-        "afl.": [
-            "AWG"
-        ], 
-        "flori\u0301n hu\u0301ngaro": [
-            "HUF"
-        ], 
-        "izraeli u\u0301j se\u0301kel": [
-            "ILS"
-        ], 
-        "nigeriaanse naira": [
-            "NGN"
-        ], 
-        "kazakhstani tenge": [
-            "KZT"
-        ], 
-        "south korean won": [
-            "KRW"
-        ], 
-        "dollar de hong kong": [
-            "HKD"
-        ], 
-        "su\u0308dkoreanischer won": [
-            "KRW"
-        ], 
-        "peso mejicano": [
-            "MXN"
-        ], 
-        "won nordcoreano": [
-            "KPW"
-        ], 
-        "mark der ddr": [
-            "DDM"
-        ], 
-        "tschechische krone": [
-            "CZK"
-        ], 
-        "solomon islands dollar": [
-            "SBD"
-        ], 
-        "boli\u0301viai boliviano": [
-            "BOB"
-        ], 
-        "costaricaanse colon": [
-            "CRC"
-        ], 
-        "jemen rial": [
-            "YER"
-        ], 
-        "mga": [
-            "MGA"
-        ], 
-        "kyd": [
-            "KYD"
-        ], 
-        "mauritaanse ouguiya": [
-            "MRO"
-        ], 
-        "gambiaanse dalasi": [
-            "GMD"
-        ], 
-        "gibraltar pound": [
-            "GIP"
-        ], 
-        "tsjechoslowaakse kroon": [
-            "CSK"
-        ], 
-        "gourde": [
-            "HTG"
-        ], 
-        "corona sueca": [
-            "SEK"
-        ], 
-        "colon costaricano": [
-            "CRC"
-        ], 
-        "franc congolais": [
-            "CDF"
-        ], 
-        "florin arubeno": [
-            "AWG"
-        ], 
-        "kaapverdische escudo": [
-            "CVE"
-        ], 
-        "venezolaanse bolivar": [
-            "VEF"
-        ], 
-        "s/": [
-            "PEN"
-        ], 
-        "dolar de nueva zelanda": [
-            "NZD"
-        ], 
-        "do\u0301lar suriname\u0301s": [
-            "SRD"
-        ], 
-        "francs suisses": [
-            "CHF"
-        ], 
-        "s$": [
-            "SGD"
-        ], 
-        "italiaanse lire": [
-            "ITL"
-        ], 
-        "italiaanse lira": [
-            "ITL"
-        ], 
-        "bahreinse dinar": [
-            "BHD"
-        ], 
-        "sr": [
-            "SAR"
-        ], 
-        "corona": [
-            "SEK"
-        ], 
-        "font sterling": [
-            "GBP"
-        ], 
-        "peso chileno": [
-            "CLP"
-        ], 
-        "tala": [
-            "WST"
-        ], 
-        "libra gibraltarena": [
-            "GIP"
-        ], 
-        "saoedi arabische riyal": [
-            "SAR"
-        ], 
-        "guinese frank": [
-            "GNF"
-        ], 
-        "dracma (moderna)": [
-            "GRD"
-        ], 
-        "franco de burundi": [
-            "BIF"
-        ], 
-        "thaise baht": [
-            "THB"
-        ], 
-        "koruna": [
-            "CZK"
-        ], 
-        "koruna ceska": [
-            "CZK"
-        ], 
-        "dram armeno": [
-            "AMD"
-        ], 
-        "st. helena pfund": [
-            "SHP"
-        ], 
-        "lek albanese": [
-            "ALL"
-        ], 
-        "trinidad en tobagodollar": [
-            "TTD"
-        ], 
-        "cuban peso": [
-            "CUP"
-        ], 
-        "gtq": [
-            "GTQ"
-        ], 
-        "djf": [
-            "DJF"
-        ], 
-        "east german mark": [
-            "DDM"
-        ], 
-        "yuan cinese": [
-            "CNY"
-        ], 
-        "jordaanse dinar": [
-            "JOD"
-        ], 
-        "guinean franc": [
-            "GNF"
-        ], 
-        "szoma\u0301liai shilling": [
-            "SOS"
-        ], 
-        "nok": [
-            "NOK"
-        ], 
-        "do\u0301lar de namibia": [
-            "NAD"
-        ], 
-        "shilingi": [
-            "TZS"
-        ], 
-        "franco yibuti": [
-            "DJF"
-        ], 
-        "rufiyah": [
-            "MVR"
-        ], 
-        "col$": [
-            "COP"
-        ], 
-        "rufiyaa": [
-            "MVR"
-        ], 
-        "tt$": [
-            "TTD"
-        ], 
-        "cheli\u0301n": [
-            "UGX", 
-            "TZS", 
-            "SOS"
-        ], 
-        "gryvnia": [
-            "UAH"
-        ], 
-        "cfp franc": [
-            "XPF"
-        ], 
-        "real brasiliano": [
-            "BRL"
-        ], 
-        "cfp frank": [
-            "XPF"
-        ], 
-        "taka bengalese": [
-            "BDT"
-        ], 
-        "ngwee": [
-            "ZMW"
-        ], 
-        "metical mozambicano": [
-            "MZN"
-        ], 
-        "lempira honduregna": [
-            "HNL"
-        ], 
-        "libra malvinense": [
-            "FKP"
-        ], 
-        "nuevo she\u0301quel": [
-            "ILS"
-        ], 
-        "rial omanais": [
-            "OMR"
-        ], 
-        "arg$": [
-            "ARS"
-        ], 
-        "nicaraguanischer co\u0301rdoba": [
-            "NIO"
-        ], 
-        "colon costaricien": [
-            "CRC"
-        ], 
-        "drtrigonbot:exchange rate data:dkk": [
-            "DKK"
-        ], 
-        "goldfranken": [
-            "XFO"
-        ], 
-        "roupie indienne": [
-            "INR"
-        ], 
-        "afghani": [
-            "AFN"
-        ], 
-        "franc cfp": [
-            "XPF"
-        ], 
-        "seychelle szigeteki ru\u0301pia": [
-            "SCR"
-        ], 
-        "franco ruandes": [
-            "RWF"
-        ], 
-        "pesification": [
-            "ARS"
-        ], 
-        "dirham des emirats arabes unis": [
-            "AED"
-        ], 
-        "$can": [
-            "CAD"
-        ], 
-        "franc cfa": [
-            "XAF", 
-            "XOF"
-        ], 
-        "nepalese roepie": [
-            "NPR"
-        ], 
-        "lwei": [
-            "AOA"
-        ], 
-        "nuovo peso argentino": [
-            "ARS"
-        ], 
-        "indonesian rupiah": [
-            "IDR"
-        ], 
-        "guatemalai quetzal": [
-            "GTQ"
-        ], 
-        "dolar de singapur": [
-            "SGD"
-        ], 
-        "peso de me\u0301xico": [
-            "MXN"
-        ], 
-        "surinamese guilder": [
-            "SRG"
-        ], 
-        "nigerian naira": [
-            "NGN"
-        ], 
-        "peso philippin": [
-            "PHP"
-        ], 
-        "mongoolse tugrik": [
-            "MNT"
-        ], 
-        "franc pacifique": [
-            "XPF"
-        ], 
-        "haitianischer gourde": [
-            "HTG"
-        ], 
-        "jemenitische rial": [
-            "YER"
-        ], 
-        "do\u0301lar": [
-            "USD", 
-            "FJD"
-        ], 
-        "kolumbianischer peso": [
-            "COP"
-        ], 
-        "co\u0301rdoba nicaraguense": [
-            "NIO"
-        ], 
-        "dollar ne\u0301oze\u0301landais": [
-            "NZD"
-        ], 
-        "meticais": [
-            "MZN"
-        ], 
-        "uqiya": [
-            "MRO"
-        ], 
-        "grivnia": [
-            "UAH"
-        ], 
-        "lakhs": [
-            "BDT"
-        ], 
-        "zar": [
-            "ZAR"
-        ], 
-        "bahamian dollar": [
-            "BSD"
-        ], 
-        "qa\u0308pik": [
+        ],
+        "argentina peeso": "ARS",
+        "peso argentinar": "ARS",
+        "پزوی آرژانتین": "ARS",
+        "argentiinan peso": "ARS",
+        "peso argentin": "ARS",
+        "peso arxentino": "ARS",
+        "פסו ארגנטינאי": "ARS",
+        "argentinski pezo": "ARS",
+        "argentin peso": "ARS",
+        "peso argentino": "ARS",
+        "アルゼンチン・ペソ": "ARS",
+        "argentinos pesas": "ARS",
+        "argentijnse peso": "ARS",
+        "peso argentyńskie": "ARS",
+        "peso argentinian": "ARS",
+        "аргентинское песо": "ARS",
+        "аргентински пезос": "ARS",
+        "argentinsk peso": "ARS",
+        "ஆர்ஜென்டின பீசோ": "ARS",
+        "arjantin pesosu": "ARS",
+        "аргентинський песо": "ARS",
+        "peso argentina": "ARS",
+        "阿根廷比索": "ARS",
+        "دولار أسترالي": "AUD",
+        "австралийски долар": "AUD",
+        "dòlar australià": "AUD",
+        "australský dolar": "AUD",
+        "australske dollar": "AUD",
+        "australischer dollar": "AUD",
+        "δολάριο αυστραλίας": "AUD",
+        "australian dollar": "AUD",
+        "aŭstralia dolaro": "AUD",
+        "dólar australiano": "AUD",
+        "austraalia dollar": "AUD",
+        "australiar dolar": "AUD",
+        "دلار استرالیا": "AUD",
+        "australian dollari": "AUD",
+        "dollar australien": "AUD",
+        "דולר אוסטרלי": "AUD",
+        "australski dolar": "AUD",
+        "ausztrál dollár": "AUD",
+        "dollaro australiano": "AUD",
+        "オーストラリア・ドル": "AUD",
+        "australijos doleris": "AUD",
+        "australische dollar": "AUD",
+        "dolar australian": "AUD",
+        "dolar australijski": "AUD",
+        "австралийский доллар": "AUD",
+        "austrálsky dolár": "AUD",
+        "аустралијски долар": "AUD",
+        "australisk dollar": "AUD",
+        "அவுஸ்திரேலிய டொலர்": "AUD",
+        "avustralya doları": "AUD",
+        "австралійський долар": "AUD",
+        "đô la úc": "AUD",
+        "澳大利亚元": "AUD",
+        "فلورن أروبي": "AWG",
+        "florí d'aruba": "AWG",
+        "arubský florin": "AWG",
+        "aruba florin": "AWG",
+        "φλορίνι της αρούμπα": "AWG",
+        "aruban florin": "AWG",
+        "aruba guldeno": "AWG",
+        "florín arubeño": "AWG",
+        "aruba floriin": "AWG",
+        "florin arubar": "AWG",
+        "آروبا فلورین": "AWG",
+        "aruban floriini": "AWG",
+        "florin arubais": "AWG",
+        "florín de aruba": "AWG",
+        "פלורין ארובי": "AWG",
+        "arupski florin": "AWG",
+        "arubai florin": "AWG",
+        "fiorino arubano": "AWG",
+        "アルバ・フロリン": "AWG",
+        "arubos florinas": "AWG",
+        "arubaanse florin": "AWG",
+        "florin arubański": "AWG",
+        "florim arubano": "AWG",
+        "florin arubez": "AWG",
+        "арубанский флорин": "AWG",
+        "arubansk florin": "AWG",
+        "aruba florini": "AWG",
+        "арубський флорин": "AWG",
+        "阿魯巴弗羅林": "AWG",
+        "alderney pound": "AYP",
+        "alderneyn punta": "AYP",
+        "aldernejska funta": "AYP",
+        "alderney i font": "AYP",
+        "sterlina di alderney": "AYP",
+        "funt alderney": "AYP",
+        "фунт олдерни": "AYP",
+        "مانات أذربيجاني": "AZN",
+        "азербайджански манат": "AZN",
+        "manat azerbaidjanès": "AZN",
+        "ázerbájdžánský manat": "AZN",
+        "aserbajdsjanske manat": "AZN",
+        "aserbaidschan manat": "AZN",
+        "μανάτ του αζερμπαϊτζάν": "AZN",
+        "azerbaijani manat": "AZN",
+        "azerbajĝana manato": "AZN",
+        "manat azerbaiyano": "AZN",
+        "aserbaidžaani manat": "AZN",
+        "azerbaijandar manat": "AZN",
+        "منات آذربایجان": "AZN",
+        "azerbaidžanin manat": "AZN",
+        "manat azerbaïdjanais": "AZN",
+        "manat acerbaixano": "AZN",
+        "מאנאט אזרבייג'ני": "AZN",
+        "azerbajdžanski manat": "AZN",
+        "azeri manat": "AZN",
+        "manat": [
+            "TMT",
             "AZN"
-        ], 
-        "ukp": [
-            "GBP"
-        ], 
-        "paraguayaanse guarani\u0301": [
-            "PYG"
-        ], 
-        "mauritiusi ru\u0301pia": [
-            "MUR"
-        ], 
-        "philippinischer peso": [
-            "PHP"
-        ], 
-        "kambodschanischer riel": [
-            "KHR"
-        ], 
-        "huf": [
-            "HUF"
-        ], 
-        "dollar de singapour": [
-            "SGD"
-        ], 
-        "dom$": [
-            "DOP"
-        ], 
-        "dinar du kowei\u0308t": [
-            "KWD"
-        ], 
-        "australian dollar": [
-            "AUD"
-        ], 
-        "namibian dollar": [
-            "NAD"
-        ], 
-        "arubaanse gulden": [
-            "AWG"
-        ], 
-        "drachme moderne grecque": [
-            "GRD"
-        ], 
-        "dinar kowe\u0301itien": [
-            "KWD"
-        ], 
-        "nieuwe israelische sheqel": [
-            "ILS"
-        ], 
-        "salyn": [
-            "THB"
-        ], 
-        "moldova\u0301n lej": [
-            "MDL"
-        ], 
-        "nepalesische rupie": [
-            "NPR"
-        ], 
-        "marka convertible": [
-            "BAM"
-        ], 
-        "bulgarian lev": [
-            "BGN"
-        ], 
-        "tengue": [
-            "KZT"
-        ], 
-        "currency of somalia": [
-            "SOS"
-        ], 
-        "franc franc\u0327ais": [
-            "FRF"
-        ], 
-        "do\u0301lar bahames": [
-            "BSD"
-        ], 
-        "som de kirguistan": [
-            "KGS"
-        ], 
-        "kip laotiano": [
-            "LAK"
-        ], 
-        "sar": [
-            "SAR"
-        ], 
-        "ngultrum butane\u0301s": [
-            "BTN"
-        ], 
-        "birr etiope": [
-            "ETB"
-        ], 
-        "fening": [
-            "BAM"
-        ], 
-        "dominicaanse peso": [
-            "DOP"
-        ], 
-        "taka": [
-            "BDT"
-        ], 
-        "\u20b2": [
-            "PYG"
-        ], 
-        "do\u0301lar neozelandes": [
-            "NZD"
-        ], 
-        "rial ye\u0301me\u0301nite": [
-            "YER"
-        ], 
-        "sterlina sud sudanese": [
-            "SSP"
-        ], 
-        "dolar de bermuda": [
-            "BMD"
-        ], 
-        "dollar taiwanais": [
-            "TWD"
-        ], 
-        "afghanis": [
-            "AFN"
-        ], 
-        "uyu": [
-            "UYU"
-        ], 
-        "cordoba": [
-            "NIO"
-        ], 
-        "bahamaanse dollar": [
-            "BSD"
-        ], 
-        "\u0111ong": [
-            "VND"
-        ], 
-        "baiza": [
-            "OMR"
-        ], 
-        "kazachse tenge": [
-            "KZT"
-        ], 
-        "vietnamesischer \u0111o\u0302\u0300ng": [
-            "VND"
-        ], 
-        "dollar de brunei": [
-            "BND"
-        ], 
-        "dollar du belize": [
-            "BZD"
-        ], 
-        "jordanian dinar": [
-            "JOD"
-        ], 
-        "nuevo sol peruviano": [
-            "PEN"
-        ], 
-        "livre turque": [
-            "TRY"
-        ], 
-        "fidschi dollar": [
-            "FJD"
-        ], 
-        "franco cfa de africa central": [
-            "XAF"
-        ], 
-        "kyrgyzstani som": [
-            "KGS"
-        ], 
-        "dolar taiwane\u0301s": [
-            "TWD"
-        ], 
-        "quetzales": [
-            "GTQ"
-        ], 
-        "pa\u0301pua u\u0301j guineai kina": [
-            "PGK"
-        ], 
-        "won nord core\u0301en": [
-            "KPW"
-        ], 
-        "couronne danoise": [
-            "DKK"
-        ], 
-        "nuevo do\u0301lar de taiwa\u0301n": [
-            "TWD"
-        ], 
-        "uruguay peso": [
-            "UYU"
-        ], 
-        "boli\u0301vares fuertes": [
-            "VEF"
-        ], 
-        "rupia de pakistan": [
-            "PKR"
-        ], 
-        "lilangeni": [
-            "SZL"
-        ], 
-        "rupia dell'india": [
-            "INR"
-        ], 
-        "libra esterlina": [
-            "GBP"
-        ], 
-        "koruna ceska\u0301": [
-            "CZK"
-        ], 
-        "\u20b3": [
-            "ARA"
-        ], 
-        "co\u0301rdoba nicaragu\u0308ense": [
-            "NIO"
-        ], 
-        "hongaarse forint": [
-            "HUF"
-        ], 
-        "loti lesothan": [
-            "LSL"
-        ], 
-        "baht thailandese": [
-            "THB"
-        ], 
-        "real brasileno": [
-            "BRL"
-        ], 
-        "katari ria\u0301l": [
-            "QAR"
-        ], 
-        "uzbekistani som": [
-            "UZS"
-        ], 
-        "armenischer dram": [
-            "AMD"
-        ], 
-        "jorda\u0301n dina\u0301r": [
-            "JOD"
-        ], 
-        "bulgaarse lev": [
-            "BGN"
-        ], 
-        "hondurasi lempira": [
-            "HNL"
-        ], 
-        "do\u0302\u0300ng vietnamita": [
-            "VND"
-        ], 
-        "gel": [
-            "GEL"
-        ], 
-        "trinidad en tobago dollar": [
-            "TTD"
-        ], 
-        "rupia de maldivas": [
-            "MVR"
-        ], 
-        "do\u0301lar liberiano": [
-            "LRD"
-        ], 
-        "vanuatuaanse vatu": [
-            "VUV"
-        ], 
-        "libe\u0301riai dolla\u0301r": [
-            "LRD"
-        ], 
-        "colon costarricense": [
-            "CRC"
-        ], 
-        "dobra di sa\u0303o tome\u0301 e pri\u0301ncipe": [
-            "STD"
-        ], 
-        "croatian kuna": [
-            "HRK"
-        ], 
-        "nouveau sol": [
-            "PEN"
-        ], 
-        "wo\u0306n norcoreano": [
-            "KPW"
-        ], 
-        "de\u0301l afrikai rand": [
-            "ZAR"
-        ], 
-        "dolar bermuden\u0303o": [
-            "BMD"
-        ], 
-        "tu\u0308rkische lira": [
-            "TRY"
-        ], 
-        "rmb": [
-            "CNY"
-        ], 
-        "ringgit malese": [
-            "MYR"
-        ], 
-        "marco de la republica democra\u0301tica alemana": [
-            "DDM"
-        ], 
-        "j$": [
-            "JMD"
-        ], 
-        "lire turque": [
-            "TRY"
-        ], 
-        "tunisian dinar": [
-            "TND"
-        ], 
-        "falkland pfund": [
-            "FKP"
-        ], 
-        "pakistani rupee": [
-            "PKR"
-        ], 
-        "central african cfa franc": [
-            "XAF"
-        ], 
-        "rouble": [
-            "SUR"
-        ], 
-        "ytl": [
-            "TRY"
-        ], 
-        "trinidad e\u0301s tobago\u0301 i dolla\u0301r": [
-            "TTD"
-        ], 
-        "orosz rubel": [
-            "RUB"
-        ], 
-        "dollar de surinam": [
-            "SRD"
-        ], 
-        "franco delle comore": [
-            "KMF"
-        ], 
-        "so\u02bbm": [
-            "UZS"
-        ], 
-        "franse franc": [
-            "FRF"
-        ], 
-        "kuna croata": [
-            "HRK"
-        ], 
-        "droits de tirage spe\u0301ciaux": [
-            "XDR"
-        ], 
-        "kuna croate": [
-            "HRK"
-        ], 
-        "dinar de kuwait": [
-            "KWD"
-        ], 
-        "dschibuti franc": [
-            "DJF"
-        ], 
-        "guinea franc": [
-            "GNF"
-        ], 
-        "kwacha zambese": [
-            "ZMW"
-        ], 
-        "guatemalteekse quetzal": [
-            "GTQ"
-        ], 
-        "chelin keniano": [
-            "KES"
-        ], 
-        "livre libanaise": [
-            "LBP"
-        ], 
-        "dkk": [
-            "DKK"
-        ], 
-        "ouguiya della mauritana": [
-            "MRO"
-        ], 
-        "kaaimaneilandse dollar": [
-            "KYD"
-        ], 
-        "drtrigonbot:exchange rate data:ltl": [
-            "LTL"
-        ], 
-        "comorese frank": [
-            "KMF"
-        ], 
-        "us $": [
-            "USD"
-        ], 
-        "lats lettone": [
-            "LVL"
-        ], 
-        "griwna": [
-            "UAH"
-        ], 
-        "qatari riyal": [
-            "QAR"
-        ], 
-        "colon": [
-            "CRC"
-        ], 
-        "franc germinal": [
-            "FRF", 
-            "XFO"
-        ], 
-        "roupie ne\u0301palaise": [
-            "NPR"
-        ], 
-        "dollar jamai\u0308cain": [
-            "JMD"
-        ], 
-        "mark": [
-            "DDM"
-        ], 
-        "indische rupie": [
-            "INR"
-        ], 
-        "angolese kwanza": [
-            "AOA"
-        ], 
-        "dollar de fidji": [
-            "FJD"
-        ], 
-        "khr": [
-            "KHR"
-        ], 
-        "krona": [
-            "SEK"
-        ], 
-        "dollaro di trinidad e tobago": [
-            "TTD"
-        ], 
-        "krone": [
-            "DKK"
-        ], 
-        "szoma\u0301li shilling": [
-            "SOS"
-        ], 
-        "rupia indiana": [
-            "INR"
-        ], 
-        "bolivar fuerte": [
-            "VEF"
-        ], 
-        "euro\u0301": [
-            "EUR"
-        ], 
-        "rupia de indonesia": [
-            "IDR"
-        ], 
-        "libra gibraltaren\u0303a": [
-            "GIP"
-        ], 
-        "indonesische rupiah": [
-            "IDR"
-        ], 
-        "panamaischer balboa": [
-            "PAB"
-        ], 
-        "ethiopian birr": [
-            "ETB"
-        ], 
-        "kubai konvertibilis peso": [
-            "CUC"
-        ], 
-        "clp": [
-            "CLP"
-        ], 
-        "florin d'aruba": [
-            "AWG"
-        ], 
-        "dolar bahames": [
-            "BSD"
-        ], 
-        "ouguiya mauritanien": [
-            "MRO"
-        ], 
-        "salomonen dollar": [
-            "SBD"
-        ], 
-        "chavito": [
-            "CUC"
-        ], 
-        "kanadai dolla\u0301r": [
-            "CAD"
-        ], 
-        "britische pfund": [
-            "GBP"
-        ], 
-        "singaporese dollar": [
-            "SGD"
-        ], 
-        "chinese renminbi": [
-            "CNY"
-        ], 
-        "saudische riyal": [
-            "SAR"
-        ], 
-        "neuer taiwan dollar": [
-            "TWD"
-        ], 
-        "do\u0301lar taiwanes": [
-            "TWD"
-        ], 
-        "keniaanse shilling": [
-            "KES"
-        ], 
-        "do\u0301lar de bahamas": [
-            "BSD"
-        ], 
-        "bhutanese ngultrum": [
-            "BTN"
-        ], 
-        "corona noruega": [
-            "NOK"
-        ], 
-        "dollaro giamaicano": [
-            "JMD"
-        ], 
-        "afgani afgano": [
-            "AFN"
-        ], 
-        "pab": [
-            "PAB"
-        ], 
-        "aruba florin": [
-            "AWG"
-        ], 
-        "tajikistani ruble": [
-            "TJR"
-        ], 
-        "franzo\u0308sischer franc": [
-            "FRF"
-        ], 
-        "lira italiana": [
-            "ITL"
-        ], 
-        "$ can": [
-            "CAD"
-        ], 
-        "marco de la rda": [
-            "DDM"
-        ], 
-        "ostkaribische wa\u0308hrungsunion": [
-            "XCD"
-        ], 
-        "naf": [
-            "ANG"
-        ], 
-        "drtrigonbot:exchange rate data:jpy": [
-            "JPY"
-        ], 
-        "afghaanse afghani": [
-            "AFN"
-        ], 
-        "peruviaanse sol": [
-            "PEN"
-        ], 
-        "livre de sainte he\u0301le\u0300ne": [
-            "SHP"
-        ], 
-        "sa\u0303o tome\u0301 and pri\u0301ncipe dobra": [
-            "STD"
-        ], 
-        "co\u0301rdoba oro": [
-            "NIO"
-        ], 
-        "moneda nacional": [
-            "CUP"
-        ], 
-        "macanese pataca": [
-            "MOP"
-        ], 
-        "couronne tcheque": [
-            "CZK"
-        ], 
-        "chelin ugande\u0301s": [
-            "UGX"
-        ], 
-        "peso cubano convertible": [
-            "CUC"
-        ], 
-        "eritreai nakfa": [
-            "ERN"
-        ], 
-        "ira\u0301ni ria\u0301l": [
-            "IRR"
-        ], 
-        "dollar canadien": [
-            "CAD"
-        ], 
-        "litouwse litas": [
-            "LTL"
-        ], 
-        "venezuelan boli\u0301var": [
-            "VEF"
-        ], 
-        "lib$": [
-            "LRD"
-        ], 
-        "cheli\u0301n keniata": [
-            "KES"
-        ], 
-        "riyal saoudien": [
-            "SAR"
-        ], 
-        "usbekistan sum": [
-            "UZS"
-        ], 
-        "chelin keniata": [
-            "KES"
-        ], 
-        "peso cubano convertibile": [
-            "CUC"
-        ], 
-        "euros": [
-            "EUR"
-        ], 
-        "dollar des bermudes": [
-            "BMD"
-        ], 
-        "liberianischer dollar": [
-            "LRD"
-        ], 
-        "peso convertibile": [
-            "CUC"
-        ], 
-        "grd": [
-            "GRD"
-        ], 
-        "tschechoslowakische krone": [
-            "CSK"
-        ], 
-        "tongan pa'anga": [
-            "TOP"
-        ], 
-        "szamoai tala": [
-            "WST"
-        ], 
-        "namibischer dollar": [
-            "NAD"
-        ], 
-        "manat azerbai\u0308djanais": [
-            "AZN"
-        ], 
-        "real": [
-            "BRL"
-        ], 
-        "tanzanian shilingi": [
-            "TZS"
-        ], 
-        "dollar liberien": [
-            "LRD"
-        ], 
-        "do\u0301lar neocelandes": [
-            "NZD"
-        ], 
-        "do\u0301lar taiwane\u0301s": [
-            "TWD"
-        ], 
-        "dinaro del bahrein": [
-            "BHD"
-        ], 
-        "florin hu\u0301ngaro": [
-            "HUF"
-        ], 
-        "zambian kwacha": [
-            "ZMW"
-        ], 
-        "dracma greca": [
-            "GRD"
-        ], 
-        "italian lira": [
-            "ITL"
-        ], 
-        "antilliaanse gulden": [
-            "ANG"
-        ], 
-        "som uzbeco": [
-            "UZS"
-        ], 
-        "yuan renminbi": [
-            "CNY"
-        ], 
-        "tenge kazajo": [
-            "KZT"
-        ], 
-        "dolar trinitense": [
-            "TTD"
-        ], 
-        "dollaro bahamense": [
-            "BSD"
-        ], 
-        "yeni kurus\u0327": [
-            "TRY"
-        ], 
-        "brunei dollar": [
-            "BND"
-        ], 
-        "lek albanes": [
-            "ALL"
-        ], 
-        "yua\u0301n chino": [
-            "CNY"
-        ], 
-        "\u20adn": [
-            "LAK"
-        ], 
-        "som kirgui\u0301s": [
-            "KGS"
-        ], 
-        "britse pond": [
-            "GBP"
-        ], 
-        "\u20b4": [
-            "UAH"
-        ], 
-        "nuevo dolar de taiwa\u0301n": [
-            "TWD"
-        ], 
-        "dominican peso": [
-            "DOP"
-        ], 
-        "mosambikanischer escudo": [
-            "MZE"
-        ], 
-        "do\u0301lar de las islas caima\u0301n": [
-            "KYD"
-        ], 
-        "gibraltar pfund": [
-            "GIP"
-        ], 
-        "lats leto\u0301n": [
-            "LVL"
-        ], 
-        "kanadische dollar": [
-            "CAD"
-        ], 
-        "srd": [
-            "SRD"
-        ], 
-        "sre": [
-            "SCR"
-        ], 
-        "comore i frank": [
-            "KMF"
-        ], 
-        "peso colombiano": [
-            "COP"
-        ], 
-        "leke\u0308": [
-            "ALL"
-        ], 
-        "\u0433\u0440\u0438\u0432\u043d\u044f": [
-            "UAH"
-        ], 
-        "alu chip": [
-            "DDM"
-        ], 
-        "kanadischer dollar": [
-            "CAD"
-        ], 
-        "suriname dollar": [
-            "SRD"
-        ], 
-        "corona ceca": [
-            "CZK"
-        ], 
-        "serbischer dinar": [
-            "RSD"
-        ], 
-        "dollar de brune\u0301i": [
-            "BND"
-        ], 
-        "denar": [
-            "MKD"
-        ], 
-        "dinar macedonio": [
-            "MKD"
-        ], 
-        "lira maltese": [
-            "MTL"
-        ], 
-        "frans geld": [
-            "FRF"
-        ], 
-        "naira nigeriana": [
-            "NGN"
-        ], 
-        "nuevo do\u0301lar taiwanes": [
-            "TWD"
-        ], 
-        "dollaro neozelandese": [
-            "NZD"
-        ], 
-        "dinar bahrei\u0308nien": [
-            "BHD"
-        ], 
-        "zweedse kroon": [
-            "SEK"
-        ], 
-        "swedish krona": [
-            "SEK"
-        ], 
-        "new israeli shekel": [
-            "ILS"
-        ], 
-        "leu moldave": [
-            "MDL"
-        ], 
-        "rupia de nepal": [
-            "NPR"
-        ], 
-        "leu moldavo": [
-            "MDL"
-        ], 
-        "fidzsi dolla\u0301r": [
-            "FJD"
-        ], 
-        "pula": [
-            "BWP"
-        ], 
-        "drachmai": [
-            "GRD"
-        ], 
-        "marco bosnio": [
-            "BAM"
-        ], 
-        "roupie seychelloise": [
-            "SCR"
-        ], 
-        "u\u0308zbe\u0301g szom": [
-            "UZS"
-        ], 
-        "tanzanian schilling": [
-            "TZS"
-        ], 
-        "gib\u00a3": [
-            "GIP"
-        ], 
-        "lett lat": [
-            "LVL"
-        ], 
-        "kc\u030cs": [
-            "CSK"
-        ], 
-        "mark der deutschen demokratischen republik": [
-            "DDM"
-        ], 
-        "yeni tu\u0308rk liras\u0131": [
-            "TRY"
-        ], 
-        "\u3012": [
-            "KZT"
-        ], 
-        "bosnische convertibele mark": [
-            "BAM"
-        ], 
-        "libra siria": [
-            "SYP"
-        ], 
-        "peso oro": [
-            "DOP"
-        ], 
-        "rupia indonesia": [
-            "IDR"
-        ], 
-        "pakistaanse rupee": [
-            "PKR"
-        ], 
-        "riel cambogiano": [
-            "KHR"
-        ], 
-        "haitian gourde": [
-            "HTG"
-        ], 
-        "tschechische wa\u0308hrung": [
-            "CZK"
-        ], 
-        "bosnia and herzegovina convertible mark": [
-            "BAM"
-        ], 
-        "francs franc\u0327ais": [
-            "FRF"
-        ], 
-        "griechische drachme": [
-            "GRD"
-        ], 
-        "nuovo sol": [
-            "PEN"
-        ], 
-        "swiss franc": [
-            "CHF"
-        ], 
-        "swiss frank": [
-            "CHF"
-        ], 
-        "somoni tayiko": [
-            "TJS"
-        ], 
-        "rial yemeni\u0301": [
-            "YER"
-        ], 
-        "nueva lira turca": [
-            "TRY"
-        ], 
-        "engelse pond": [
-            "GBP"
-        ], 
-        "chelin tanzano": [
-            "TZS"
-        ], 
-        "peso de repu\u0301blica dominicana": [
-            "DOP"
-        ], 
-        "dalasi gambese": [
-            "GMD"
-        ], 
-        "nicaraguaanse co\u0301rdoba": [
-            "NIO"
-        ], 
-        "lira libanese": [
-            "LBP"
-        ], 
-        "baht tailandes": [
-            "THB"
-        ], 
-        "khoum": [
-            "MRO"
-        ], 
-        "lek albane\u0301s": [
-            "ALL"
-        ], 
-        "botswanischer pula": [
-            "BWP"
-        ], 
-        "dinar mace\u0301donien": [
-            "MKD"
-        ], 
-        "dollar": [
-            "USD"
-        ], 
-        "dolar bahame\u0301s": [
-            "BSD"
-        ], 
-        "\u20ac": [
-            "EUR"
-        ], 
-        "dollar singapourien": [
-            "SGD"
-        ], 
-        "israe\u0308lische sjekel": [
-            "ILS"
-        ], 
-        "wo\u0306n surcoreano": [
-            "KRW"
-        ], 
-        "ukra\u0301n hrivnya": [
-            "UAH"
-        ], 
-        "dinar algerien": [
-            "DZD"
-        ], 
-        "cedi ghanese": [
-            "GHS"
-        ], 
-        "cfa franc bceao": [
-            "XOF"
-        ], 
-        "scr": [
-            "SCR"
-        ], 
-        "\u0442\u04e9\u0433\u0440\u04e9\u0433": [
-            "MNT"
-        ], 
-        "izlandi korona": [
-            "ISK"
-        ], 
-        "englisches pfund": [
-            "GBP"
-        ], 
-        "ws$": [
-            "WST"
-        ], 
-        "wikipedia:raadsel/netties20070405": [
-            "GRD"
-        ], 
-        "dolar neozelande\u0301s": [
-            "NZD"
-        ], 
-        "samoanischer tala": [
-            "WST"
-        ], 
-        "syrisch pond": [
-            "SYP"
-        ], 
-        "caymaneilandse dollar": [
-            "KYD"
-        ], 
-        "cordoba oro": [
-            "NIO"
-        ], 
-        "kina papuana": [
-            "PGK"
-        ], 
-        "szent ilona i font": [
-            "SHP"
-        ], 
-        "sudanese pound": [
-            "SDG"
-        ], 
-        "gourde haitiano": [
-            "HTG"
-        ], 
-        "dollar hongkongais": [
-            "HKD"
-        ], 
-        "haiti gourde": [
-            "HTG"
-        ], 
-        "eyrir": [
-            "ISK"
-        ], 
-        "australes": [
-            "ARA"
-        ], 
-        "livres turques": [
-            "TRY"
-        ], 
-        "dollar barbadien": [
-            "BBD"
-        ], 
-        "congolese franc": [
-            "CDF"
-        ], 
-        "wst": [
-            "WST"
-        ], 
-        "t$": [
-            "TOP"
-        ], 
-        "congolese frank": [
-            "CDF"
-        ], 
-        "nafka": [
-            "ERN"
-        ], 
-        "dansk krone": [
-            "DKK"
-        ], 
-        "jordanischer dinar": [
-            "JOD"
-        ], 
-        "dolar de bahamas": [
-            "BSD"
-        ], 
-        "brasilianischer real": [
-            "BRL"
-        ], 
-        "nz$": [
-            "NZD"
-        ], 
-        "leone sierra le\u0301onais": [
-            "SLL"
-        ], 
-        "tunesische dinar": [
-            "TND"
-        ], 
-        "do\u0301lar namibio": [
-            "NAD"
-        ], 
-        "$ca": [
-            "CAD"
-        ], 
-        "bengalese taka": [
-            "BDT"
-        ], 
-        "dollar fidjien": [
-            "FJD"
-        ], 
-        "ungarischer forint": [
-            "HUF"
-        ], 
-        "dinar serbe": [
-            "RSD"
-        ], 
-        "do\u0301lar de trinidad y tobago": [
-            "TTD"
-        ], 
-        "belize dollar": [
-            "BZD"
-        ], 
-        "sum": [
-            "UZS"
-        ], 
-        "franc rwandais": [
-            "RWF"
-        ], 
-        "dinar jordanien": [
-            "JOD"
-        ], 
-        "moldauischer leu": [
-            "MDL"
-        ], 
-        "dolar de las islas salomon": [
-            "SBD"
-        ], 
-        "lire italienne": [
-            "ITL"
-        ], 
-        "ang": [
-            "ANG"
-        ], 
-        "\u0e3f": [
-            "THB"
-        ], 
-        "sucre": [
-            "XSU"
-        ], 
-        "kzt": [
-            "KZT"
-        ], 
-        "kronor": [
-            "SEK"
-        ], 
-        "somalische shilling": [
-            "SOS"
-        ], 
-        "dollaro namibiano": [
-            "NAD"
-        ], 
-        "omanischer rial": [
-            "OMR"
-        ], 
-        "do\u0301lar bermuden\u0303o": [
-            "BMD"
-        ], 
-        "marka": [
-            "BAM"
-        ], 
-        "marco convertibile": [
-            "BAM"
-        ], 
-        "rublo ruso": [
-            "RUB"
-        ], 
-        "uae dirham": [
-            "AED"
-        ], 
-        "vae dirham": [
-            "AED"
-        ], 
-        "ngultrum del bhutan": [
-            "BTN"
-        ], 
-        "samoaanse tala": [
-            "WST"
-        ], 
-        "maltesische lira": [
-            "MTL"
-        ], 
-        "couronne norvegienne": [
-            "NOK"
-        ], 
-        "franc burundais": [
-            "BIF"
-        ], 
-        "flori\u0301n arubeno": [
-            "AWG"
-        ], 
-        "georgian kupon lari": [
-            "GEL"
-        ], 
-        "dollar de trinidad et tobago": [
-            "TTD"
-        ], 
-        "t\u0323a\u0304ka\u0304": [
-            "BDT"
-        ], 
-        "tonga pa\u02bbanga": [
-            "TOP"
-        ], 
-        "dinar kuwaiti": [
-            "KWD"
-        ], 
-        "kenia schilling": [
-            "KES"
-        ], 
-        "\u20a1": [
-            "CRC"
-        ], 
-        "guarani paraguayen": [
-            "PYG"
-        ], 
-        "lats letton": [
-            "LVL"
-        ], 
-        "quetzal guate\u0301malte\u0300que": [
-            "GTQ"
-        ], 
-        "netherlands antillean guilder": [
-            "ANG"
-        ], 
-        "balboa panamen\u0303o": [
-            "PAB"
-        ], 
-        "dolar de brune\u0301i": [
-            "BND"
-        ], 
-        "sheqel": [
-            "ILS"
-        ], 
-        "escudo capoverdiano": [
-            "CVE"
-        ], 
-        "boli\u0301var fuerte": [
-            "VEF"
-        ], 
-        "franco della guinea": [
-            "GNF"
-        ], 
-        "boli\u0301var": [
-            "VEF"
-        ], 
-        "lilangeni swazilandais": [
-            "SZL"
-        ], 
-        "dracma griega moderna": [
-            "GRD"
-        ], 
-        "tenge kazako": [
-            "KZT"
-        ], 
-        "tenge kazakh": [
-            "KZT"
-        ], 
-        "mexican centavo": [
-            "MXN"
-        ], 
-        "peso uruguaiano": [
-            "UYU"
-        ], 
-        "franco cfp": [
-            "XPF"
-        ], 
-        "so'm": [
-            "UZS"
-        ], 
-        "drtrigonbot:exchange rate data:chf": [
-            "CHF"
-        ], 
-        "konvertible mark": [
-            "BAM"
-        ], 
-        "nouveau manat aze\u0301ri": [
-            "AZN"
-        ], 
-        "nordjemenitischer rial": [
-            "YER"
-        ], 
-        "bolivares": [
-            "VEF"
-        ], 
-        "\u043b\u0435\u0432": [
-            "BGN"
-        ], 
-        "deg": [
-            "XDR"
-        ], 
-        "guarani paraguaiano": [
-            "PYG"
-        ], 
-        "scellino keniano": [
-            "KES"
-        ], 
-        "f$": [
-            "FJD"
-        ], 
-        "couronne islandaise": [
-            "ISK"
-        ], 
-        "dollar de la barbade": [
-            "BBD"
-        ], 
-        "macause pataca": [
-            "MOP"
-        ], 
-        "do\u0301lar bermudeno": [
-            "BMD"
-        ], 
-        "isk": [
-            "ISK"
-        ], 
-        "west african cfa franc": [
-            "XOF"
-        ], 
-        "armeense dram": [
-            "AMD"
-        ], 
-        "renminbi yuan": [
-            "CNY"
-        ], 
-        "aussie dollar": [
-            "AUD"
-        ], 
-        "franco francese": [
-            "FRF"
-        ], 
-        "tetradrachmon": [
-            "GRD"
-        ], 
-        "dinar irakien": [
-            "IQD"
-        ], 
-        "tongan pa\u02bbanga": [
-            "TOP"
-        ], 
-        "fr": [
-            "FRF"
-        ], 
-        "ft": [
-            "HUF"
-        ], 
-        "nuevo sol": [
-            "PEN"
-        ], 
-        "peso convertible argentino": [
-            "ARS"
-        ], 
-        "ff": [
-            "FRF"
-        ], 
-        "dollar de taiwan": [
-            "TWD"
-        ], 
-        "azerbaijani manat": [
-            "AZN"
-        ], 
-        "dirham": [
-            "AED"
-        ], 
-        "antillen gulden": [
-            "ANG"
-        ], 
-        "lari ge\u0301orgien": [
-            "GEL"
-        ], 
-        "fijian dollar": [
-            "FJD"
-        ], 
-        "mark convertible de bosnie herze\u0301govine": [
-            "BAM"
-        ], 
-        "nuovo siclo israeliano": [
-            "ILS"
-        ], 
-        "bhuta\u0301ni ngultrum": [
-            "BTN"
-        ], 
-        "guarani\u0301 paraguayen": [
-            "PYG"
-        ], 
-        "jamaican dollar": [
-            "JMD"
-        ], 
-        "rupia": [
-            "LKR", 
-            "SCR", 
-            "INR", 
-            "NPR"
-        ], 
-        "dinar libyen": [
-            "LYD"
-        ], 
-        "dinaro giordano": [
-            "JOD"
-        ], 
-        "paraguayan guarani\u0301": [
-            "PYG"
-        ], 
-        "maldivische rufiyaa": [
-            "MVR"
-        ], 
-        "marokkanischer dirham": [
-            "MAD"
-        ], 
-        "franco pacifico": [
-            "XPF"
-        ], 
-        "lats": [
-            "LVL"
-        ], 
-        "forinto": [
-            "HUF"
-        ], 
-        "dollar be\u0301lizien": [
-            "BZD"
-        ], 
-        "forints": [
-            "HUF"
-        ], 
-        "do\u0301lar bahameno": [
-            "BSD"
-        ], 
-        "hrywen": [
-            "UAH"
-        ], 
-        "roupie pakistanaise": [
-            "PKR"
-        ], 
-        "rwf": [
-            "RWF"
-        ], 
-        "iraanse rial": [
-            "IRR"
-        ], 
-        "chetrum": [
-            "BTN"
-        ], 
-        "do\u0301lar de las bahamas": [
-            "BSD"
-        ], 
-        "lesothischer loti": [
-            "LSL"
-        ], 
-        "djiboutian franc": [
-            "DJF"
-        ], 
-        "soviet ruble": [
-            "SUR"
-        ], 
-        "madagascan ariary": [
-            "MGA"
-        ], 
-        "hryvna": [
-            "UAH"
-        ], 
-        "komoren franc": [
-            "KMF"
-        ], 
-        "sterlina britannica": [
-            "GBP"
-        ], 
-        "sonderziehungsrecht": [
-            "XDR"
-        ], 
-        "jamaicai dolla\u0301r": [
-            "JMD"
-        ], 
-        "sierra leone i leone": [
-            "SLL"
-        ], 
-        "laoszi kip": [
-            "LAK"
-        ], 
-        "ma\u0301ltai li\u0301ra": [
-            "MTL"
-        ], 
-        "dolar de fiji": [
-            "FJD"
-        ], 
-        "dirham de los emiratos a\u0301rabes unidos": [
-            "AED"
-        ], 
-        "dollaro della namibia": [
-            "NAD"
-        ], 
-        "vn\u0111": [
-            "VND"
-        ], 
-        "dollar des carai\u0308bes orientales": [
-            "XCD"
-        ], 
-        "kelet karibi dolla\u0301r": [
-            "XCD"
-        ], 
-        "dinar argelino": [
-            "DZD"
-        ], 
-        "dolar de barbados": [
-            "BBD"
-        ], 
-        "sbd": [
-            "SBD"
-        ], 
-        "saoedische riyal": [
-            "SAR"
-        ], 
-        "dinar bareini\u0301": [
-            "BHD"
-        ], 
-        "do\u0301lar de guyana": [
-            "GYD"
-        ], 
-        "won norcoreano": [
-            "KPW"
-        ], 
-        "dram arme\u0301nien": [
-            "AMD"
-        ], 
-        "peso de me\u0301jico": [
-            "MXN"
-        ], 
-        "kuna": [
-            "HRK"
-        ], 
-        "kubanischer peso": [
-            "CUP"
-        ], 
-        "sambia kwacha": [
-            "ZMW"
-        ], 
-        "sri lankaanse roepie": [
-            "LKR"
-        ], 
-        "neue tu\u0308rkische lira": [
-            "TRY"
-        ], 
-        "algerischer dinar": [
-            "DZD"
-        ], 
-        "hong kong dollar": [
-            "HKD"
-        ], 
-        "$a": [
-            "ARP"
-        ], 
-        "rupia nepalese": [
-            "NPR"
-        ], 
-        "bhat": [
-            "THB"
-        ], 
-        "maleisische ringgit": [
-            "MYR"
-        ], 
-        "rupia nepalesa": [
-            "NPR"
-        ], 
-        "tsjechische kroon": [
-            "CZK"
-        ], 
-        "dong": [
-            "VND"
-        ], 
-        "xof": [
-            "XOF"
-        ], 
-        "chilean peso": [
-            "CLP"
-        ], 
-        "nordkoreanischer won": [
-            "KPW"
-        ], 
-        "soedanese pond": [
-            "SDG"
-        ], 
-        "angol font": [
-            "GBP"
-        ], 
-        "kip laosiano": [
-            "LAK"
-        ], 
-        "dollaro delle barbados": [
-            "BBD"
-        ], 
-        "gpb": [
-            "GBP"
-        ], 
-        "nuovo dollaro taiwanese": [
-            "TWD"
-        ], 
-        "pond sterling": [
-            "GBP"
-        ], 
-        "nouveau shekel": [
-            "ILS"
-        ], 
-        "libanees pond": [
-            "LBP"
-        ], 
-        "kuvaiti dina\u0301r": [
-            "KWD"
-        ], 
-        "kenyan shilling": [
-            "KES"
-        ], 
-        "dolar bahamen\u0303o": [
-            "BSD"
-        ], 
-        "surinaamse gulden": [
-            "SRG"
-        ], 
-        "tschang": [
-            "THB"
-        ], 
-        "north korean won": [
-            "KPW"
-        ], 
-        "fiorino ungherese": [
-            "HUF"
-        ], 
-        "franco yibuti\u0301": [
-            "DJF"
-        ], 
-        "servische dinar": [
-            "RSD"
-        ], 
-        "manat turkme\u0300ne": [
-            "TMT"
-        ], 
-        "swiss franken": [
-            "CHF"
-        ], 
-        "costa rica colo\u0301n": [
-            "CRC"
-        ], 
-        "franco yibutiense": [
-            "DJF"
-        ], 
-        "venezolaanse boli\u0301var": [
-            "VEF"
-        ], 
-        "marco de la repu\u0301blica democratica alemana": [
-            "DDM"
-        ], 
-        "karod": [
-            "NPR"
-        ], 
-        "riyal": [
-            "SAR"
-        ], 
-        "birr e\u0301thiopien": [
-            "ETB"
-        ], 
-        "francs pacifique": [
-            "XPF"
-        ], 
-        "rufiyaa delle maldive": [
-            "MVR"
-        ], 
-        "libyan dinar": [
-            "LYD"
-        ], 
-        "siclo israeliano": [
-            "ILS"
-        ], 
-        "santomese dobra": [
-            "STD"
-        ], 
-        "mauritiaanse roepie": [
-            "MUR"
-        ], 
-        "srilankaanse rupee": [
-            "LKR"
-        ], 
-        "sum uzbeco": [
-            "UZS"
-        ], 
-        "laari": [
-            "MVR"
-        ], 
-        "dolar de trinidad y tobago": [
-            "TTD"
-        ], 
-        "austral argentino": [
-            "ARA"
-        ], 
-        "do\u0301lar fijiano": [
-            "FJD"
-        ], 
-        "bz$": [
-            "BZD"
-        ], 
-        "argentijnse peso": [
-            "ARS"
-        ], 
-        "vnd": [
-            "VND"
-        ], 
-        "dong vietnamien": [
-            "VND"
-        ], 
-        "ngultrum butanes": [
-            "BTN"
-        ], 
-        "do\u0301lar del caribe este": [
-            "XCD"
-        ], 
-        "pakistaanse roepie": [
-            "PKR"
-        ], 
-        "drtrigonbot:exchange rate data:usd": [
-            "USD"
-        ], 
-        "indone\u0301z ru\u0301pia": [
-            "IDR"
-        ], 
-        "riyal dell'oman": [
-            "OMR"
-        ], 
-        "gambiai dalasi": [
-            "GMD"
-        ], 
-        "dollaro delle salomone": [
-            "SBD"
-        ], 
-        "bermuda dollar": [
-            "BMD"
-        ], 
-        "km": [
-            "BAM"
-        ], 
-        "kr": [
-            "DKK"
-        ], 
-        "mozambican escudo": [
-            "MZE"
-        ], 
-        "samoan tala": [
-            "WST"
-        ], 
-        "brazil real": [
-            "BRL"
-        ], 
-        "dollaro della guyana": [
-            "GYD"
-        ], 
-        "norve\u0301g korona": [
-            "NOK"
-        ], 
-        "dobra di sao tome\u0301 e principe": [
-            "STD"
-        ], 
-        "cdf": [
-            "CDF"
-        ], 
-        "azerbeidzjaanse manat": [
-            "AZN"
-        ], 
-        "droits de tirage speciaux": [
-            "XDR"
-        ], 
-        "paanga": [
-            "TOP"
-        ], 
-        "livre des i\u0302les malouines": [
-            "FKP"
-        ], 
-        "ugx": [
-            "UGX"
-        ], 
-        "holland antilla\u0301kbeli forint": [
-            "ANG"
-        ], 
-        "\u20a3": [
-            "FRF"
-        ], 
-        "costa rican colo\u0301n": [
-            "CRC"
-        ], 
-        "roupie indone\u0301sienne": [
-            "IDR"
-        ], 
-        "rd$": [
-            "DOP"
-        ], 
-        "dollar australien": [
-            "AUD"
-        ], 
-        "russian ruble": [
-            "RUB"
-        ], 
-        "mianmari kjap": [
-            "MMK"
-        ], 
-        "nicaraguan co\u0301rdoba": [
-            "NIO"
-        ], 
-        "florin aruben\u0303o": [
-            "AWG"
-        ], 
-        "rupie indiane": [
-            "INR"
-        ], 
-        "florin arubain": [
-            "AWG"
-        ], 
-        "dinar kuwaiti\u0301": [
-            "KWD"
-        ], 
-        "hryvnya": [
-            "UAH"
-        ], 
-        "tamil rupee": [
-            "LKR"
-        ], 
-        "oegandese shilling": [
-            "UGX"
-        ], 
-        "corona cecoslovacca": [
-            "CSK"
-        ], 
-        "clp$": [
-            "CLP"
-        ], 
-        "cheli\u0301n ugandes": [
-            "UGX"
-        ], 
-        "kina": [
-            "PGK"
-        ], 
-        "noord koreaanse won": [
-            "KPW"
-        ], 
-        "chilenischer peso": [
-            "CLP"
-        ], 
-        "uganda schilling": [
-            "UGX"
-        ], 
-        "uruguayaanse peso": [
-            "UYU"
-        ], 
-        "metical": [
-            "MZN"
-        ], 
-        "\u0440\u0443\u0431": [
-            "RUB"
-        ], 
-        "marokko\u0301i dirham": [
-            "MAD"
-        ], 
-        "ars": [
-            "ARS"
-        ], 
-        "iraki dina\u0301r": [
-            "IQD"
-        ], 
-        "tugrik mongolo": [
-            "MNT"
-        ], 
-        "soedanees pond": [
-            "SDG"
-        ], 
-        "honduran lempira": [
-            "HNL"
-        ], 
-        "rial dell'oman": [
-            "OMR"
-        ], 
-        "sek": [
-            "SEK"
-        ], 
-        "franc malgache": [
-            "MGA"
-        ], 
-        "fille\u0301r": [
-            "HUF"
-        ], 
-        "piso": [
-            "PHP"
-        ], 
-        "cayman islands dollar": [
-            "KYD"
-        ], 
-        "guyaanse dollar": [
-            "GYD"
-        ], 
-        "won": [
-            "KRW"
-        ], 
-        "barbadosi dolla\u0301r": [
-            "BBD"
-        ], 
-        "bosnische inwisselbare mark": [
-            "BAM"
-        ], 
-        "\u20b8": [
-            "KZT"
-        ], 
-        "dollar neo zelandais": [
-            "NZD"
-        ], 
-        "leone sierraleonese": [
-            "SLL"
-        ], 
-        "franco comorano": [
-            "KMF"
-        ], 
-        "guineese frank": [
-            "GNF"
-        ], 
+        ],
+        "manat azero": "AZN",
+        "アゼルバイジャン・マナト": "AZN",
+        "azerbaidžano manatas": "AZN",
+        "azerbeidzjaanse manat": "AZN",
+        "manat azerbejdżański": "AZN",
+        "manate azeri": "AZN",
+        "manat azer": "AZN",
+        "азербайджанский манат": "AZN",
+        "azerbajdžanský manat": "AZN",
+        "азербејџански манат": "AZN",
+        "azerbajdzjansk manat": "AZN",
+        "அசர்பைஜானிய மனாட்": "AZN",
+        "azerbaycan manatı": "AZN",
+        "азербайджанський манат": "AZN",
+        "manat azerbaijan": "AZN",
+        "阿塞拜疆马纳特": "AZN",
+        "مارك بوسني": "BAM",
+        "босненска конвертируема марка": "BAM",
+        "marc convertible": "BAM",
+        "konvertibilní marka": "BAM",
+        "konvertibilna mark": "BAM",
+        "konvertible mark": "BAM",
+        "μετατρέψιμο μάρκο βοσνίας και ερζεγοβίνης": "BAM",
+        "bosnia and herzegovina convertible mark": "BAM",
+        "konvertebla marko": "BAM",
+        "marco bosnioherzegovino": "BAM",
+        "مارک تبدیلپذیر بوسنی و هرزگوین": "BAM",
+        "bosnian ja hertsegovinan vaihdettava markka": "BAM",
+        "mark convertible de bosnie herzégovine": "BAM",
+        "marco convertible": "BAM",
+        "מארק סחיר": "BAM",
+        "konvertibilna marka": "BAM",
+        "bosnyák konvertibilis márka": "BAM",
+        "marco bosniaco": "BAM",
+        "兌換マルク": "BAM",
+        "konvertuojamoji markė": "BAM",
+        "bosnische inwisselbare mark": "BAM",
+        "marka zamienna": "BAM",
+        "marco conversível": "BAM",
+        "marcă bosniacă convertibilă": "BAM",
+        "конвертируемая марка": "BAM",
+        "konvertibilná marka": "BAM",
+        "конвертибилна марка": "BAM",
+        "கன்வர்ட்டிபிள் மார்க்கு": "BAM",
+        "bosna hersek değiştirilebilir markı": "BAM",
+        "конвертовна марка": "BAM",
+        "波斯尼亚和黑塞哥维那可兑换马克": "BAM",
+        "دولار بربادوسي": "BBD",
+        "барбадоски долар": "BBD",
+        "dòlar de barbados": "BBD",
+        "barbadoský dolar": "BBD",
+        "barbados dollar": "BBD",
+        "δολάριο μπαρμπάντος": "BBD",
+        "barbadian dollar": "BBD",
+        "barbada dolaro": "BBD",
+        "dólar barbadense": "BBD",
+        "dolar barbadostar": "BBD",
+        "دلار باربادوس": "BBD",
+        "barbadoksen dollari": "BBD",
+        "dollar barbadien": "BBD",
+        "dólar de barbados": "BBD",
+        "barbadoski dolar": "BBD",
+        "barbadosi dollár": "BBD",
+        "dollaro di barbados": "BBD",
+        "バルバドス・ドル": "BBD",
+        "barbadoso doleris": "BBD",
+        "barbadiaanse dollar": "BBD",
+        "dolar barbadoski": "BBD",
+        "барбадосский доллар": "BBD",
+        "barbadoský dolár": "BBD",
+        "barbadisk dollar": "BBD",
+        "barbados doları": "BBD",
+        "барбадоський долар": "BBD",
+        "đô la barbados": "BBD",
+        "巴貝多元": "BBD",
+        "تاكا بنغلاديشي": "BDT",
+        "бангладешка така": "BDT",
+        "taka": "BDT",
+        "bangladéšská taka": "BDT",
+        "μπανγκλαντεσιανή τάκα": "BDT",
+        "bangladeshi taka": "BDT",
+        "bangladeŝa tako": "BDT",
+        "taka bangladesí": "BDT",
+        "تاکا بنگلادش": "BDT",
+        "bangladeshin taka": "BDT",
+        "bangladeška taka": "BDT",
+        "bangladesi taka": "BDT",
+        "taka bengalese": "BDT",
+        "タカ": "BDT",
+        "bangladešo taka": "BDT",
+        "bengalese taka": "BDT",
+        "бангладешская така": "BDT",
+        "வங்காளதேச இட்டாக்கா": "BDT",
+        "bangladeş takası": "BDT",
+        "бангладеська така": "BDT",
+        "taka bangladesh": "BDT",
+        "孟加拉塔卡": "BDT",
+        "ليف بلغاري": "BGN",
+        "български лев": "BGN",
+        "lev": "BGN",
+        "bulharský lev": "BGN",
+        "bulgarske leva": "BGN",
+        "lew": "BGN",
+        "λεβ": "BGN",
+        "bulgarian lev": "BGN",
+        "bulgara levo": "BGN",
+        "leev": "BGN",
+        "bulgariar lev": "BGN",
+        "لو بلغارستان": "BGN",
+        "bulgarian leva": "BGN",
+        "lev bulgare": "BGN",
+        "lev búlgaro": "BGN",
+        "לב": "BGN",
+        "bugarski lev": "BGN",
+        "bolgár leva": "BGN",
+        "lev bulgaro": "BGN",
+        "レフ": "BGN",
+        "bulgarijos levas": "BGN",
+        "bulgaarse lev": "BGN",
+        "leva": "BGN",
+        "болгарский лев": "BGN",
+        "bolgarski lev": "BGN",
+        "бугарски лев": "BGN",
+        "பல்கேரிய லெவ்": "BGN",
+        "болгарський лев": "BGN",
+        "lev bulgaria": "BGN",
+        "保加利亞列弗": "BGN",
+        "دينار بحريني": "BHD",
+        "бахрейнски динар": "BHD",
+        "dinar de bahrain": "BHD",
+        "bahrajnský dinár": "BHD",
+        "bahrain dinar": "BHD",
+        "δηνάριο μπαχρέιν": "BHD",
+        "bahraini dinar": "BHD",
+        "barejna dinaro": "BHD",
+        "dinar bareiní": "BHD",
+        "دینار بحرین": "BHD",
+        "bahrainin dinaari": "BHD",
+        "dinar bahreïni": "BHD",
+        "דינר בחרייני": "BHD",
+        "bahreinski dinar": "BHD",
+        "bahreini dinár": "BHD",
+        "dinaro del bahrein": "BHD",
+        "バーレーン・ディナール": "BHD",
+        "bahreino dinaras": "BHD",
+        "bahreinse dinar": "BHD",
+        "dinar bahrajski": "BHD",
+        "dinar bareinita": "BHD",
+        "бахрейнский динар": "BHD",
+        "бахреински динар": "BHD",
+        "bahrainsk dinar": "BHD",
+        "bahreyn dinarı": "BHD",
+        "бахрейнський динар": "BHD",
+        "巴林第納爾": "BHD",
+        "فرنك بوروندي": "BIF",
+        "бурундийски франк": "BIF",
+        "franc de burundi": "BIF",
+        "burundský frank": "BIF",
+        "burundi franc": "BIF",
+        "φράγκο μπουρούντι": "BIF",
+        "burundian franc": "BIF",
+        "burunda franko": "BIF",
+        "franco burundés": "BIF",
+        "فرانک بوروندی": "BIF",
+        "burundin frangi": "BIF",
+        "franc burundais": "BIF",
+        "burundski franak": "BIF",
+        "burundi frank": "BIF",
+        "franco del burundi": "BIF",
+        "ブルンジ・フラン": "BIF",
+        "burundžio frankas": "BIF",
+        "burundese frank": "BIF",
+        "frank burundyjski": "BIF",
+        "franco do burundi": "BIF",
+        "бурундийский франк": "BIF",
+        "бурундски франак": "BIF",
+        "burundisk franc": "BIF",
+        "புரூண்டி பிராங்க்": "BIF",
+        "burundi frangı": "BIF",
+        "бурундійський франк": "BIF",
+        "蒲隆地法郎": "BIF",
+        "دولار برمودي": "BMD",
+        "dòlar de les bermudes": "BMD",
+        "bermudský dolar": "BMD",
+        "bermuda dollar": "BMD",
+        "δολάριο βερμούδων": "BMD",
+        "bermudian dollar": "BMD",
+        "bermuda dolaro": "BMD",
+        "dólar bermudeño": "BMD",
+        "dolar bermudar": "BMD",
+        "دلار برمودا": "BMD",
+        "bermudan dollari": "BMD",
+        "dollar bermudien": "BMD",
+        "bermudski dolar": "BMD",
+        "bermudai dollár": "BMD",
+        "dollaro di bermuda": "BMD",
+        "バミューダ・ドル": "BMD",
+        "bermudos doleris": "BMD",
+        "bermudaanse dollar": "BMD",
+        "dolar bermudzki": "BMD",
+        "dólar bermudense": "BMD",
+        "бермудский доллар": "BMD",
+        "бермудски долар": "BMD",
+        "bermudisk dollar": "BMD",
+        "bermuda doları": "BMD",
+        "бермудський долар": "BMD",
+        "đô la bermuda": "BMD",
+        "百慕達元": "BMD",
+        "دولار بروني": "BND",
+        "брунейски долар": "BND",
+        "dòlar de brunei": "BND",
+        "brunejský dolar": "BND",
+        "brunei dollar": "BND",
+        "bruneja dolaro": "BND",
+        "dólar de brunéi": "BND",
+        "dolar bruneitar": "BND",
+        "دلار برونئی": "BND",
+        "brunein dollari": "BND",
+        "dollar de brunei": "BND",
+        "dólar de brunei": "BND",
+        "דולר ברוניי": "BND",
+        "brunejski dolar": "BND",
+        "brunei dollár": "BND",
+        "dollaro del brunei": "BND",
+        "ブルネイ・ドル": "BND",
+        "brunėjaus doleris": "BND",
+        "bruneise dollar": "BND",
+        "dolar brunejski": "BND",
+        "брунейский доллар": "BND",
+        "брунејски долар": "BND",
+        "bruneisk dollar": "BND",
+        "புருனே டாலர்": "BND",
+        "brunei doları": "BND",
+        "брунейський долар": "BND",
+        "đô la brunei": "BND",
+        "汶萊元": "BND",
+        "بوليفاريو بوليفي": "BOB",
+        "boliviano": "BOB",
+        "bolivijský boliviano": "BOB",
+        "μπολιβιάνο": "BOB",
+        "bolivian boliviano": "BOB",
+        "bolivia bolivjano": "BOB",
+        "bigarren boliviano": "BOB",
+        "بولیویانو بولیوی": "BOB",
+        "בוליביאנו": "BOB",
+        "bolivijski bolivijano": "BOB",
+        "bolíviai boliviano": "BOB",
+        "ボリビアーノ": "BOB",
+        "bolivianas": "BOB",
+        "boliviaanse boliviano": "BOB",
+        "боливиано": "BOB",
+        "боливијски боливијано": "BOB",
+        "болівійський болівіано": "BOB",
+        "玻利維亞玻利維亞諾": "BOB",
+        "boliviano con mantenimiento de valor respecto al dólar estadounidense": "BOV",
+        "ريال برازيلي": "BRL",
+        "бразилски реал": "BRL",
+        "real brasiler": "BRL",
+        "brazilský real": "BRL",
+        "brasiliansk real": "BRL",
+        "brasilianischer real": "BRL",
+        "ρεάλ βραζιλίας": "BRL",
+        "brazilian real": "BRL",
+        "brazila realo": "BRL",
+        "real brasileño": "BRL",
+        "erreal brasildar": "BRL",
+        "رئال برزیل": "BRL",
+        "brasilian real": "BRL",
+        "réal brésilien": "BRL",
+        "real brasileiro": "BRL",
+        "ריאל ברזילאי": "BRL",
+        "brazilski real": "BRL",
+        "brazil real": "BRL",
+        "real brasiliano": "BRL",
+        "レアル": "BRL",
+        "brazilijos realas": "BRL",
+        "braziliaanse real": "BRL",
+        "real brazylijski": "BRL",
+        "real": "BRL",
+        "бразильский реал": "BRL",
+        "பிரேசிலிய ரெயால்": "BRL",
+        "brezilya reali": "BRL",
+        "бразильський реал": "BRL",
+        "real brasil": "BRL",
+        "巴西雷亚尔": "BRL",
+        "دولار بهامي": "BSD",
+        "бахамски долар": "BSD",
+        "dòlar de les bahames": "BSD",
+        "bahamský dolar": "BSD",
+        "bahama dollar": "BSD",
+        "bahamian dollar": "BSD",
+        "bahama dolaro": "BSD",
+        "dólar bahameño": "BSD",
+        "dolar bahamar": "BSD",
+        "دلار باهاما": "BSD",
+        "bahaman dollari": "BSD",
+        "dollar bahaméen": "BSD",
+        "dólar bahamés": "BSD",
+        "bahamski dolar": "BSD",
+        "bahamai dollár": "BSD",
+        "dollaro delle bahamas": "BSD",
+        "バハマ・ドル": "BSD",
+        "bahamų doleris": "BSD",
+        "bahamaanse dollar": "BSD",
+        "dolar bahamski": "BSD",
+        "dólar baamiano": "BSD",
+        "багамский доллар": "BSD",
+        "bahamský dolár": "BSD",
+        "bahamansk dollar": "BSD",
+        "bahama doları": "BSD",
+        "багамський долар": "BSD",
+        "đô la bahamas": "BSD",
+        "巴哈馬元": "BSD",
+        "نغولترم بوتاني": "BTN",
+        "бутански нгултрум": "BTN",
+        "ngultrum": "BTN",
+        "bhútánský ngultrum": "BTN",
+        "νγκούλτρουμ": "BTN",
+        "bhutanese ngultrum": "BTN",
+        "butana ngultrumo": "BTN",
+        "ngultrum butanés": "BTN",
+        "bhutani ngultrum": "BTN",
+        "نگولتروم بوتان": "BTN",
+        "bhutanin ngultrum": "BTN",
+        "butanski ngultrum": "BTN",
+        "bhutáni ngultrum": "BTN",
+        "ngultrum del bhutan": "BTN",
+        "ニュルタム": "BTN",
+        "ngultrumas": "BTN",
+        "bhutaanse ngultrum": "BTN",
+        "нгултрум": "BTN",
+        "பூட்டானின் இங்குல்ட்ரம்": "BTN",
+        "ngultrum bhutan": "BTN",
+        "不丹努尔特鲁姆": "BTN",
+        "بولا بوتسواني": "BWP",
+        "ботсванска пула": "BWP",
+        "pula botswanesa": "BWP",
+        "botswanská pula": "BWP",
+        "pula": "BWP",
+        "botswanischer pula": "BWP",
+        "πούλα": "BWP",
+        "botswana pula": "BWP",
+        "bocvana pulao": "BWP",
+        "botswanar pula": "BWP",
+        "پولای بوتسوانا": "BWP",
+        "פולה": "BWP",
+        "bocvanska pula": "BWP",
+        "botswanai pula": "BWP",
+        "pula del botswana": "BWP",
+        "プラ": "BWP",
+        "botsvanos pula": "BWP",
+        "botswaanse pula": "BWP",
+        "pula botswaneză": "BWP",
+        "ботсванская пула": "BWP",
+        "боцванска пула": "BWP",
+        "botsvana pulası": "BWP",
+        "ботсванська пула": "BWP",
+        "波札那普拉": "BWP",
+        "روبل بلاروسي": "BYN",
+        "беларуска рубла": "BYN",
+        "ruble bielorús": "BYN",
+        "běloruský rubl": "BYN",
+        "hviderussiske rubler": "BYN",
+        "weißrussischer rubel": "BYN",
+        "λευκορωσικό ρούβλι": "BYN",
+        "belarusian ruble": "BYN",
+        "belorusia rublo": "BYN",
+        "rublo bielorruso": "BYN",
+        "valgevene rubla": "BYN",
+        "روبل بلاروس": "BYN",
+        "valko venäjän rupla": "BYN",
+        "rouble biélorusse": "BYN",
+        "rublo belaruso": "BYN",
+        "רובל בלארוסי": "BYN",
+        "bjeloruski rubalj": "BYN",
+        "belarusz rubel": "BYN",
+        "rublo bielorusso": "BYN",
+        "ベラルーシ・ルーブル": "BYN",
+        "baltarusijos rublis": "BYN",
+        "wit russische roebel": "BYN",
+        "rubel białoruski": "BYN",
+        "rublo bielorrusso": "BYN",
+        "rublă belarusă": "BYN",
+        "белорусский рубль": "BYN",
+        "bieloruský rubeľ": "BYN",
+        "beloruski rubelj": "BYN",
+        "белоруска рубља": "BYN",
+        "belarusisk rubel": "BYN",
+        "பெலருசிய ரூபிள்": "BYN",
+        "belarus rublesi": "BYN",
+        "білоруський рубель": "BYN",
+        "rúp belarus": "BYN",
+        "白俄羅斯盧布": "BYN",
+        "دولار بليزي": "BZD",
+        "белизийски долар": "BZD",
+        "dòlar de belize": "BZD",
+        "belizský dolar": "BZD",
+        "belize dollar": "BZD",
+        "δολάριο μπελίζ": "BZD",
+        "beliza dolaro": "BZD",
+        "dólar beliceño": "BZD",
+        "dolar belizetar": "BZD",
+        "دلار بلیز": "BZD",
+        "belizen dollari": "BZD",
+        "dollar bélizien": "BZD",
+        "dólar de belize": "BZD",
+        "דולר בליזי": "BZD",
+        "belizejski dolar": "BZD",
+        "belize i dollár": "BZD",
+        "dollaro del belize": "BZD",
+        "ベリーズ・ドル": "BZD",
+        "belizo doleris": "BZD",
+        "belizaanse dollar": "BZD",
+        "dolar belizeński": "BZD",
+        "белизский доллар": "BZD",
+        "белизејски долар": "BZD",
+        "belizisk dollar": "BZD",
+        "belize doları": "BZD",
+        "белізький долар": "BZD",
+        "đô la belize": "BZD",
+        "貝里斯元": "BZD",
+        "دولار كندي": "CAD",
+        "канадски долар": "CAD",
+        "dòlar canadenc": "CAD",
+        "kanadský dolar": "CAD",
+        "canadiske dollar": "CAD",
+        "kanadischer dollar": "CAD",
+        "δολάριο καναδά": "CAD",
+        "canadian dollar": "CAD",
+        "kanada dolaro": "CAD",
+        "dólar canadiense": "CAD",
+        "kanada dollar": "CAD",
+        "dolar kanadar": "CAD",
+        "دلار کانادا": "CAD",
+        "kanadan dollari": "CAD",
+        "dollar canadien": "CAD",
+        "dólar canadense": "CAD",
+        "דולר קנדי": "CAD",
+        "kanadski dolar": "CAD",
+        "kanadai dollár": "CAD",
+        "dollar canadian": "CAD",
+        "dollaro canadese": "CAD",
+        "カナダドル": "CAD",
+        "kanados doleris": "CAD",
+        "canadese dollar": "CAD",
+        "dolar kanadyjski": "CAD",
+        "dolar canadian": "CAD",
+        "канадский доллар": "CAD",
+        "kanadský dolár": "CAD",
+        "kanadensisk dollar": "CAD",
+        "கனடா டொலர்": "CAD",
+        "kanada doları": "CAD",
+        "канадський долар": "CAD",
+        "đô la canada": "CAD",
+        "加拿大元": "CAD",
+        "فرنك كونغولي": "CDF",
+        "конгоански франк": "CDF",
+        "franc congolès": "CDF",
+        "konžský frank": "CDF",
+        "kongo franc": "CDF",
+        "congolese franc": "CDF",
+        "konga franko": "CDF",
+        "franco congoleño": "CDF",
+        "فرانک کنگو": "CDF",
+        "kongon frangi": "CDF",
+        "franc congolais": "CDF",
+        "franco congolés": "CDF",
+        "פרנק קונגולזי": "CDF",
+        "kongoanski franak": "CDF",
+        "kongói frank": "CDF",
+        "franco congolese": "CDF",
+        "コンゴ・フラン": "CDF",
+        "kongo frankas": "CDF",
+        "congolese frank": "CDF",
+        "frank kongijski": "CDF",
+        "franco congolês": "CDF",
+        "конголезский франк": "CDF",
+        "конгоански франак": "CDF",
+        "kongolesisk franc": "CDF",
+        "kongo frangı": "CDF",
+        "конголезький франк": "CDF",
+        "franc congo": "CDF",
+        "剛果法郎": "CDF",
+        "فرنك سويسري": "CHF",
+        "швейцарски франк": "CHF",
+        "franc suís": "CHF",
+        "švýcarský frank": "CHF",
+        "schweiziske franc": "CHF",
+        "schweizer franken": "CHF",
+        "ελβετικό φράγκο": "CHF",
+        "swiss franc": "CHF",
+        "svisa franko": "CHF",
+        "franco suizo": "CHF",
+        "šveitsi frank": "CHF",
+        "franko suitzar": "CHF",
+        "فرانک سوئیس": "CHF",
+        "sveitsin frangi": "CHF",
+        "franc suisse": "CHF",
+        "franco suízo": "CHF",
+        "פרנק שווייצרי": "CHF",
+        "švicarski franak": "CHF",
+        "svájci frank": "CHF",
+        "franco svizzero": "CHF",
+        "スイス・フラン": "CHF",
+        "šveicarijos frankas": "CHF",
+        "zwitserse frank": "CHF",
+        "franc soís": "CHF",
+        "frank szwajcarski": "CHF",
+        "franco suíço": "CHF",
+        "franc elvețian": "CHF",
+        "швейцарский франк": "CHF",
+        "švajčiarsky frank": "CHF",
+        "švicarski frank": "CHF",
+        "швајцарски франак": "CHF",
+        "schweizisk franc": "CHF",
+        "சுவிசு பிராங்க்": "CHF",
+        "స్విస్ ఫ్రాంక్": "CHF",
+        "i̇sviçre frangı": "CHF",
+        "швейцарський франк": "CHF",
+        "franc thụy sĩ": "CHF",
+        "瑞士法郎": "CHF",
+        "دولار جزر كوك": "CKD",
+        "dòlar de les illes cook": "CKD",
+        "dolar cookových ostrovů": "CKD",
+        "cookinseln dollar": "CKD",
+        "δολάριο νήσων κουκ": "CKD",
+        "cook islands dollar": "CKD",
+        "kukinsula dolaro": "CKD",
+        "dólar de las islas cook": "CKD",
+        "دلار جزایر کوک": "CKD",
+        "cookinsaarten dollari": "CKD",
+        "dollar des îles cook": "CKD",
+        "dólar das illas cook": "CKD",
+        "kukovootočki dolar": "CKD",
+        "cook szigeteki dollár": "CKD",
+        "dollaro delle cook": "CKD",
+        "kuko salų doleris": "CKD",
+        "cookeilandse dollar": "CKD",
+        "dolar wysp cooka": "CKD",
+        "dólar das ilhas cook": "CKD",
+        "dolar din insulele cook": "CKD",
+        "доллар островов кука": "CKD",
+        "долар островів кука": "CKD",
+        "đô la quần đảo cook": "CKD",
+        "庫克群島元": "CKD",
+        "unidad de fomento": "CLF",
+        "uf值": "CLF",
+        "بيزو تشيلي": "CLP",
+        "чилийско песо": "CLP",
+        "peso xilè": "CLP",
+        "chilské peso": "CLP",
+        "peso tsile": "CLP",
+        "chilenischer peso": "CLP",
+        "πέσο χιλής": "CLP",
+        "chilean peso": "CLP",
+        "ĉilia peso": "CLP",
+        "tšiili peeso": "CLP",
+        "peso txiletar": "CLP",
+        "پزو شیلی": "CLP",
+        "chilen peso": "CLP",
+        "peso chilien": "CLP",
+        "peso chileno": "CLP",
+        "פסו צ'יליאני": "CLP",
+        "čileanski pezo": "CLP",
+        "chilei peso": "CLP",
+        "peso cileno": "CLP",
+        "チリ・ペソ": "CLP",
+        "čilės pesas": "CLP",
+        "chileense peso": "CLP",
+        "peso de chile": "CLP",
+        "peso chilijskie": "CLP",
+        "чилийское песо": "CLP",
+        "čilenski peso": "CLP",
+        "чилеански пезос": "CLP",
+        "chilensk peso": "CLP",
+        "şili pesosu": "CLP",
+        "чилійський песо": "CLP",
+        "peso chile": "CLP",
+        "智利比索": "CLP",
+        "رنمينبي": "CNY",
+        "китайски юан": "CNY",
+        "མི་དམངས་ཤོག་དངུལ": "CNY",
         "renminbi": [
+            "CNH",
             "CNY"
-        ], 
-        "alba\u0301n lek": [
-            "ALL"
-        ], 
-        "ethiopische birr": [
-            "ETB"
-        ], 
-        "sterlina di sant\u2019elena": [
-            "SHP"
-        ], 
-        "corona islandesa": [
-            "ISK"
-        ], 
-        "corona islandese": [
-            "ISK"
-        ], 
-        "dolar bermudeno": [
-            "BMD"
-        ], 
-        "surinamese dollar": [
-            "SRD"
-        ], 
-        "nicaraguaanse cordoba": [
-            "NIO"
-        ], 
-        "loti lesothiano": [
-            "LSL"
-        ], 
-        "australischer dollar": [
-            "AUD"
-        ], 
-        "canadian dollar": [
-            "CAD"
-        ], 
-        "yen giapponese": [
-            "JPY"
-        ], 
-        "mongolian to\u0308gro\u0308g": [
-            "MNT"
-        ], 
-        "chelin ugandes": [
-            "UGX"
-        ], 
-        "chinese yuan": [
-            "CNY"
-        ], 
-        "shilling somalien": [
-            "SOS"
-        ], 
-        "hongkongse dollar": [
-            "HKD"
-        ], 
-        "bolivar": [
-            "VEF"
-        ], 
-        "riyal yemenita": [
-            "YER"
-        ], 
-        "florin des antilles ne\u0301erlandaises": [
-            "ANG"
-        ], 
-        "\u20b9": [
-            "INR"
-        ], 
-        "xaf": [
-            "XAF"
-        ], 
-        "philippine peso": [
-            "PHP"
-        ], 
-        "afghan afghani": [
-            "AFN"
-        ], 
-        "dominikai peso": [
-            "DOP"
-        ], 
-        "zuid koreaanse won": [
-            "KRW"
-        ], 
-        "cubaanse peso": [
-            "CUP"
-        ], 
-        "nepalese rupee": [
-            "NPR"
-        ], 
-        "kyat birmano": [
-            "MMK"
-        ], 
-        "franc or": [
-            "XFO"
-        ], 
-        "fiorino surinamese": [
-            "SRG"
-        ], 
-        "czech koruna": [
-            "CZK"
-        ], 
-        "verenigde arabische emiraten dirham": [
-            "AED"
-        ], 
-        "tanzaniaanse shilling": [
-            "TZS"
-        ], 
-        "rupia mauriziana": [
-            "MUR"
-        ], 
-        "monnaie canadienne": [
-            "CAD"
-        ], 
-        "do\u0301lar bruneano": [
-            "BND"
-        ], 
-        "koruna c\u030cesko slovenska\u0301": [
-            "CSK"
-        ], 
-        "pound": [
-            "GBP"
-        ], 
-        "pounds sterling": [
-            "GBP"
-        ], 
-        "jpy": [
-            "JPY"
-        ], 
-        "bs$": [
-            "BSD"
-        ], 
-        "pula botswanais": [
-            "BWP"
-        ], 
-        "haitiaanse gourde": [
-            "HTG"
-        ], 
-        "dinar de bahrein": [
-            "BHD"
-        ], 
-        "dollar jamaicain": [
-            "JMD"
-        ], 
-        "peso ley": [
-            "ARS"
-        ], 
-        "do\u0301lares neozelandeses": [
-            "NZD"
-        ], 
-        "ten\u030cn\u030ce": [
-            "TMT"
-        ], 
-        "pondteken": [
-            "GBP"
-        ], 
-        "\u5143": [
-            "CNY"
-        ], 
-        "franc uic": [
-            "XFU"
-        ], 
-        "syp": [
-            "SYP"
-        ], 
-        "dzsibuti frank": [
-            "DJF"
-        ], 
-        "dollar de la jamai\u0308que": [
-            "JMD"
-        ], 
-        "dinaro tunisino": [
-            "TND"
-        ], 
+        ],
+        "čínský jüan": "CNY",
+        "κινεζικό γουάν": "CNY",
+        "renminbio": "CNY",
+        "رنمینبی": "CNY",
         "yuan": [
+            "CNH",
             "CNY"
-        ], 
-        "sudanesisches pfund": [
-            "SDG"
-        ], 
-        "euro": [
-            "EUR"
-        ], 
-        "peruanischer nuevo sol": [
-            "PEN"
-        ], 
-        "falkland pound": [
-            "FKP"
-        ], 
-        "forint hungaro": [
-            "HUF"
-        ], 
-        "couronne suedoise": [
-            "SEK"
-        ], 
-        "peso uruguayen": [
-            "UYU"
-        ], 
-        "nami\u0301biai dolla\u0301r": [
-            "NAD"
-        ], 
-        "do\u0301lar bahamen\u0303o": [
-            "BSD"
-        ], 
-        "leone": [
-            "SLL"
-        ], 
-        "libanon pfund": [
-            "LBP"
-        ], 
-        "riyal saudi": [
-            "SAR"
-        ], 
-        "mozambican metical": [
-            "MZN"
-        ], 
-        "dollaro liberiano": [
-            "LRD"
-        ], 
-        "dolar de guyana": [
-            "GYD"
-        ], 
-        "brazilian real": [
-            "BRL"
-        ], 
-        "do\u0301lar de las islas caiman": [
-            "KYD"
-        ], 
-        "$": [
-            "USD", 
-            "MXN", 
-            "ARS", 
-            "CAD"
-        ], 
-        "cup": [
-            "CUP"
-        ], 
-        "real brasilen\u0303o": [
-            "BRL"
-        ], 
-        "peso mexicain": [
-            "MXN"
-        ], 
-        "cuc": [
-            "CUC"
-        ], 
-        "\u0433\u0440\u043d": [
-            "UAH"
-        ], 
-        "monnaie franc\u0327aise": [
-            "FRF"
-        ], 
-        "guarani\u0301 de paraguay": [
-            "PYG"
-        ], 
-        "pa\u02bbanga": [
-            "TOP"
-        ], 
-        "marco": [
-            "DDM"
-        ], 
-        "panamese balboa": [
-            "PAB"
-        ], 
-        "dolar caimano": [
-            "KYD"
-        ], 
-        "feninga": [
-            "BAM"
-        ], 
-        "kazah tenge": [
-            "KZT"
-        ], 
-        "na\u0192": [
-            "ANG"
-        ], 
-        "belgian congolese franc": [
-            "CDF"
-        ], 
-        "jamaika dollar": [
-            "JMD"
-        ], 
-        "to\u0308ro\u0308k u\u0301j li\u0301ra": [
-            "TRY"
-        ], 
-        "nige\u0301riai naira": [
-            "NGN"
-        ], 
-        "oude metical": [
-            "MZN"
-        ], 
-        "singapur dollar": [
-            "SGD"
-        ], 
-        "b$": [
-            "BSD"
-        ], 
-        "metical del mozambico": [
-            "MZN"
-        ], 
-        "ariary malgascio": [
-            "MGA"
-        ], 
-        "bolivar venezuelano": [
-            "VEF"
-        ], 
-        "corona norvegese": [
-            "NOK"
-        ], 
-        "s/.": [
-            "PEN"
-        ], 
-        "franco del burundi": [
-            "BIF"
-        ], 
-        "yemeni rial": [
-            "YER"
-        ], 
-        "dirham de emiratos arabes unidos": [
-            "AED"
-        ], 
-        "riel": [
-            "KHR"
-        ], 
-        "venezolanischer boli\u0301var": [
-            "VEF"
-        ], 
-        "de\u0301l szuda\u0301ni font": [
-            "SSP"
-        ], 
-        "\u20a4": [
-            "ITL"
-        ], 
-        "dolar de brunei": [
-            "BND"
-        ], 
-        "colo\u0301n costaricano": [
-            "CRC"
-        ], 
-        "dinaro kuwaitiano": [
-            "KWD"
-        ], 
-        "re\u0301aux bre\u0301siliens": [
-            "BRL"
-        ], 
-        "pen": [
-            "PEN"
-        ], 
-        "indiase roepie": [
-            "INR"
-        ], 
-        "rupia delle seychelles": [
-            "SCR"
-        ], 
-        "lari": [
-            "GEL"
-        ], 
-        "dollaro di barbados": [
-            "BBD"
-        ], 
-        "xang": [
-            "THB"
-        ], 
-        "taiwanese dollar": [
-            "TWD"
-        ], 
-        "paraguayi guarani\u0301": [
-            "PYG"
-        ], 
-        "cambodian riel": [
-            "KHR"
-        ], 
-        "rub": [
-            "RUB"
-        ], 
-        "dinaro algerino": [
-            "DZD"
-        ], 
-        "bs": [
-            "BSD", 
-            "BOB"
-        ], 
-        "syrisches pfund": [
-            "SYP"
-        ], 
-        "rial iranien": [
+        ],
+        "רנמינבי": "CNY",
+        "renminbi cinese": "CNY",
+        "人民元": "CNY",
+        "juanis": "CNY",
+        "chinese renminbi": "CNY",
+        "yuan renminbi": "CNY",
+        "китайский юань": "CNY",
+        "čínsky jüan": "CNY",
+        "женминби": "CNY",
+        "ரென்மின்பி": "CNY",
+        "юань женьміньбі": "CNY",
+        "nhân dân tệ": "CNY",
+        "人民币": "CNY",
+        "بيزو كولومبي": "COP",
+        "колумбийско песо": "COP",
+        "peso colombià": "COP",
+        "kolumbijské peso": "COP",
+        "colombiansk peso": "COP",
+        "kolumbianischer peso": "COP",
+        "πέσο κολομβίας": "COP",
+        "colombian peso": "COP",
+        "kolombia peso": "COP",
+        "peso colombiano": "COP",
+        "colombia peeso": "COP",
+        "peso kolonbiar": "COP",
+        "پزوی کلمبیا": "COP",
+        "kolumbian peso": "COP",
+        "peso colombien": "COP",
+        "פסו קולומביאני": "COP",
+        "kolumbijski pezo": "COP",
+        "kolumbiai peso": "COP",
+        "コロンビア・ペソ": "COP",
+        "kolumbijos pesas": "COP",
+        "colombiaanse peso": "COP",
+        "peso kolumbijskie": "COP",
+        "колумбийское песо": "COP",
+        "колумбијски пезос": "COP",
+        "kolombiya pesosu": "COP",
+        "колумбійський песо": "COP",
+        "peso colombia": "COP",
+        "哥伦比亚比索": "COP",
+        "كولون كوستاريكي": "CRC",
+        "костарикански колон": "CRC",
+        "colón costa riqueny": "CRC",
+        "kostarický colón": "CRC",
+        "costa rica colón": "CRC",
+        "costa rican colón": "CRC",
+        "kostarika kolumbo": "CRC",
+        "colón": "CRC",
+        "colón costarricar": "CRC",
+        "کولون کاستاریکا": "CRC",
+        "colón costaricien": "CRC",
+        "colón costarriqueño": "CRC",
+        "kostarikanski kolon": "CRC",
+        "costa rica i colón": "CRC",
+        "colón costaricano": "CRC",
+        "コスタリカ・コロン": "CRC",
+        "kosta rikos kolonas": "CRC",
+        "costa ricaanse colon": "CRC",
+        "colon kostarykański": "CRC",
+        "colón costa riquenho": "CRC",
+        "коста риканский колон": "CRC",
+        "costaricansk colón": "CRC",
+        "kosta rika colónu": "CRC",
+        "костариканський колон": "CRC",
+        "哥斯大黎加科朗": "CRC",
+        "بيزو كوبي": "CUP",
+        "кубинско песо": "CUP",
+        "peso cubà": "CUP",
+        "kubánské peso": "CUP",
+        "cubanske pesos": "CUP",
+        "kubanischer peso": "CUP",
+        "πέσο κούβας": "CUP",
+        "cuban peso": "CUP",
+        "kuba peso": "CUP",
+        "peso cubano": "CUP",
+        "پزوی کوبا": "CUP",
+        "kuuban peso": "CUP",
+        "peso cubain": "CUP",
+        "kubanski pezo": "CUP",
+        "kubai peso": "CUP",
+        "キューバ・ペソ": "CUP",
+        "kubos pesas": "CUP",
+        "cubaanse peso": "CUP",
+        "peso kubańskie": "CUP",
+        "peso cubanez": "CUP",
+        "кубинское песо": "CUP",
+        "кубански пезос": "CUP",
+        "kubansk peso": "CUP",
+        "küba pesosu": "CUP",
+        "кубинський песо": "CUP",
+        "peso cuba": "CUP",
+        "古巴比索": "CUP",
+        "إيسكودو جزر الرأس الأخضر": "CVE",
+        "ескудо на кабо верде": "CVE",
+        "escut de cap verd": "CVE",
+        "kapverdské escudo": "CVE",
+        "kapverdiske escudo": "CVE",
+        "kap verde escudo": "CVE",
+        "εσκούδο του πράσινου ακρωτηρίου": "CVE",
+        "cape verdean escudo": "CVE",
+        "kaboverda eskudo": "CVE",
+        "escudo caboverdiano": "CVE",
+        "اسکودوی کیپ ورد": "CVE",
+        "kap verden escudo": "CVE",
+        "escudo cap verdien": "CVE",
+        "zelenortski eskudo": "CVE",
+        "zöld foki escudo": "CVE",
+        "escudo capoverdiano": "CVE",
+        "カーボベルデ・エスクード": "CVE",
+        "žaliojo kyšulio eskudas": "CVE",
+        "kaapverdische escudo": "CVE",
+        "escudo zielonego przylądka": "CVE",
+        "escudo cabo verdiano": "CVE",
+        "эскудо кабо верде": "CVE",
+        "зеленортски ескудо": "CVE",
+        "kapverdisk escudo": "CVE",
+        "yeşil burun adaları eskudosu": "CVE",
+        "ескудо кабо верде": "CVE",
+        "escudo cabo verde": "CVE",
+        "維德角埃斯庫多": "CVE",
+        "كرونة تشيكية": "CZK",
+        "чешка крона": "CZK",
+        "corona txeca": "CZK",
+        "koruna česká": "CZK",
+        "tjekkiske koruna": "CZK",
+        "tschechische krone": "CZK",
+        "κορόνα τσεχίας": "CZK",
+        "czech koruna": "CZK",
+        "ĉeĥa krono": "CZK",
+        "corona checa": "CZK",
+        "tšehhi kroon": "CZK",
+        "txekiar koroa": "CZK",
+        "کرونای چک": "CZK",
+        "tšekin koruna": "CZK",
+        "couronne tchèque": "CZK",
+        "coroa checa": "CZK",
+        "קורונה צ'כית": "CZK",
+        "češka kruna": "CZK",
+        "cseh korona": "CZK",
+        "corona ceca": "CZK",
+        "チェコ・コルナ": "CZK",
+        "čekijos krona": "CZK",
+        "tsjechische kroon": "CZK",
+        "corona chèca": "CZK",
+        "korona czeska": "CZK",
+        "coroană cehă": "CZK",
+        "чешская крона": "CZK",
+        "česká koruna": "CZK",
+        "češka krona": "CZK",
+        "чешка круна": "CZK",
+        "tjeckisk krona": "CZK",
+        "செக் கொருனா": "CZK",
+        "çek korunası": "CZK",
+        "чеська крона": "CZK",
+        "koruna séc": "CZK",
+        "捷克克朗": "CZK",
+        "فرنك جيبوتي": "DJF",
+        "джибутски франк": "DJF",
+        "franc de djibouti": "DJF",
+        "džibutský frank": "DJF",
+        "djiboutiske franc": "DJF",
+        "dschibuti franc": "DJF",
+        "φράγκο του τζιμπουτί": "DJF",
+        "djiboutian franc": "DJF",
+        "ĝibutia franko": "DJF",
+        "franco yibutiano": "DJF",
+        "فرانک جیبوتی": "DJF",
+        "djiboutin frangi": "DJF",
+        "franc djibouti": "DJF",
+        "džibutski franak": "DJF",
+        "dzsibuti frank": "DJF",
+        "franco gibutiano": "DJF",
+        "ジブチ・フラン": "DJF",
+        "džibučio frankas": "DJF",
+        "djiboutiaanse frank": "DJF",
+        "frank dżibuti": "DJF",
+        "franco do jibuti": "DJF",
+        "франк джибути": "DJF",
+        "џибутски франак": "DJF",
+        "djiboutisk franc": "DJF",
+        "cibuti frangı": "DJF",
+        "франк джибуті": "DJF",
+        "吉布地法郎": "DJF",
+        "كرونة دنماركية": "DKK",
+        "датска крона": "DKK",
+        "corona danesa": "DKK",
+        "dánská koruna": "DKK",
+        "danske kroner": "DKK",
+        "dänische krone": "DKK",
+        "κορόνα δανίας": "DKK",
+        "danish krone": "DKK",
+        "dana krono": "DKK",
+        "taani kroon": "DKK",
+        "daniar koroa": "DKK",
+        "کرون دانمارک": "DKK",
+        "tanskan kruunu": "DKK",
+        "couronne danoise": "DKK",
+        "coroa dinamarquesa": "DKK",
+        "כתר דני": "DKK",
+        "danska kruna": "DKK",
+        "dán korona": "DKK",
+        "corona danese": "DKK",
+        "デンマーク・クローネ": "DKK",
+        "danijos krona": "DKK",
+        "deense kroon": "DKK",
+        "korona duńska": "DKK",
+        "coroană daneză": "DKK",
+        "датская крона": "DKK",
+        "dánska koruna": "DKK",
+        "данска круна": "DKK",
+        "dansk krona": "DKK",
+        "டானிய குரோன்": "DKK",
+        "danimarka kronu": "DKK",
+        "данська крона": "DKK",
+        "krone đan mạch": "DKK",
+        "丹麥克朗": "DKK",
+        "بيزو دومنيكاني": "DOP",
+        "доминиканско песо": "DOP",
+        "peso dominicà": "DOP",
+        "dominikánské peso": "DOP",
+        "dominikanischer peso": "DOP",
+        "πέσο δομινικανής δημοκρατίας": "DOP",
+        "dominican peso": "DOP",
+        "dominga peso": "DOP",
+        "peso dominicano": "DOP",
+        "peso dominikar": "DOP",
+        "پزو دومینیکن": "DOP",
+        "dominikaanisen tasavallan peso": "DOP",
+        "peso dominicain": "DOP",
+        "dominikanski pezo": "DOP",
+        "dominikai peso": "DOP",
+        "ドミニカ・ペソ": "DOP",
+        "dominikos pesas": "DOP",
+        "dominicaanse peso": "DOP",
+        "peso dominikańskie": "DOP",
+        "доминиканское песо": "DOP",
+        "доминикански пезос": "DOP",
+        "dominikansk peso": "DOP",
+        "dominik pesosu": "DOP",
+        "домініканський песо": "DOP",
+        "多明尼加比索": "DOP",
+        "دينار جزائري": "DZD",
+        "алжирски динар": "DZD",
+        "dinar algerià": "DZD",
+        "alžírský dinár": "DZD",
+        "dinar algeriaidd": "DZD",
+        "algerischer dinar": "DZD",
+        "δηνάριο αλγερίας": "DZD",
+        "algerian dinar": "DZD",
+        "alĝeria dinaro": "DZD",
+        "dinar argelino": "DZD",
+        "aljeriar dinar": "DZD",
+        "دینار الجزایر": "DZD",
+        "algerian dinaari": "DZD",
+        "dinar algérien": "DZD",
+        "dinar alxeriano": "DZD",
+        "דינר אלג'ירי": "DZD",
+        "alžirski dinar": "DZD",
+        "algériai dinár": "DZD",
+        "dinaro algerino": "DZD",
+        "アルジェリア・ディナール": "DZD",
+        "alžyro dinaras": "DZD",
+        "algerijnse dinar": "DZD",
+        "dinar algierski": "DZD",
+        "dinar algerian": "DZD",
+        "алжирский динар": "DZD",
+        "algerisk dinar": "DZD",
+        "cezayir dinarı": "DZD",
+        "алжирський динар": "DZD",
+        "dinar algérie": "DZD",
+        "阿爾及利亞第納爾": "DZD",
+        "جنيه مصري": "EGP",
+        "египетска лира": "EGP",
+        "lliura egípcia": "EGP",
+        "egyptská libra": "EGP",
+        "ägyptisches pfund": "EGP",
+        "λίρα αιγύπτου": "EGP",
+        "egyptian pound": "EGP",
+        "egipta pundo": "EGP",
+        "libra egipcia": "EGP",
+        "egiptuse nael": "EGP",
+        "libera egiptoar": "EGP",
+        "پوند مصر": "EGP",
+        "egyptin punta": "EGP",
+        "livre égyptienne": "EGP",
+        "libra exipcia": "EGP",
+        "לירה מצרית": "EGP",
+        "egipatska funta": "EGP",
+        "egyiptomi font": "EGP",
+        "sterlina egiziana": "EGP",
+        "エジプト・ポンド": "EGP",
+        "egipto svaras": "EGP",
+        "egyptisch pond": "EGP",
+        "funt egipski": "EGP",
+        "libra egípcia": "EGP",
+        "liră egipteană": "EGP",
+        "египетский фунт": "EGP",
+        "egyptiskt pund": "EGP",
+        "mısır lirası": "EGP",
+        "єгипетський фунт": "EGP",
+        "bảng ai cập": "EGP",
+        "埃及鎊": "EGP",
+        "ناكفا": "ERN",
+        "nakfa": "ERN",
+        "eritrejská nakfa": "ERN",
+        "eritreischer nakfa": "ERN",
+        "νάκφα": "ERN",
+        "eritrean nakfa": "ERN",
+        "eritrea nakfo": "ERN",
+        "ناکفای اریتره": "ERN",
+        "nakfa érythréen": "ERN",
+        "נאקפה": "ERN",
+        "eritrejska nakfa": "ERN",
+        "eritreai nakfa": "ERN",
+        "nacfa eritreo": "ERN",
+        "ナクファ": "ERN",
+        "eritrese nakfa": "ERN",
+        "эритрейская накфа": "ERN",
+        "еритрејска накфа": "ERN",
+        "eritre nakfası": "ERN",
+        "еритрейська накфа": "ERN",
+        "厄立特里亚纳克法": "ERN",
+        "بير إثيوبي": "ETB",
+        "етиопски бир": "ETB",
+        "birr": "ETB",
+        "etiopský birr": "ETB",
+        "etiopiske birr": "ETB",
+        "äthiopischer birr": "ETB",
+        "μπιρ": "ETB",
+        "ethiopian birr": "ETB",
+        "etiopa birro": "ETB",
+        "birr etíope": "ETB",
+        "بیر اتیوپی": "ETB",
+        "etiopian birr": "ETB",
+        "etiopski bir": "ETB",
+        "etióp birr": "ETB",
+        "birr etiope": "ETB",
+        "ブル": "ETB",
+        "etiopijos biras": "ETB",
+        "ethiopische birr": "ETB",
+        "эфиопский быр": "ETB",
+        "ефіопський бир": "ETB",
+        "衣索比亞比爾": "ETB",
+        "إيثريوم": "ETH",
+        "етериум": "ETH",
+        "ethereum": "ETH",
+        "اتریم": "ETH",
+        "אתריום": "ETH",
+        "イーサリアム": "ETH",
+        "ஈத்தரீயம்": "ETH",
+        "以太坊": "ETH",
+        "يورو": "EUR",
+        "евро": "EUR",
+        "euro": "EUR",
+        "ewro": "EUR",
+        "ευρώ": "EUR",
+        "eŭro": "EUR",
+        "یورو": "EUR",
+        "אירו": "EUR",
+        "euró": "EUR",
+        "ユーロ": "EUR",
+        "euras": "EUR",
+        "èuro": "EUR",
+        "evro": "EUR",
+        "ஐரோ": "EUR",
+        "యూరో": "EUR",
+        "євро": "EUR",
+        "欧元": "EUR",
+        "دولار فيجي": "FJD",
+        "фиджийски долар": "FJD",
+        "dòlar fijià": "FJD",
+        "fidžijský dolar": "FJD",
+        "fidschi dollar": "FJD",
+        "δολάριο φίτζι": "FJD",
+        "fijian dollar": "FJD",
+        "fiĝia dolaro": "FJD",
+        "dólar fiyiano": "FJD",
+        "دلار فیجی": "FJD",
+        "fidžin dollari": "FJD",
+        "dollar de fidji": "FJD",
+        "dólar fidxiano": "FJD",
+        "fidžijski dolar": "FJD",
+        "fidzsi dollár": "FJD",
+        "dollaro delle figi": "FJD",
+        "フィジー・ドル": "FJD",
+        "fidžio doleris": "FJD",
+        "fiji dollar": "FJD",
+        "dolar fidżi": "FJD",
+        "dólar de fiji": "FJD",
+        "dolar fijian": "FJD",
+        "доллар фиджи": "FJD",
+        "fidžijský dolár": "FJD",
+        "фиџијски долар": "FJD",
+        "fijidollar": "FJD",
+        "பிஜி டாலர்": "FJD",
+        "fiji doları": "FJD",
+        "фіджійський долар": "FJD",
+        "斐濟元": "FJD",
+        "جنيه جزر فوكلاند": "FKP",
+        "lliura de les malvines": "FKP",
+        "falklandská libra": "FKP",
+        "falkland pfund": "FKP",
+        "λίρα φώκλαντ": "FKP",
+        "falkland islands pound": "FKP",
+        "falklanda pundo": "FKP",
+        "libra malvinense": "FKP",
+        "libera falklandar": "FKP",
+        "پوند جزایر فالکلند": "FKP",
+        "falklandin punta": "FKP",
+        "livre des îles malouines": "FKP",
+        "לירה שטרלינג של איי פוקלנד": "FKP",
+        "falklandska funta": "FKP",
+        "falkland szigeteki font": "FKP",
+        "sterlina delle falkland": "FKP",
+        "フォークランド諸島ポンド": "FKP",
+        "folklando svaras": "FKP",
+        "falklandeilands pond": "FKP",
+        "funt falklandzki": "FKP",
+        "libra das ilhas malvinas": "FKP",
+        "liră din insulele falkland": "FKP",
+        "фунт фолклендских островов": "FKP",
+        "falklandspund": "FKP",
+        "falkland adaları poundu": "FKP",
+        "фолклендський фунт": "FKP",
+        "福克蘭群島鎊": "FKP",
+        "كرونة فاروية": "FOK",
+        "corona feroesa": "FOK",
+        "faerská koruna": "FOK",
+        "færøske kroner": "FOK",
+        "färöische krone": "FOK",
+        "faroese króna": "FOK",
+        "feroa krono": "FOK",
+        "fääri kroon": "FOK",
+        "کرون فاروئی": "FOK",
+        "färsaarten kruunu": "FOK",
+        "couronne féroïenne": "FOK",
+        "coroa feroesa": "FOK",
+        "føroyarska kruna": "FOK",
+        "feröeri korona": "FOK",
+        "corona delle fær øer": "FOK",
+        "フェロー・クローネ": "FOK",
+        "farerų krona": "FOK",
+        "faeröerse kroon": "FOK",
+        "korona wysp owczych": "FOK",
+        "coroană feroeză": "FOK",
+        "фарерская крона": "FOK",
+        "фарска круна": "FOK",
+        "färöisk krona": "FOK",
+        "பரோயே குரோனா": "FOK",
+        "faroe kronu": "FOK",
+        "фарерська крона": "FOK",
+        "法羅群島克朗": "FOK",
+        "جنيه إسترليني": "GBP",
+        "британска лира": "GBP",
+        "lliura esterlina": "GBP",
+        "libra šterlinků": "GBP",
+        "punt sterling": "GBP",
+        "britiske pund": "GBP",
+        "pfund sterling": "GBP",
+        "στερλίνα": "GBP",
+        "pound sterling": "GBP",
+        "brita pundo": "GBP",
+        "libra esterlina": "GBP",
+        "suurbritannia naelsterling": "GBP",
+        "libera esterlina": "GBP",
+        "پوند استرلینگ": "GBP",
+        "englannin punta": "GBP",
+        "livre sterling": "GBP",
+        "לירה שטרלינג": "GBP",
+        "britanska funta": "GBP",
+        "font sterling": "GBP",
+        "sterlina britannica": "GBP",
+        "スターリング・ポンド": "GBP",
+        "svaras sterlingų": "GBP",
+        "pond sterling": "GBP",
+        "liura esterlina": "GBP",
+        "funt szterling": "GBP",
+        "liră sterlină": "GBP",
+        "фунт стерлингов": "GBP",
+        "anglická libra": "GBP",
+        "funt šterling": "GBP",
+        "британска фунта": "GBP",
+        "brittiskt pund": "GBP",
+        "பிரித்தானிய பவுண்டு": "GBP",
+        "i̇ngiliz sterlini": "GBP",
+        "фунт стерлінгів": "GBP",
+        "bảng anh": "GBP",
+        "英镑": "GBP",
+        "لاري جورجي": "GEL",
+        "грузинско лари": "GEL",
+        "lari": "GEL",
+        "gruzínský lari": "GEL",
+        "georgiske lari": "GEL",
+        "georgischer lari": "GEL",
+        "λάρι γεωργίας": "GEL",
+        "georgian lari": "GEL",
+        "lario": "GEL",
+        "lari georgiano": "GEL",
+        "لاری گرجستان": "GEL",
+        "לארי גאורגי": "GEL",
+        "gruzijski lari": "GEL",
+        "grúz lari": "GEL",
+        "ラリ": "GEL",
+        "laris": "GEL",
+        "georgische lari": "GEL",
+        "грузинский лари": "GEL",
+        "gruzínske lari": "GEL",
+        "грузијски лари": "GEL",
+        "georgiska lari": "GEL",
+        "ஜார்ஜிய லாரி": "GEL",
+        "gürcistan larisi": "GEL",
+        "грузинський ларі": "GEL",
+        "格鲁吉亚拉里": "GEL",
+        "جنيه جيرنزي": "GGP",
+        "lliura de guernsey": "GGP",
+        "guernseyská libra": "GGP",
+        "guernsey pfund": "GGP",
+        "guernsey pound": "GGP",
+        "libra de guernsey": "GGP",
+        "پوند گرنزی": "GGP",
+        "guernseyn punta": "GGP",
+        "livre de guernesey": "GGP",
+        "guernseyjska funta": "GGP",
+        "guernsey i font": "GGP",
+        "sterlina di guernsey": "GGP",
+        "ガーンジー・ポンド": "GGP",
+        "gernsio svaras": "GGP",
+        "guernseypond": "GGP",
+        "funt guernsey": "GGP",
+        "liră din guernsey": "GGP",
+        "гернсийский фунт": "GGP",
+        "гернзијска фунта": "GGP",
+        "guernseypund": "GGP",
+        "குயெர்ன்சி பவுண்டு": "GGP",
+        "guernsey sterlini": "GGP",
+        "гернсійський фунт": "GGP",
+        "根西鎊": "GGP",
+        "سيدي غاني": "GHS",
+        "ганайско седи": "GHS",
+        "cedi": "GHS",
+        "ghanský cedi": "GHS",
+        "σέντι της γκάνας": "GHS",
+        "ghanaian cedi": "GHS",
+        "ganaa cedio": "GHS",
+        "سدی غنا": "GHS",
+        "ganski cedi": "GHS",
+        "ghánai cedi": "GHS",
+        "cedi ghanese": "GHS",
+        "セディ": "GHS",
+        "sedis": "GHS",
+        "ghanese cedi": "GHS",
+        "ганский седи": "GHS",
+        "гански седи": "GHS",
+        "ghana cedi": "GHS",
+        "ганський седі": "GHS",
+        "迦納塞地": "GHS",
+        "جنيه جبل طارق": "GIP",
+        "гибралтарска лира": "GIP",
+        "lliura de gibraltar": "GIP",
+        "gibraltarská libra": "GIP",
+        "gibraltariske pund": "GIP",
+        "gibraltar pfund": "GIP",
+        "gibraltar pound": "GIP",
+        "ĝibraltara pundo": "GIP",
+        "libra gibraltareña": "GIP",
+        "gibraltari nael": "GIP",
+        "پوند جبلطارق": "GIP",
+        "gibraltarin punta": "GIP",
+        "livre de gibraltar": "GIP",
+        "libra de xibraltar": "GIP",
+        "gibraltarska funta": "GIP",
+        "gibraltári font": "GIP",
+        "sterlina di gibilterra": "GIP",
+        "ジブラルタル・ポンド": "GIP",
+        "gibraltaro svaras": "GIP",
+        "gibraltarees pond": "GIP",
+        "funt gibraltarski": "GIP",
+        "libra de gibraltar": "GIP",
+        "liră din gibraltar": "GIP",
+        "гибралтарский фунт": "GIP",
+        "gibraltárska libra": "GIP",
+        "гибралтарска фунта": "GIP",
+        "gibraltarpund": "GIP",
+        "கிப்ரால்ட்டர் பவுண்டு": "GIP",
+        "гібралтарський фунт": "GIP",
+        "bảng gibraltar": "GIP",
+        "直布羅陀鎊": "GIP",
+        "دالاسي غامبي": "GMD",
+        "гамбийско даласи": "GMD",
+        "dalasi": "GMD",
+        "gambijský dalasi": "GMD",
+        "νταλάζι": "GMD",
+        "gambian dalasi": "GMD",
+        "gambia dalasio": "GMD",
+        "دالاسی گامبیا": "GMD",
+        "gambijski dalasi": "GMD",
+        "gambiai dalasi": "GMD",
+        "dalasi gambese": "GMD",
+        "ダラシ": "GMD",
+        "dalasis": "GMD",
+        "gambiaanse dalasi": "GMD",
+        "даласи": "GMD",
+        "гамбијски даласи": "GMD",
+        "гамбійський даласі": "GMD",
+        "甘比亞達拉西": "GMD",
+        "فرنك غيني": "GNF",
+        "гвинейски франк": "GNF",
+        "franc guineà": "GNF",
+        "guinejský frank": "GNF",
+        "franc guinéen": "GNF",
+        "φράγκο γουινέας": "GNF",
+        "guinean franc": "GNF",
+        "gvinea franko": "GNF",
+        "franco guineano": "GNF",
+        "فرانک گینه": "GNF",
+        "guinean frangi": "GNF",
+        "פרנק גינאי": "GNF",
+        "gvinejski franak": "GNF",
+        "guineai frank": "GNF",
+        "ギニア・フラン": "GNF",
+        "gvinėjos frankas": "GNF",
+        "guineese frank": "GNF",
+        "frank gwinejski": "GNF",
+        "franco da guiné": "GNF",
+        "гвинейский франк": "GNF",
+        "гвинејски франак": "GNF",
+        "guinesisk franc": "GNF",
+        "gine frangı": "GNF",
+        "гвінейський франк": "GNF",
+        "幾內亞法郎": "GNF",
+        "كتزال غواتيمالي": "GTQ",
+        "гватемалски кецал": "GTQ",
+        "quetzal": "GTQ",
+        "guatemalský quetzal": "GTQ",
+        "guatemaltekischer quetzal": "GTQ",
+        "κετσάλ": "GTQ",
+        "guatemalan quetzal": "GTQ",
+        "gvatemala kecalo": "GTQ",
+        "ketzal": "GTQ",
+        "کوتزال گواتمالا": "GTQ",
+        "קצאל": "GTQ",
+        "gvatemalski kvecal": "GTQ",
+        "guatemalai quetzal": "GTQ",
+        "quetzal guatemalteco": "GTQ",
+        "ケツァル": "GTQ",
+        "gvatemalos kecalis": "GTQ",
+        "guatemalteekse quetzal": "GTQ",
+        "гватемальский кетсаль": "GTQ",
+        "гватемалски квецал": "GTQ",
+        "guatemala quetzalı": "GTQ",
+        "гватемальський кетсаль": "GTQ",
+        "瓜地馬拉格查爾": "GTQ",
+        "portuguese guinean escudo": "GWE",
+        "escudo guineoportugués": "GWE",
+        "اسکودوی گینه پرتغال": "GWE",
+        "portugalin guinean escudo": "GWE",
+        "escudo de guinée bissau": "GWE",
+        "ポルトガル領ギニア・エスクード": "GWE",
+        "гвинейский эскудо": "GWE",
+        "دولار غياني": "GYD",
+        "гвиански долар": "GYD",
+        "dòlar de guyana": "GYD",
+        "guyanský dolar": "GYD",
+        "guyana dollar": "GYD",
+        "δολάριο γουιάνας": "GYD",
+        "guyanese dollar": "GYD",
+        "gujana dolaro": "GYD",
+        "dólar guyanés": "GYD",
+        "dolar guyanar": "GYD",
+        "دلار گویان": "GYD",
+        "guyanan dollari": "GYD",
+        "dollar guyanien": "GYD",
+        "dólar güianés": "GYD",
+        "gvajanski dolar": "GYD",
+        "guyanai dollár": "GYD",
+        "dollaro della guyana": "GYD",
+        "ガイアナ・ドル": "GYD",
+        "gajanos doleris": "GYD",
+        "guyaanse dollar": "GYD",
+        "dolar gujański": "GYD",
+        "dólar da guiana": "GYD",
+        "dolar guyanez": "GYD",
+        "гайанский доллар": "GYD",
+        "гвајански долар": "GYD",
+        "guyansk dollar": "GYD",
+        "guyana doları": "GYD",
+        "гаянський долар": "GYD",
+        "圭亞那元": "GYD",
+        "دولار هونغ كونغ": "HKD",
+        "хонконгски долар": "HKD",
+        "dòlar de hong kong": "HKD",
+        "hongkongský dolar": "HKD",
+        "doler hong cong": "HKD",
+        "hongkong dollar": "HKD",
+        "δολάριο χονγκ κονγκ": "HKD",
+        "hong kong dollar": "HKD",
+        "honkonga dolaro": "HKD",
+        "dólar de hong kong": "HKD",
+        "hongkongi dollar": "HKD",
+        "dolar hongkongdar": "HKD",
+        "دلار هنگ کنگ": "HKD",
+        "hongkongin dollari": "HKD",
+        "dollar de hong kong": "HKD",
+        "דולר הונג קונגי": "HKD",
+        "hongkonški dolar": "HKD",
+        "hongkongi dollár": "HKD",
+        "dollaro di hong kong": "HKD",
+        "香港ドル": "HKD",
+        "honkongo doleris": "HKD",
+        "hongkongse dollar": "HKD",
+        "dolar hongkongu": "HKD",
+        "гонконгский доллар": "HKD",
+        "hongkonský dolár": "HKD",
+        "хонгконшки долар": "HKD",
+        "hongkongdollar": "HKD",
+        "ஹொங்கொங் டொலர்": "HKD",
+        "hong kong doları": "HKD",
+        "гонконгський долар": "HKD",
+        "đô la hồng kông": "HKD",
+        "港元": "HKD",
+        "لمبيرة هندوراسية": "HNL",
+        "хондураска лемпира": "HNL",
+        "lempira": "HNL",
+        "honduraská lempira": "HNL",
+        "λεμπίρα": "HNL",
+        "honduran lempira": "HNL",
+        "hondura lempiro": "HNL",
+        "لامپیرای هندوراس": "HNL",
+        "hondurasin lempira": "HNL",
+        "למפירה": "HNL",
+        "honduraška lempira": "HNL",
+        "hondurasi lempira": "HNL",
+        "lempira honduregna": "HNL",
+        "レンピラ": "HNL",
+        "hondūro lempira": "HNL",
+        "hondurese lempira": "HNL",
+        "гондурасская лемпира": "HNL",
+        "honduras lempirası": "HNL",
+        "гондураська лемпіра": "HNL",
+        "宏都拉斯倫皮拉": "HNL",
+        "كونا كرواتية": "HRK",
+        "хърватска куна": "HRK",
+        "kuna": "HRK",
+        "chorvatská kuna": "HRK",
+        "kroatiske kuna": "HRK",
+        "kroatische kuna": "HRK",
+        "κούνα κροατίας": "HRK",
+        "croatian kuna": "HRK",
+        "kroata kunao": "HRK",
+        "kuna croata": "HRK",
+        "کونای کرواسی": "HRK",
+        "kroatian kuna": "HRK",
+        "kuna croate": "HRK",
+        "קונה": "HRK",
+        "hrvatska kuna": "HRK",
+        "horvát kuna": "HRK",
+        "クーナ": "HRK",
+        "kroatijos kuna": "HRK",
+        "хорватская куна": "HRK",
+        "chorvátska kuna": "HRK",
+        "hrvaška kuna": "HRK",
+        "хрватска куна": "HRK",
+        "kroatisk kuna": "HRK",
+        "குனா": "HRK",
+        "hırvat kunası": "HRK",
+        "хорватська куна": "HRK",
+        "kuna croatia": "HRK",
+        "克羅埃西亞庫納": "HRK",
+        "جوردة هايتية": "HTG",
+        "gourde": "HTG",
+        "haitský gourde": "HTG",
+        "γκουρντ": "HTG",
+        "haitian gourde": "HTG",
+        "haitia gurdo": "HTG",
+        "گورد هائیتی": "HTG",
+        "haitin gourde": "HTG",
+        "haićanski gourd": "HTG",
+        "haiti gourde": "HTG",
+        "gourde haitiano": "HTG",
+        "グールド": "HTG",
+        "gurdas": "HTG",
+        "haïtiaanse gourde": "HTG",
+        "гаитянский гурд": "HTG",
+        "хаићански гурд": "HTG",
+        "гаїтянський гурд": "HTG",
+        "海地古德": "HTG",
+        "فورنت مجري": "HUF",
+        "унгарски форинт": "HUF",
+        "fòrint": "HUF",
+        "maďarský forint": "HUF",
+        "ungarske forint": "HUF",
+        "forint": "HUF",
+        "φιορίνι ουγγαρίας": "HUF",
+        "hungarian forint": "HUF",
+        "hungara forinto": "HUF",
+        "forinto húngaro": "HUF",
+        "hungariar forint": "HUF",
+        "فورینت مجارستان": "HUF",
+        "unkarin forintti": "HUF",
+        "florín húngaro": "HUF",
+        "פורינט": "HUF",
+        "mađarska forinta": "HUF",
+        "magyar forint": "HUF",
+        "fiorino ungherese": "HUF",
+        "フォリント": "HUF",
+        "forintas": "HUF",
+        "hongaarse forint": "HUF",
+        "florim húngaro": "HUF",
+        "форинт": "HUF",
+        "madžarski forint": "HUF",
+        "мађарска форинта": "HUF",
+        "அங்கேரிய போரிண்ட்": "HUF",
+        "macar forinti": "HUF",
+        "угорський форинт": "HUF",
+        "匈牙利福林": "HUF",
+        "pengő": "HUP",
+        "maďarské pengő": "HUP",
+        "hungarian pengő": "HUP",
+        "pengo": "HUP",
+        "pengö": "HUP",
+        "پنگوی مجارستان": "HUP",
+        "unkarin pengő": "HUP",
+        "פנגו הונגרי": "HUP",
+        "mađarski peng": "HUP",
+        "magyar pengő": "HUP",
+        "pengő ungherese": "HUP",
+        "ペンゲー": "HUP",
+        "pengė": "HUP",
+        "pengheu maghiar": "HUP",
+        "пенгё": "HUP",
+        "угорський пенге": "HUP",
+        "匈牙利帕戈": "HUP",
+        "روبية إندونيسية": "IDR",
+        "индонезийска рупия": "IDR",
+        "rupia indonèsia": "IDR",
+        "indonéská rupie": "IDR",
+        "rupiah": "IDR",
+        "indonesische rupiah": "IDR",
+        "ρουπία ινδονησίας": "IDR",
+        "indonesian rupiah": "IDR",
+        "indonezia rupio": "IDR",
+        "rupia indonesia": "IDR",
+        "errupia indonesiar": "IDR",
+        "روپیه اندونزی": "IDR",
+        "indonesian rupia": "IDR",
+        "roupie indonésienne": "IDR",
+        "indonezijska rupija": "IDR",
+        "indonéz rúpia": "IDR",
+        "rupia indonesiana": "IDR",
+        "ルピア": "IDR",
+        "indonezijos rupija": "IDR",
+        "indonesische roepia": "IDR",
+        "rupia indonezyjska": "IDR",
+        "rupia indonésia": "IDR",
+        "индонезийская рупия": "IDR",
+        "индонежанска рупија": "IDR",
+        "இந்தோனேசிய ரூபாய்": "IDR",
+        "endonezya rupiahı": "IDR",
+        "індонезійська рупія": "IDR",
+        "印尼盾": "IDR",
+        "شيكل إسرائيلي جديد": "ILS",
+        "израелски шекел": "ILS",
+        "nou xéquel": "ILS",
+        "nový izraelský šekel": "ILS",
+        "sicl newydd israel": "ILS",
+        "ny shekel": "ILS",
+        "schekel": "ILS",
+        "νέο ισραηλινό σεκέλ": "ILS",
+        "israeli new shekel": "ILS",
+        "nova israela siklo": "ILS",
+        "nuevo séquel": "ILS",
+        "iisraeli seekel": "ILS",
+        "shekel berri": "ILS",
+        "شکل جدید اسرائیل": "ILS",
+        "uusi israelin sekeli": "ILS",
+        "shekel": "ILS",
+        "novo shekel": "ILS",
+        "שקל חדש": "ILS",
+        "izraelski novi šekel": "ILS",
+        "izraeli új sékel": "ILS",
+        "nuovo shekel israeliano": "ILS",
+        "新シェケル": "ILS",
+        "izraelio naujasis šekelis": "ILS",
+        "israëlische sjekel": "ILS",
+        "nowy izraelski szekel": "ILS",
+        "novo shekel israelense": "ILS",
+        "новый израильский шекель": "ILS",
+        "нови израелски шекел": "ILS",
+        "புது இசுரேலிய சேக்கல்": "ILS",
+        "yeni i̇srail şekeli": "ILS",
+        "ізраїльський новий шекель": "ILS",
+        "以色列新谢克尔": "ILS",
+        "جنيه مانكس": "IMP",
+        "lliura de l'illa de man": "IMP",
+        "manská libra": "IMP",
+        "isle of man pfund": "IMP",
+        "manx pound": "IMP",
+        "libra manesa": "IMP",
+        "پوند مانکس": "IMP",
+        "mansaaren punta": "IMP",
+        "livre mannoise": "IMP",
+        "libra da illa de man": "IMP",
+        "manska funta": "IMP",
+        "man szigeti font": "IMP",
+        "sterlina di man": "IMP",
+        "マンクス・ポンド": "IMP",
+        "meno salos svaras": "IMP",
+        "isle of man pond": "IMP",
+        "funt manx": "IMP",
+        "liră din insula man": "IMP",
+        "фунт острова мэн": "IMP",
+        "манска фунта": "IMP",
+        "isle of man pund": "IMP",
+        "மான்க்ஸ் பவுண்டு": "IMP",
+        "фунт острова мен": "IMP",
+        "曼島鎊": "IMP",
+        "روبية هندية": "INR",
+        "индийска рупия": "INR",
+        "rupia índia": "INR",
+        "indická rupie": "INR",
+        "indiske rupier": "INR",
+        "indische rupie": "INR",
+        "ρουπία ινδίας": "INR",
+        "indian rupee": "INR",
+        "barata rupio": "INR",
+        "rupia india": "INR",
+        "india ruupia": "INR",
+        "errupia indiar": "INR",
+        "روپیه هند": "INR",
+        "intian rupia": "INR",
+        "roupie indienne": "INR",
+        "רופי הודי": "INR",
+        "indijska rupija": "INR",
+        "indiai rúpia": "INR",
+        "rupia indiana": "INR",
+        "インド・ルピー": "INR",
+        "indijos rupija": "INR",
+        "indiase roepie": "INR",
+        "ropia d'índia": "INR",
+        "rupia indyjska": "INR",
+        "rupie indiană": "INR",
+        "индийская рупия": "INR",
+        "indická rupia": "INR",
+        "индијска рупија": "INR",
+        "indisk rupie": "INR",
+        "இந்திய ரூபாய்": "INR",
+        "రూపాయి": "INR",
+        "hindistan rupisi": "INR",
+        "індійська рупія": "INR",
+        "rupee ấn độ": "INR",
+        "印度盧比": "INR",
+        "دينار عراقي": "IQD",
+        "иракски динар": "IQD",
+        "dinar iraquià": "IQD",
+        "irakiske dinarer": "IQD",
+        "irakischer dinar": "IQD",
+        "iraqi dinar": "IQD",
+        "iraka dinaro": "IQD",
+        "dinar iraquí": "IQD",
+        "دینار عراق": "IQD",
+        "irakin dinaari": "IQD",
+        "dinar irakien": "IQD",
+        "דינר עיראקי": "IQD",
+        "irački dinar": "IQD",
+        "iraki dinár": "IQD",
+        "dinaro iracheno": "IQD",
+        "イラク・ディナール": "IQD",
+        "irako dinaras": "IQD",
+        "iraakse dinar": "IQD",
+        "dinar iracki": "IQD",
+        "dinar iraquiano": "IQD",
+        "иракский динар": "IQD",
+        "ирачки динар": "IQD",
+        "irakisk dinar": "IQD",
+        "irak dinarı": "IQD",
+        "іракський динар": "IQD",
+        "伊拉克第納爾": "IQD",
+        "ريال إيراني": "IRR",
+        "ирански риал": "IRR",
+        "rial iranià": "IRR",
+        "íránský rijál": "IRR",
+        "rial": [
+            "SAR",
             "IRR"
-        ], 
-        "dollar namibien": [
-            "NAD"
-        ], 
-        "couronne tche\u0301coslovaque": [
-            "CSK"
-        ], 
-        "couronne tchecoslovaque": [
-            "CSK"
-        ], 
-        "peruvian nuevo sol": [
-            "PEN"
-        ], 
-        "lat leton": [
-            "LVL"
-        ], 
-        "costa ricaanse colon": [
-            "CRC"
-        ], 
-        "schweizer franken": [
-            "CHF"
-        ], 
-        "dollar tai\u0308wanais": [
-            "TWD"
-        ], 
-        "japanese yen": [
-            "JPY"
-        ], 
-        "malediven rupie": [
-            "MVR"
-        ], 
-        "arubaanse florijn": [
-            "AWG"
-        ], 
-        "grivna": [
-            "UAH"
-        ], 
-        "ostkaribischer dollar": [
-            "XCD"
-        ], 
-        "mkd": [
-            "MKD"
-        ], 
-        "\u00a5": [
-            "JPY"
-        ], 
-        "ci$": [
-            "KYD"
-        ], 
-        "yuans": [
-            "CNY"
-        ], 
-        "xpf": [
-            "XPF"
-        ], 
-        "lao kip": [
-            "LAK"
-        ], 
-        "franco congoleno": [
-            "CDF"
-        ], 
-        "marco bosnioherzegovino": [
-            "BAM"
-        ], 
-        "sdr": [
-            "XDR"
-        ], 
-        "dollaro del belize": [
-            "BZD"
-        ], 
-        "peso argentino": [
-            "ARP"
-        ], 
-        "dinaro iracheno": [
-            "IQD"
-        ], 
-        "hongkong dollar": [
-            "HKD"
-        ], 
-        "guarani\u0301 paraguaiano": [
-            "PYG"
-        ], 
-        "flori\u0301n antillano neerlande\u0301s": [
-            "ANG"
-        ], 
-        "dirham marocain": [
+        ],
+        "iranischer rial": "IRR",
+        "ιρανικό ριάλ": "IRR",
+        "iranian rial": "IRR",
+        "irana rialo": "IRR",
+        "rial iraní": "IRR",
+        "irandar rial": "IRR",
+        "ریال ایران": "IRR",
+        "iranin rial": "IRR",
+        "rial iranien": "IRR",
+        "ריאל איראני": "IRR",
+        "iranski rijal": "IRR",
+        "iráni riál": "IRR",
+        "riyal iraniano": "IRR",
+        "イラン・リヤル": "IRR",
+        "irano rialas": "IRR",
+        "iraanse rial": "IRR",
+        "rial irański": "IRR",
+        "rial iraniano": "IRR",
+        "rial iranian": "IRR",
+        "иранский риал": "IRR",
+        "iránsky rial": "IRR",
+        "ирански ријал": "IRR",
+        "iransk rial": "IRR",
+        "i̇ran riyali": "IRR",
+        "іранський ріал": "IRR",
+        "rial iran": "IRR",
+        "伊朗里亞爾": "IRR",
+        "كرونة آيسلندية": "ISK",
+        "исландска крона": "ISK",
+        "corona islandesa": "ISK",
+        "islandská koruna": "ISK",
+        "islandske krónur": "ISK",
+        "isländische krone": "ISK",
+        "κορόνα ισλανδίας": "ISK",
+        "icelandic króna": "ISK",
+        "islanda krono": "ISK",
+        "islandi kroon": "ISK",
+        "islandiar koroa": "ISK",
+        "کرونای ایسلند": "ISK",
+        "islannin kruunu": "ISK",
+        "couronne islandaise": "ISK",
+        "coroa islandesa": "ISK",
+        "קרונה איסלנדית": "ISK",
+        "islandska kruna": "ISK",
+        "izlandi korona": "ISK",
+        "corona islandese": "ISK",
+        "アイスランド・クローナ": "ISK",
+        "islandijos krona": "ISK",
+        "ijslandse kroon": "ISK",
+        "korona islandzka": "ISK",
+        "coroană islandeză": "ISK",
+        "исландская крона": "ISK",
+        "islandska krona": "ISK",
+        "исландска круна": "ISK",
+        "isländsk krona": "ISK",
+        "ஐஸ்லாந்திய குரோனா": "ISK",
+        "i̇zlanda kronası": "ISK",
+        "ісландська крона": "ISK",
+        "冰岛克朗": "ISK",
+        "جنيه جيرزي": "JEP",
+        "lliura de jersey": "JEP",
+        "jerseyská libra": "JEP",
+        "jersey pfund": "JEP",
+        "jersey pound": "JEP",
+        "ĵerzeja pundo": "JEP",
+        "libra de jersey": "JEP",
+        "پوند جرسی": "JEP",
+        "jerseyn punta": "JEP",
+        "livre de jersey": "JEP",
+        "jerseyjska funta": "JEP",
+        "jersey i font": "JEP",
+        "sterlina di jersey": "JEP",
+        "ジャージー・ポンド": "JEP",
+        "džersio svaras": "JEP",
+        "jerseypond": "JEP",
+        "funt jersey": "JEP",
+        "liră din jersey": "JEP",
+        "джерсийский фунт": "JEP",
+        "џерсијска фунта": "JEP",
+        "jerseypund": "JEP",
+        "ஜெர்சி பவுண்டு": "JEP",
+        "джерсійський фунт": "JEP",
+        "澤西鎊": "JEP",
+        "دولار جامايكي": "JMD",
+        "ямайски долар": "JMD",
+        "dòlar jamaicà": "JMD",
+        "jamajský dolar": "JMD",
+        "jamaika dollar": "JMD",
+        "δολάριο τζαμάικας": "JMD",
+        "jamaican dollar": "JMD",
+        "jamajka dolaro": "JMD",
+        "dólar jamaiquino": "JMD",
+        "dolar jamaikar": "JMD",
+        "دلار جامائیکا": "JMD",
+        "jamaikan dollari": "JMD",
+        "dollar jamaïcain": "JMD",
+        "dólar xamaicano": "JMD",
+        "jamajčanski dolar": "JMD",
+        "jamaicai dollár": "JMD",
+        "dollaro giamaicano": "JMD",
+        "ジャマイカ・ドル": "JMD",
+        "jamaikos doleris": "JMD",
+        "jamaicaanse dollar": "JMD",
+        "dolar jamajski": "JMD",
+        "dólar jamaicano": "JMD",
+        "ямайский доллар": "JMD",
+        "јамајкански долар": "JMD",
+        "jamaicansk dollar": "JMD",
+        "jamaika doları": "JMD",
+        "ямайський долар": "JMD",
+        "牙買加元": "JMD",
+        "دينار أردني": "JOD",
+        "йордански динар": "JOD",
+        "dinar jordà": "JOD",
+        "jordánský dinár": "JOD",
+        "jordanischer dinar": "JOD",
+        "ιορδανικό δηνάριο": "JOD",
+        "jordanian dinar": "JOD",
+        "jordania dinaro": "JOD",
+        "dinar jordano": "JOD",
+        "jordaania dinaar": "JOD",
+        "jordaniako dinar": "JOD",
+        "دینار اردن": "JOD",
+        "jordanian dinaari": "JOD",
+        "dinar jordanien": "JOD",
+        "דינר ירדני": "JOD",
+        "jordanski dinar": "JOD",
+        "jordán dinár": "JOD",
+        "dinaro giordano": "JOD",
+        "ヨルダン・ディナール": "JOD",
+        "jordanijos dinaras": "JOD",
+        "jordaanse dinar": "JOD",
+        "dinar jordański": "JOD",
+        "dinar iordanian": "JOD",
+        "иорданский динар": "JOD",
+        "јордански динар": "JOD",
+        "jordansk dinar": "JOD",
+        "ürdün dinarı": "JOD",
+        "йорданський динар": "JOD",
+        "約旦第納爾": "JOD",
+        "ين ياباني": "JPY",
+        "японска йена": "JPY",
+        "ien": "JPY",
+        "japonský jen": "JPY",
+        "yen": "JPY",
+        "γιεν": "JPY",
+        "japanese yen": "JPY",
+        "japana eno": "JPY",
+        "jaapani jeen": "JPY",
+        "ین ژاپن": "JPY",
+        "japanin jeni": "JPY",
+        "ין יפני": "JPY",
+        "japanski jen": "JPY",
+        "japán jen": "JPY",
+        "円": "JPY",
+        "jena": "JPY",
+        "japanse yen": "JPY",
+        "jen": "JPY",
+        "iene": "JPY",
+        "иена": "JPY",
+        "јапански јен": "JPY",
+        "யென்": "JPY",
+        "japon yeni": "JPY",
+        "єна": "JPY",
+        "yên nhật": "JPY",
+        "日圓": "JPY",
+        "شيلينغ كيني": "KES",
+        "кенийски шилинг": "KES",
+        "xíling kenyà": "KES",
+        "keňský šilink": "KES",
+        "kenyansk shilling": "KES",
+        "kenia schilling": "KES",
+        "σελίνι της κένυας": "KES",
+        "kenyan shilling": "KES",
+        "kenja ŝilingo": "KES",
+        "chelín keniano": "KES",
+        "keenia šilling": "KES",
+        "شیلینگ کنیا": "KES",
+        "kenian šillinki": "KES",
+        "shilling kényan": "KES",
+        "xilin kenyano": "KES",
+        "שילינג קנייתי": "KES",
+        "kenijski šiling": "KES",
+        "kenyai shilling": "KES",
+        "scellino keniota": "KES",
+        "ケニア・シリング": "KES",
+        "kenijos šilingas": "KES",
+        "keniaanse shilling": "KES",
+        "szyling kenijski": "KES",
+        "xelim queniano": "KES",
+        "кенийский шиллинг": "KES",
+        "кенијски шилинг": "KES",
+        "kenya şilini": "KES",
+        "кенійський шилінг": "KES",
+        "肯尼亞先令": "KES",
+        "سوم قيرغيزستاني": "KGS",
+        "киргизстански сом": "KGS",
+        "som kirguís": "KGS",
+        "kyrgyzský som": "KGS",
+        "som": [
+            "UZS",
+            "KGS"
+        ],
+        "σομ κιργιζίας": "KGS",
+        "kyrgyzstani som": "KGS",
+        "kirgiza somo": "KGS",
+        "سوم قرقیزستان": "KGS",
+        "kirgisian som": "KGS",
+        "som kirguiz": "KGS",
+        "kirgistanski som": "KGS",
+        "kirgiz szom": "KGS",
+        "som kirghiso": "KGS",
+        "キルギス・ソム": "KGS",
+        "somas": "KGS",
+        "kirgizische som": "KGS",
+        "som kîrgîz": "KGS",
+        "киргизский сом": "KGS",
+        "киргиски сом": "KGS",
+        "kirgizistansk som": "KGS",
+        "kırgızistan somu": "KGS",
+        "киргизький сом": "KGS",
+        "吉尔吉斯斯坦索姆": "KGS",
+        "ريال كمبودي": "KHR",
+        "камбоджански риел": "KHR",
+        "riel": "KHR",
+        "kambodžský riel": "KHR",
+        "kambodschanischer riel": "KHR",
+        "ριέλ καμπότζης": "KHR",
+        "cambodian riel": "KHR",
+        "kamboĝa rielo": "KHR",
+        "riel camboyano": "KHR",
+        "kanbodiar bigarren riel": "KHR",
+        "ریال کامبوج": "KHR",
+        "kambodžan riel": "KHR",
+        "kambodžanski rijal": "KHR",
+        "kambodzsai riel": "KHR",
+        "riel cambogiano": "KHR",
+        "リエル": "KHR",
+        "kambodžos rielis": "KHR",
+        "cambodjaanse riel": "KHR",
+        "riel kambodżański": "KHR",
+        "riel cambojano": "KHR",
+        "риель": "KHR",
+        "камбоџански ријел": "KHR",
+        "камбоджійський рієль": "KHR",
+        "riel campuchia": "KHR",
+        "柬埔寨瑞爾": "KHR",
+        "دولار كريباتي": "KID",
+        "kiribatský dolar": "KID",
+        "kiribati dollar": "KID",
+        "δολάριο κιριμπάτι": "KID",
+        "kiribata dolaro": "KID",
+        "dólar de kiribati": "KID",
+        "دلار کیریباتی": "KID",
+        "kiribatin dollari": "KID",
+        "dollar des kiribati": "KID",
+        "kiribatski dolar": "KID",
+        "dollaro delle kiribati": "KID",
+        "キリバス・ドル": "KID",
+        "kiribačio doleris": "KID",
+        "dolar kiribati": "KID",
+        "dolar din kiribati": "KID",
+        "доллар кирибати": "KID",
+        "долар кірибаті": "KID",
+        "基里巴斯元": "KID",
+        "فرنك قمري": "KMF",
+        "коморски франк": "KMF",
+        "franc de les comores": "KMF",
+        "komorský frank": "KMF",
+        "komoren franc": "KMF",
+        "φράγκο κομορών": "KMF",
+        "comorian franc": "KMF",
+        "komora franko": "KMF",
+        "franco comorense": "KMF",
+        "فرانک کمر": "KMF",
+        "komorien frangi": "KMF",
+        "franc comorien": "KMF",
+        "komorski franak": "KMF",
+        "comore i frank": "KMF",
+        "franco delle comore": "KMF",
+        "コモロ・フラン": "KMF",
+        "komorų frankas": "KMF",
+        "comorese frank": "KMF",
+        "frank komorów": "KMF",
+        "franco comoriano": "KMF",
+        "franc comorian": "KMF",
+        "франк комор": "KMF",
+        "коморски франак": "KMF",
+        "komorisk franc": "KMF",
+        "komor frangı": "KMF",
+        "коморський франк": "KMF",
+        "葛摩法郎": "KMF",
+        "وون كوري شمالي": "KPW",
+        "севернокорейски вон": "KPW",
+        "won nord coreà": "KPW",
+        "severokorejský won": "KPW",
+        "nordkoreanske won": "KPW",
+        "nordkoreanischer won": "KPW",
+        "γουόν βόρειας κορέας": "KPW",
+        "north korean won": "KPW",
+        "nord korea ŭono": "KPW",
+        "won norcoreano": "KPW",
+        "põhja korea vonn": "KPW",
+        "وون کره شمالی": "KPW",
+        "pohjois korean won": "KPW",
+        "won nord coréen": "KPW",
+        "וון צפון קוריאני": "KPW",
+        "sjevernokorejski von": "KPW",
+        "észak koreai von": "KPW",
+        "won nordcoreano": "KPW",
+        "朝鮮民主主義人民共和国ウォン": "KPW",
+        "šiaurės korėjos vona": "KPW",
+        "noord koreaanse won": "KPW",
+        "won północnokoreański": "KPW",
+        "won norte coreano": "KPW",
+        "won nord coreean": "KPW",
+        "северокорейская вона": "KPW",
+        "севернокорејски вон": "KPW",
+        "nordkoreansk won": "KPW",
+        "kuzey kore wonu": "KPW",
+        "північнокорейська вона": "KPW",
+        "won cộng hòa dân chủ nhân dân triều tiên": "KPW",
+        "朝鮮圓": "KPW",
+        "وون كوري جنوبي": "KRW",
+        "южнокорейски вон": "KRW",
+        "won sud coreà": "KRW",
+        "jihokorejský won": "KRW",
+        "sydkoreanske won": "KRW",
+        "südkoreanischer won": "KRW",
+        "γουόν νότιας κορέας": "KRW",
+        "south korean won": "KRW",
+        "sud korea ŭono": "KRW",
+        "won surcoreano": "KRW",
+        "lõuna korea vonn": "KRW",
+        "وون کره جنوبی": "KRW",
+        "etelä korean won": "KRW",
+        "won sud coréen": "KRW",
+        "južnokorejski von": "KRW",
+        "dél koreai von": "KRW",
+        "won sudcoreano": "KRW",
+        "大韓民国ウォン": "KRW",
+        "pietų korėjos vonas": "KRW",
+        "zuid koreaanse won": "KRW",
+        "won południowokoreański": "KRW",
+        "won sul coreano": "KRW",
+        "won sud coreean": "KRW",
+        "южнокорейская вона": "KRW",
+        "јужнокорејски вон": "KRW",
+        "sydkoreansk won": "KRW",
+        "güney kore wonu": "KRW",
+        "південнокорейська вона": "KRW",
+        "won hàn quốc": "KRW",
+        "韓圓": "KRW",
+        "دينار كويتي": "KWD",
+        "кувейтски динар": "KWD",
+        "dinar kuwaitià": "KWD",
+        "kuvajtský dinár": "KWD",
+        "kuwaitiske dinarer": "KWD",
+        "kuwait dinar": "KWD",
+        "δηνάριο κουβέιτ": "KWD",
+        "kuwaiti dinar": "KWD",
+        "kuvajta dinaro": "KWD",
+        "dinar kuwaití": "KWD",
+        "دینار کویت": "KWD",
+        "kuwaitin dinaari": "KWD",
+        "dinar koweïtien": "KWD",
+        "דינר כוויתי": "KWD",
+        "kuvaiti dinár": "KWD",
+        "dinaro kuwaitiano": "KWD",
+        "クウェート・ディナール": "KWD",
+        "kuveito dinaras": "KWD",
+        "koeweitse dinar": "KWD",
+        "dinar kuwejcki": "KWD",
+        "dinar kuwaitiano": "KWD",
+        "кувейтский динар": "KWD",
+        "кувајтски динар": "KWD",
+        "kuwaitisk dinar": "KWD",
+        "குவைத் தினார்": "KWD",
+        "kuveyt dinarı": "KWD",
+        "кувейтський динар": "KWD",
+        "dinar kuwait": "KWD",
+        "科威特第納爾": "KWD",
+        "دولار جزر كايمان": "KYD",
+        "dòlar de les illes caiman": "KYD",
+        "dolar kajmanských ostrovů": "KYD",
+        "kaiman dollar": "KYD",
+        "δολάριο νησιών κέιμαν": "KYD",
+        "cayman islands dollar": "KYD",
+        "kajmana dolaro": "KYD",
+        "dólar de las islas caimán": "KYD",
+        "dolar kaimandar": "KYD",
+        "دلار جزایر کیمن": "KYD",
+        "caymansaarten dollari": "KYD",
+        "dollar des îles caïmans": "KYD",
+        "kajmanski dolar": "KYD",
+        "kajmán szigeteki dollár": "KYD",
+        "dollaro delle cayman": "KYD",
+        "ケイマン諸島・ドル": "KYD",
+        "kaimanų salų doleris": "KYD",
+        "kaaimaneilandse dollar": "KYD",
+        "dolar kajmański": "KYD",
+        "dólar das ilhas cayman": "KYD",
+        "доллар каймановых островов": "KYD",
+        "долар кајманских острва": "KYD",
+        "caymansk dollar": "KYD",
+        "cayman adaları doları": "KYD",
+        "долар кайманових островів": "KYD",
+        "đô la quần đảo cayman": "KYD",
+        "開曼群島元": "KYD",
+        "تينغ كازاخستاني": "KZT",
+        "казахстанско тенге": "KZT",
+        "tenge": "KZT",
+        "τένγκε": "KZT",
+        "kazakhstani tenge": "KZT",
+        "kazaĥa tengo": "KZT",
+        "tenge kazajo": "KZT",
+        "تنگه قزاقستان": "KZT",
+        "kazakstanin tenge": "KZT",
+        "tenge kazakh": "KZT",
+        "kazahstanski tenge": "KZT",
+        "kazah tenge": "KZT",
+        "tenge kazako": "KZT",
+        "テンゲ": "KZT",
+        "kazachstano tengė": "KZT",
+        "kazachse tenge": "KZT",
+        "казахстанский тенге": "KZT",
+        "kazachstanský tenge": "KZT",
+        "казахстански тенге": "KZT",
+        "கசக்ஸ்தானிய டெங்கே": "KZT",
+        "казахстанський теньге": "KZT",
+        "tenge kazakhstan": "KZT",
+        "哈萨克斯坦坚戈": "KZT",
+        "كيب لاوي": "LAK",
+        "лаоски кип": "LAK",
+        "kip": "LAK",
+        "laoský kip": "LAK",
+        "laotischer kip": "LAK",
+        "κιπ": "LAK",
+        "lao kip": "LAK",
+        "laosa kipo": "LAK",
+        "kip laosiano": "LAK",
+        "laostar kip berria": "LAK",
+        "کیپ لائوس": "LAK",
+        "laosin kip": "LAK",
+        "laoski kip": "LAK",
+        "laoszi kip": "LAK",
+        "kip laotiano": "LAK",
+        "キープ": "LAK",
+        "laoso kipas": "LAK",
+        "laotiaanse kip": "LAK",
+        "лаосский кип": "LAK",
+        "laos kipi": "LAK",
+        "лаоський кіп": "LAK",
+        "kíp lào": "LAK",
+        "寮國基普": "LAK",
+        "ليرة لبنانية": "LBP",
+        "ливанска лира": "LBP",
+        "lliura libanesa": "LBP",
+        "libanesisches pfund": "LBP",
+        "λίρα του λιβάνου": "LBP",
+        "lebanese pound": "LBP",
+        "libana liro": "LBP",
+        "libra libanesa": "LBP",
+        "لیره لبنان": "LBP",
+        "libanonin punta": "LBP",
+        "livre libanaise": "LBP",
+        "לירה לבנונית": "LBP",
+        "libanonska funta": "LBP",
+        "libanoni font": "LBP",
+        "lira libanese": "LBP",
+        "レバノン・ポンド": "LBP",
+        "libano svaras": "LBP",
+        "libanees pond": "LBP",
+        "funt libański": "LBP",
+        "ливанский фунт": "LBP",
+        "libanonski funt": "LBP",
+        "либанска фунта": "LBP",
+        "libanesiskt pund": "LBP",
+        "lübnan lirası": "LBP",
+        "ліванський фунт": "LBP",
+        "黎巴嫩鎊": "LBP",
+        "روبية سريلانكي": "LKR",
+        "шриланкийска рупия": "LKR",
+        "rupia de sri lanka": "LKR",
+        "srilankanske rupee": "LKR",
+        "sri lanka rupie": "LKR",
+        "sri lankan rupee": "LKR",
+        "srilanka rupio": "LKR",
+        "errupia srilankar": "LKR",
+        "روپیه سریلانکا": "LKR",
+        "sri lankan rupia": "LKR",
+        "roupie srilankaise": "LKR",
+        "šrilanska rupija": "LKR",
+        "srí lanka i rúpia": "LKR",
+        "rupia singalese": "LKR",
+        "スリランカ・ルピー": "LKR",
+        "šri lankos rupija": "LKR",
+        "sri lankaanse roepie": "LKR",
+        "rupia lankijska": "LKR",
+        "rupia do sri lanka": "LKR",
+        "шри ланкийская рупия": "LKR",
+        "шриланчанска рупија": "LKR",
+        "lankesisk rupee": "LKR",
+        "இலங்கை ரூபாய்": "LKR",
+        "sri lanka rupisi": "LKR",
+        "рупія шрі ланки": "LKR",
+        "rupee sri lanka": "LKR",
+        "斯里蘭卡盧比": "LKR",
+        "دولار ليبيري": "LRD",
+        "либерийски долар": "LRD",
+        "dòlar liberià": "LRD",
+        "liberijský dolar": "LRD",
+        "liberiansk dollar": "LRD",
+        "liberianischer dollar": "LRD",
+        "δολάριο λιβερίας": "LRD",
+        "liberian dollar": "LRD",
+        "liberia dolaro": "LRD",
+        "dólar liberiano": "LRD",
+        "دلار لیبریا": "LRD",
+        "liberian dollari": "LRD",
+        "dollar libérien": "LRD",
+        "דולר ליברי": "LRD",
+        "liberijski dolar": "LRD",
+        "libériai dollár": "LRD",
+        "dollaro liberiano": "LRD",
+        "リベリア・ドル": "LRD",
+        "liberijos doleris": "LRD",
+        "liberiaanse dollar": "LRD",
+        "dolar liberyjski": "LRD",
+        "либерийский доллар": "LRD",
+        "либеријски долар": "LRD",
+        "liberya doları": "LRD",
+        "ліберійський долар": "LRD",
+        "賴比瑞亞元": "LRD",
+        "لوتي ليسوتو": "LSL",
+        "loti": "LSL",
+        "lesothský loti": "LSL",
+        "maloti": "LSL",
+        "lesothischer loti": "LSL",
+        "λότι": "LSL",
+        "lesotho loti": "LSL",
+        "lesota lotio": "LSL",
+        "لوتی لسوتو": "LSL",
+        "lesothon loti": "LSL",
+        "lesotski loti": "LSL",
+        "lesothói loti": "LSL",
+        "loti lesothiano": "LSL",
+        "ロチ": "LSL",
+        "lesothaanse loti": "LSL",
+        "лоти лесото": "LSL",
+        "лесотски лоти": "LSL",
+        "лоті лесото": "LSL",
+        "賴索托洛蒂": "LSL",
+        "دينار ليبي": "LYD",
+        "либийски динар": "LYD",
+        "dinar libi": "LYD",
+        "libyjský dinár": "LYD",
+        "dinar libia": "LYD",
+        "libyske dinarer": "LYD",
+        "libyscher dinar": "LYD",
+        "δηνάριο λιβύης": "LYD",
+        "libyan dinar": "LYD",
+        "libia dinaro": "LYD",
+        "dinar libio": "LYD",
+        "دینار لیبی": "LYD",
+        "libyan dinaari": "LYD",
+        "dinar libyen": "LYD",
+        "דינר לובי": "LYD",
+        "libijski dinar": "LYD",
+        "líbiai dinár": "LYD",
+        "dinaro libico": "LYD",
+        "リビア・ディナール": "LYD",
+        "libijos dinaras": "LYD",
+        "libische dinar": "LYD",
+        "dinar libijski": "LYD",
+        "dinar líbio": "LYD",
+        "ливийский динар": "LYD",
+        "либијски динар": "LYD",
+        "libysk dinar": "LYD",
+        "libya dinarı": "LYD",
+        "лівійський динар": "LYD",
+        "利比亞第納爾": "LYD",
+        "درهم مغربي": "MAD",
+        "марокански дирхам": "MAD",
+        "dírham marroquí": "MAD",
+        "marocký dirham": "MAD",
+        "dirham moroco": "MAD",
+        "marokkanischer dirham": "MAD",
+        "ντιρχάμ μαρόκου": "MAD",
+        "moroccan dirham": "MAD",
+        "maroka dirhamo": "MAD",
+        "marokoar dirham": "MAD",
+        "درهم مراکش": "MAD",
+        "marokon dirhami": "MAD",
+        "dirham marocain": "MAD",
+        "dirham": [
+            "AED",
             "MAD"
-        ], 
-        "rial irani": [
-            "IRR"
-        ], 
-        "peso d'uruguay": [
-            "UYU"
-        ], 
-        "forinto hu\u0301ngaro": [
-            "HUF"
-        ], 
-        "escudo cap verdien": [
-            "CVE"
-        ], 
-        "mongol tugrik": [
-            "MNT"
-        ], 
-        "gha\u0301nai cedi": [
-            "GHS"
-        ], 
-        "do\u0301lar del caribe oriental": [
-            "XCD"
-        ], 
-        "riyal saudita": [
-            "SAR"
-        ], 
-        "omani rial": [
-            "OMR"
-        ], 
-        "dinar tunisien": [
-            "TND"
-        ], 
-        "cape verdean escudo": [
-            "CVE"
-        ], 
-        "peso do\u0301lar": [
-            "ARS"
-        ], 
-        "dolar namibio": [
-            "NAD"
-        ], 
-        "lyd": [
-            "LYD"
-        ], 
-        "sint heleens pond": [
-            "SHP"
-        ], 
-        "nieuwe israe\u0308lische sheqel": [
-            "ILS"
-        ], 
-        "laotiaanse kip": [
-            "LAK"
-        ], 
-        "bolivian boliviano": [
-            "BOB"
-        ], 
-        "kirgizische som": [
-            "KGS"
-        ], 
-        "denaro macedone": [
-            "MKD"
-        ], 
-        "swiss franco": [
-            "CHF"
-        ], 
-        "birr eti\u0301ope": [
-            "ETB"
-        ], 
-        "barbadian dollar": [
-            "BBD"
-        ], 
-        "dolar canadiense": [
-            "CAD"
-        ], 
-        "swiss francs": [
-            "CHF"
-        ], 
-        "tonga pa`anga": [
-            "TOP"
-        ], 
-        "dinar de bahrei\u0308n": [
-            "BHD"
-        ], 
-        "dollar des iles salomon": [
-            "SBD"
-        ], 
-        "dobra santotomense": [
-            "STD"
-        ], 
-        "leu rumano": [
-            "RON"
-        ], 
-        "lisente": [
-            "LSL"
-        ], 
-        "manat turcomano": [
-            "TMT"
-        ], 
-        "taka bangladeshi": [
-            "BDT"
-        ], 
-        "dram": [
-            "AMD"
-        ], 
-        "macedonische denar": [
-            "MKD"
-        ], 
-        "israelische sjekel": [
-            "ILS"
-        ], 
-        "dop": [
-            "DOP"
-        ], 
-        "vanuatu vatu": [
-            "VUV"
-        ], 
-        "dollar des i\u0302les salomon": [
-            "SBD"
-        ], 
-        "franzo\u0308sischer franken": [
-            "FRF"
-        ], 
-        "guarani": [
-            "PYG"
-        ], 
-        "su\u0308dsudan pfund": [
-            "SSP"
-        ], 
-        "roemeense leu": [
-            "RON"
-        ], 
-        "mark convertible": [
-            "BAM"
-        ], 
-        "franco de djibouti": [
-            "DJF"
-        ], 
-        "ugandan shilling": [
-            "UGX"
-        ], 
-        "pazifik franc": [
-            "XPF"
-        ], 
-        "rublo tayiko": [
-            "TJR"
-        ], 
-        "argentinischer peso": [
-            "ARS"
-        ], 
-        "bahraini dinar": [
-            "BHD"
-        ], 
-        "amerikaanse dollar": [
-            "USD"
-        ], 
-        "franc comorien": [
-            "KMF"
-        ], 
-        "dolar neocelande\u0301s": [
-            "NZD"
-        ], 
-        "libra sudanesa": [
-            "SDG"
-        ], 
-        "ugandai shilling": [
-            "UGX"
-        ], 
-        "peso argentin": [
-            "ARS"
-        ], 
-        "tugrik mongol": [
-            "MNT"
-        ], 
-        "fiorino delle antille olandesi": [
-            "ANG"
-        ], 
-        "hryvnia": [
-            "UAH"
-        ], 
-        "ma\u0308tonya": [
-            "ETB"
-        ], 
-        "dalasi": [
-            "GMD"
-        ], 
-        "couronne tche\u0300que": [
-            "CZK"
-        ], 
-        "lkr": [
-            "LKR"
-        ], 
-        "clps": [
-            "CLP"
-        ], 
-        "dolar surinames": [
-            "SRD"
-        ], 
-        "kuwait dinar": [
-            "KWD"
-        ], 
-        "ruma\u0308nischer leu": [
-            "RON"
-        ], 
-        "do\u0301lar jamaicano": [
-            "JMD"
-        ], 
-        "nuevo dolar taiwane\u0301s": [
-            "TWD"
-        ], 
-        "venezolanischer bolivar": [
-            "VEF"
-        ], 
-        "qatarese rial": [
-            "QAR"
-        ], 
-        "do\u0301lar de surinam": [
-            "SRD"
-        ], 
-        "livres sterling": [
-            "GBP"
-        ], 
-        "g$": [
-            "GYD"
-        ], 
-        "ruma\u0308nischer lei": [
-            "RON"
-        ], 
-        "leone della sierra leone": [
-            "SLL"
-        ], 
-        "manat azero": [
-            "AZN"
-        ], 
-        "rwandese frank": [
-            "RWF"
-        ], 
-        "ancien franc": [
-            "FRF"
-        ], 
-        "naira": [
-            "NGN"
-        ], 
-        "koruna ceskoslovenska": [
-            "CSK"
-        ], 
-        "colo\u0301n costarricense": [
-            "CRC"
-        ], 
-        "kubai peso": [
-            "CUP"
-        ], 
-        "riel camboyano": [
-            "KHR"
-        ], 
-        "pa'anga tongano": [
-            "TOP"
-        ], 
-        "sri lankan rupee": [
-            "LKR"
-        ], 
-        "hk$": [
-            "HKD"
-        ], 
-        "dollar libe\u0301rien": [
-            "LRD"
-        ], 
-        "pa'anga di tonga": [
-            "TOP"
-        ], 
-        "norwegian krone": [
-            "NOK"
-        ], 
-        "scudo capoverdiano": [
-            "CVE"
-        ], 
-        "franco congolese": [
-            "CDF"
-        ], 
-        "birr": [
-            "ETB"
-        ], 
-        "schwedische krone": [
-            "SEK"
-        ], 
-        "boliviano bolivien": [
-            "BOB"
-        ], 
-        "bdt": [
-            "BTN"
-        ], 
-        "do\u0301lar guyanes": [
-            "GYD"
-        ], 
-        "lilangeni dello swaziland": [
-            "SZL"
-        ], 
-        "libanesisches pfund": [
-            "LBP"
-        ], 
-        "schottische pfund": [
-            "GBP"
-        ], 
-        "griekse drachme": [
-            "GRD"
-        ], 
-        "moldovan leu": [
-            "MDL"
-        ], 
-        "lek": [
-            "ALL"
-        ], 
-        "\u00a3": [
-            "GBP"
-        ], 
-        "do\u0301lar australiano": [
-            "AUD"
-        ], 
-        "lev": [
-            "BGN"
-        ], 
-        "lew": [
-            "BGN"
-        ], 
-        "uganda shilling": [
-            "UGX"
-        ], 
-        "hkd": [
-            "HKD"
-        ], 
-        "bd$": [
-            "BMD"
-        ], 
-        "re\u0301al bre\u0301silien": [
-            "BRL"
-        ], 
-        "tunesischer dinar": [
-            "TND"
-        ], 
-        "austral (monnaie)": [
-            "ARA"
-        ], 
-        "tongaanse pa'anga": [
-            "TOP"
-        ], 
-        "couronne sue\u0301doise": [
-            "SEK"
-        ], 
-        "franc de djibouti": [
-            "DJF"
-        ], 
-        "madagaszka\u0301ri ariary": [
-            "MGA"
-        ], 
-        "rupia mauricia": [
-            "MUR"
-        ], 
-        "solomon dollar": [
-            "SBD"
-        ], 
-        "kro\u0301nur": [
-            "ISK"
-        ], 
-        "khoums": [
-            "MRO"
-        ], 
-        "su\u0308dsudan pound": [
-            "SSP"
-        ], 
-        "sgd": [
-            "SGD"
-        ], 
-        "russischer rubel": [
-            "RUB"
-        ], 
-        "usd": [
-            "USD"
-        ], 
-        "livre des i\u0302les falkland": [
-            "FKP"
-        ], 
-        "comorian franc": [
-            "KMF"
-        ], 
-        "chf": [
-            "CHF"
-        ], 
-        "ush": [
-            "UGX"
-        ], 
-        "costa rica colon": [
-            "CRC"
-        ], 
-        "rial yemenita": [
-            "YER"
-        ], 
-        "marco bosniaco": [
-            "BAM"
-        ], 
-        "rial yemenite": [
-            "YER"
-        ], 
-        "brit font": [
-            "GBP"
-        ], 
-        "tercera dracma griega": [
-            "GRD"
-        ], 
-        "tala samoano": [
-            "WST"
-        ], 
-        "manat azeri": [
-            "AZN"
-        ], 
-        "santi\u0304ms": [
-            "LVL"
-        ], 
-        "ostmark": [
-            "DDM"
-        ], 
-        "f": [
-            "ANG"
-        ], 
-        "nuova lira turca": [
-            "TRY"
-        ], 
-        "zuid soedanees pond": [
-            "SSP"
-        ], 
-        "turkish lira": [
-            "TRY"
-        ], 
-        "rupia indonesiana": [
-            "IDR"
-        ], 
-        "da\u0308nische krone": [
-            "DKK"
-        ], 
-        "diritti speciali di prelievo": [
-            "XDR"
-        ], 
-        "do\u0301lar de nueva zelanda": [
-            "NZD"
-        ], 
-        "aluchip": [
-            "DDM"
-        ], 
-        "peso uruguayo": [
-            "UYU"
-        ], 
-        "xcd": [
-            "XCD"
-        ], 
-        "nuevo do\u0301lar de taiwan": [
-            "TWD"
-        ], 
-        "k.s.": [
-            "KGS"
-        ], 
-        "dinars alge\u0301rien": [
-            "DZD"
-        ], 
-        "russische roebel": [
-            "RUB"
-        ], 
-        "afn": [
-            "AFN"
-        ], 
-        "\u20a6": [
-            "NGN"
-        ], 
-        "corona danese": [
-            "DKK"
-        ], 
-        "corona danesa": [
-            "DKK"
-        ], 
-        "moneda canadiense": [
-            "CAD"
-        ], 
-        "ruandai frank": [
-            "RWF"
-        ], 
-        "libra de santa helena": [
-            "SHP"
-        ], 
-        "manat azeri\u0301": [
-            "AZN"
-        ], 
-        "do\u0301lar de hong kong": [
-            "HKD"
-        ], 
-        "armenian dram": [
-            "AMD"
-        ], 
-        "tetradrachme": [
-            "GRD"
-        ], 
-        "chileense peso": [
-            "CLP"
-        ], 
-        "franchi svizzeri": [
-            "CHF"
-        ], 
-        "boliviaanse boliviano": [
-            "BOB"
-        ], 
-        "do\u0301lar de bermudas": [
-            "BMD"
-        ], 
-        "colon costaricain": [
-            "CRC"
-        ], 
-        "dollar bahame\u0301en": [
-            "BSD"
-        ], 
-        "dollaro delle cayman": [
-            "KYD"
-        ], 
-        "do\u0301lar neozelande\u0301s": [
-            "NZD"
-        ], 
-        "riyal saudi\u0301": [
-            "SAR"
-        ], 
-        "georgian lari": [
-            "GEL"
-        ], 
-        "kiwi dollar": [
-            "NZD"
-        ], 
-        "shekkel": [
-            "ILS"
-        ], 
-        "si$": [
-            "SBD"
-        ], 
-        "dobra santome\u0301en": [
-            "STD"
-        ], 
-        "dolar neoze\u0301landes": [
-            "NZD"
-        ], 
-        "fiorino di aruba": [
-            "AWG"
-        ], 
-        "dobra": [
-            "STD"
-        ], 
-        "british pound": [
-            "GBP"
-        ], 
-        "to\u0308mling": [
-            "THB"
-        ], 
-        "afg": [
-            "AFN"
-        ], 
-        "thai ba\u0301t": [
-            "THB"
-        ], 
-        "fu\u0308lo\u0308p szigeteki peso": [
-            "PHP"
-        ], 
-        "noorse kroon": [
-            "NOK"
-        ], 
-        "dollar de trinite\u0301 et tobago": [
-            "TTD"
-        ], 
-        "tsh": [
-            "TZS"
-        ], 
-        "lm": [
-            "MTL"
-        ], 
-        "saudi arabische riyal": [
-            "SAR"
-        ], 
-        "ausztra\u0301l dolla\u0301r": [
-            "AUD"
-        ], 
-        "oekraiense hryvnja": [
-            "UAH"
-        ], 
-        "deense kroon": [
-            "DKK"
-        ], 
-        "eur": [
-            "EUR"
-        ], 
-        "uruguayi peso": [
-            "UYU"
-        ], 
-        "liberian dollar": [
-            "LRD"
-        ], 
-        "livre sud soudanaise": [
-            "SSP"
-        ], 
-        "do\u0301lar de fiji": [
-            "FJD"
-        ], 
-        "dollar de la carai\u0308be orientale": [
-            "XCD"
-        ], 
-        "franc poincare\u0301": [
-            "XFO"
-        ], 
-        "gepik": [
-            "AZN"
-        ], 
-        "fl\u00a3": [
-            "FKP"
-        ], 
-        "mexican peso": [
-            "MXN"
-        ], 
-        "diram": [
-            "TJS"
-        ], 
-        "denar mace\u0301donien": [
-            "MKD"
-        ], 
-        "hongkongi dolla\u0301r": [
-            "HKD"
-        ], 
-        "belizaanse dollar": [
-            "BZD"
-        ], 
-        "azeri manat": [
-            "AZN"
-        ], 
-        "dong vietnamita": [
-            "VND"
-        ], 
-        "rublo russo": [
-            "RUB"
-        ], 
-        "dolar beliceno": [
-            "BZD"
-        ], 
-        "su\u0308dsudanesisches pfund": [
-            "SSP"
-        ], 
-        "dolar de las islas caima\u0301n": [
-            "KYD"
-        ], 
-        "ec$": [
-            "XCD"
-        ], 
-        "dirham degli emirati arabi uniti": [
-            "AED"
-        ], 
-        "surinaamse dollar": [
-            "SRD"
-        ], 
-        "franco cfa de africa occidental": [
-            "XOF"
-        ], 
-        "french franc": [
-            "FRF"
-        ], 
-        "\u0192": [
-            "ANG"
-        ], 
-        "roma\u0301n lej": [
-            "RON"
-        ], 
-        "pa'anga": [
-            "TOP"
-        ], 
-        "dollaro dei caraibi orientali": [
-            "XCD"
-        ], 
-        "tyiyn": [
-            "KGS"
-        ], 
-        "cuban convertible peso": [
-            "CUC"
-        ], 
-        "dirham des e\u0301mirats arabes unis": [
-            "AED"
-        ], 
-        "japa\u0301n jen": [
-            "JPY"
-        ], 
-        "kroatische kuna": [
-            "HRK"
-        ], 
-        "sowjetischer rubel": [
-            "SUR"
-        ], 
-        "won sudcoreano": [
-            "KRW"
-        ], 
-        "chelin somali\u0301": [
-            "SOS"
-        ], 
-        "santims": [
-            "LVL"
-        ], 
-        "franc": [
-            "CHF", 
-            "FRF"
-        ], 
-        "halalas": [
-            "SAR"
-        ], 
-        "sva\u0301jci frank": [
-            "CHF"
-        ], 
-        "shekel": [
-            "ILS"
-        ], 
-        "dinar kowei\u0308tien": [
-            "KWD"
-        ], 
-        "l\u00a3": [
-            "LBP"
-        ], 
-        "moroccan dirham": [
-            "MAD"
-        ], 
-        "goldfranc": [
-            "XFO"
-        ], 
-        "jod": [
-            "JOD"
-        ], 
-        "oost carai\u0308bische dollar": [
-            "XCD"
-        ], 
-        "ouguiya mauritana": [
-            "MRO"
-        ], 
-        "cambodjaanse riel": [
-            "KHR"
-        ], 
-        "taka bangladesi\u0301": [
-            "BDT"
-        ], 
-        "ltl": [
-            "LTL"
-        ], 
-        "lettischer lat": [
-            "LVL"
-        ], 
-        "santi\u0304mu": [
-            "LVL"
-        ], 
-        "marco de la repu\u0301blica democra\u0301tica alemana": [
-            "DDM"
-        ], 
-        "franco di gibuti": [
-            "DJF"
-        ], 
-        "santi\u0304mi": [
-            "LVL"
-        ], 
-        "couronne norve\u0301gienne": [
-            "NOK"
-        ], 
-        "libanoni font": [
-            "LBP"
-        ], 
-        "belize i dolla\u0301r": [
-            "BZD"
-        ], 
-        "da\u0301n korona": [
-            "DKK"
-        ], 
-        "serbian dinar": [
-            "RSD"
-        ], 
-        "rial omani": [
-            "OMR"
-        ], 
-        "mark convertible bosniaque": [
-            "BAM"
-        ], 
-        "dollar du be\u0301lize": [
-            "BZD"
-        ], 
-        "pesos argentinos": [
-            "ARS"
-        ], 
-        "lesothaanse loti": [
-            "LSL"
-        ], 
-        "tu\u0308rk liras\u0131": [
-            "TRY"
-        ], 
-        "kwacha zambien": [
-            "ZMW"
-        ], 
-        "dollar trinidadien": [
-            "TTD"
-        ], 
-        "moldavische leu": [
-            "MDL"
-        ], 
-        "tughrik": [
-            "MNT"
-        ], 
-        "leu roumain": [
-            "RON"
-        ], 
-        "szva\u0301zifo\u0308ldi lilangeni": [
-            "SZL"
-        ], 
-        "morocota": [
-            "VEF"
-        ], 
-        "haitianische gourde": [
-            "HTG"
-        ], 
-        "eritreischer nakfa": [
-            "ERN"
-        ], 
-        "mongolischer to\u0308gro\u0308g": [
-            "MNT"
-        ], 
-        "escudo di capo verde": [
-            "CVE"
-        ], 
-        "zwitserse frank": [
-            "CHF"
-        ], 
-        "afga\u0301n afga\u0301ni": [
-            "AFN"
-        ], 
-        "neet": [
-            "GBP"
-        ], 
-        "zwitserse franc": [
-            "CHF"
-        ], 
-        "roupie mauricienne": [
-            "MUR"
-        ], 
-        "do\u0301lar trinitense": [
-            "TTD"
-        ], 
-        "marco de la republica democratica alemana": [
-            "DDM"
-        ], 
-        "tongai pa\u2019anga": [
-            "TOP"
-        ], 
-        "israeli new sheqel": [
-            "ILS"
-        ], 
-        "bermudai dolla\u0301r": [
-            "BMD"
-        ], 
-        "\u20ba": [
-            "TRY"
-        ], 
-        "oost caribische dollar": [
-            "XCD"
-        ], 
-        "ugandese shilling": [
-            "UGX"
-        ], 
-        "derechos especiales de giro": [
-            "XDR"
-        ], 
-        "rupaya": [
-            "INR"
-        ], 
-        "suriname gulden": [
-            "SRD"
-        ], 
-        "tajvani u\u0301j dolla\u0301r": [
-            "TWD"
-        ], 
-        "costa rica i colo\u0301n": [
-            "CRC"
-        ], 
-        "pakistanische rupie": [
-            "PKR"
-        ], 
-        "irak dinar": [
-            "IQD"
-        ], 
-        "alge\u0301riai dina\u0301r": [
-            "DZD"
-        ], 
-        "perui u\u0301j sol": [
-            "PEN"
-        ], 
-        "do\u0301lar caribe este": [
-            "XCD"
-        ], 
-        "kurus": [
-            "TRY"
-        ], 
-        "sfr": [
-            "CHF"
-        ], 
-        "huard canadien": [
-            "CAD"
-        ], 
-        "new zealand dollar": [
-            "NZD"
-        ], 
-        "so\u0308m": [
-            "UZS"
-        ], 
-        "awg": [
-            "AWG"
-        ], 
-        "dollar de guyana": [
-            "GYD"
-        ], 
-        "bosnya\u0301k konvertibilis ma\u0301rka": [
-            "BAM"
-        ], 
-        "suriname i dolla\u0301r": [
-            "SRD"
-        ], 
-        "ukrainische hrywnja": [
-            "UAH"
-        ], 
-        "ngultrum": [
-            "BTN"
-        ], 
-        "gde.": [
-            "HTG"
-        ], 
-        "mexican nuevo peso": [
-            "MXN"
-        ], 
-        "fjd": [
-            "FJD"
-        ], 
-        "dolar jamaiquino": [
-            "JMD"
-        ], 
-        "libyscher dinar": [
-            "LYD"
-        ], 
-        "nuevo shequel": [
-            "ILS"
-        ], 
-        "cheli\u0301n keniano": [
-            "KES"
-        ], 
-        "dollar surinamien": [
-            "SRD"
-        ], 
-        "rublo sovietico": [
-            "SUR"
-        ], 
-        "kaiman dollar": [
-            "KYD"
-        ], 
-        "dollar ne\u0301o ze\u0301landais": [
-            "NZD"
-        ], 
-        "bolga\u0301r leva": [
-            "BGN"
-        ], 
-        "cub$": [
-            "CUP"
-        ], 
-        "szl": [
-            "SZL"
-        ], 
-        "aruba gulden": [
-            "AWG"
-        ], 
-        "mexikanischer peso": [
-            "MXN"
-        ], 
-        "australische dollar": [
-            "AUD"
-        ], 
-        "roupie indonesienne": [
-            "IDR"
-        ], 
-        "albanese lek": [
-            "ALL"
-        ], 
-        "lettische wa\u0308hrung": [
-            "LVL"
-        ], 
-        "dollar ame\u0301ricain": [
-            "USD"
-        ], 
-        "zo\u0308ld foki szigeteki escudo": [
-            "CVE"
-        ], 
-        "saudi riyal": [
-            "SAR"
-        ], 
-        "libra": [
-            "GBP"
-        ], 
-        "isla\u0308ndische krone": [
-            "ISK"
-        ], 
-        "saudi rial": [
-            "SAR"
-        ], 
-        "dollaro della bermuda": [
-            "BMD"
-        ], 
-        "macedo\u0301n de\u0301na\u0301r": [
-            "MKD"
-        ], 
-        "kwanza": [
-            "AOA"
-        ], 
-        "dollar du guyana": [
-            "GYD"
-        ], 
-        "nuevo peso argentino": [
-            "ARS"
-        ], 
-        "dollaro del suriname": [
-            "SRD"
-        ], 
-        "ariary malgache": [
-            "MGA"
-        ], 
-        "saint helena pound": [
-            "SHP"
-        ], 
-        "kambodzsai riel": [
-            "KHR"
-        ], 
-        "surinam dollar": [
-            "SRD"
-        ], 
-        "ouguiya": [
-            "MRO"
-        ], 
-        "mala\u0301j ringgit": [
-            "MYR"
-        ], 
-        "united states dollar": [
-            "USD"
-        ], 
-        "icelandic kro\u0301na": [
-            "ISK"
-        ], 
-        "gbp": [
-            "GBP"
-        ], 
-        "falkland szigeteki font": [
-            "FKP"
-        ], 
-        "sa\u0303o tome\u0301ischer dobra": [
-            "STD"
-        ], 
-        "kwanza angolano": [
-            "AOA"
-        ], 
-        "scellino": [
-            "KES"
-        ], 
-        "dollars canadiens": [
-            "CAD"
-        ], 
-        "guarani\u0301": [
-            "PYG"
-        ], 
-        "kwanza angolana": [
-            "AOA"
-        ], 
-        "litas lituanien": [
-            "LTL"
-        ], 
-        "kajma\u0301n szigeteki dolla\u0301r": [
-            "KYD"
-        ], 
-        "som de kirguista\u0301n": [
-            "KGS"
-        ], 
-        "btn": [
-            "BTN"
-        ], 
-        "chelin somali": [
-            "SOS"
-        ], 
-        "dracma griego moderno": [
-            "GRD"
-        ], 
-        "hai\u0308tiaanse gourde": [
-            "HTG"
-        ], 
-        "kc\u030c": [
-            "CZK"
-        ], 
-        "peso de chile": [
-            "CLP"
-        ], 
-        "mazedonischer denar": [
-            "MKD"
-        ], 
-        "sierra leoonse leone": [
-            "SLL"
-        ], 
-        "franco france\u0301s": [
-            "FRF"
-        ], 
-        "marco della germania est": [
-            "DDM"
-        ], 
-        "cordoba nicaraguense": [
-            "NIO"
-        ], 
-        "do\u0301lar jamaiquino": [
-            "JMD"
-        ], 
-        "cordoba nicaraguayen": [
-            "NIO"
-        ], 
-        "rupia de pakista\u0301n": [
-            "PKR"
-        ], 
-        "pfund sterling": [
-            "GBP"
-        ], 
-        "dollar jamai\u0308quain": [
-            "JMD"
-        ], 
-        "koruna c\u030ceskoslovenska\u0301": [
-            "CSK"
-        ], 
-        "vatu di vanuatu": [
-            "VUV"
-        ], 
-        "nicaraguai co\u0301rdoba": [
-            "NIO"
-        ], 
-        "salu\u0308ng": [
-            "THB"
-        ], 
-        "drachmon": [
-            "GRD"
-        ], 
-        "somalia schilling": [
-            "SOS"
-        ], 
-        "dinar iraqui": [
-            "IQD"
-        ], 
-        "escudo": [
-            "CVE"
-        ], 
-        "hrywni": [
-            "UAH"
-        ], 
-        "libra de santa elena": [
-            "SHP"
-        ], 
-        "couronnes tche\u0300ques": [
-            "CZK"
-        ], 
-        "dolar fiyiano": [
-            "FJD"
-        ], 
-        "\u20a9": [
-            "KRW"
-        ], 
-        "rial iraniano": [
-            "IRR"
-        ], 
-        "bbd": [
-            "BBD"
-        ], 
-        "e\u0301szak i\u0301r font": [
-            "GBP"
-        ], 
-        "$ ca": [
-            "CAD"
-        ], 
-        "quid": [
-            "GBP"
-        ], 
-        "ta\u0301dzsik szomoni": [
-            "TJS"
-        ], 
-        "dram armenio": [
-            "AMD"
-        ], 
-        "rupia singalese": [
-            "LKR"
-        ], 
-        "botswaanse pula": [
-            "BWP"
-        ], 
-        "co\u0301rdoba nicaraguayen": [
-            "NIO"
-        ], 
-        "c$": [
-            "NIO", 
-            "CAD"
-        ], 
-        "oost caraibische dollar": [
-            "XCD"
-        ], 
-        "guyanese dollar": [
-            "GYD"
-        ], 
-        "indonesische roepia": [
-            "IDR"
-        ], 
-        "corone ceche": [
-            "CZK"
-        ], 
-        "franco cfa de a\u0301frica occidental": [
-            "XOF"
-        ], 
-        "currency of mexico": [
-            "MXN"
-        ], 
-        "kwanza reajustado": [
-            "AOA"
-        ], 
-        "botswanai pula": [
-            "BWP"
-        ], 
-        "reais": [
-            "BRL"
-        ], 
-        "cve": [
-            "CVE"
-        ], 
-        "flori\u0301n suriname\u0301s": [
-            "SRG"
-        ], 
-        "franc djibouti": [
-            "DJF"
-        ], 
-        "do\u0301lar beliceno": [
-            "BZD"
-        ], 
-        "forint hu\u0301ngaro": [
-            "HUF"
-        ], 
-        "iranischer rial": [
-            "IRR"
-        ], 
-        "tenge": [
-            "KZT"
-        ], 
-        "czechoslovak koruna": [
-            "CSK"
-        ], 
-        "grivna ucraniana": [
-            "UAH"
-        ], 
-        "dinar alge\u0301rien": [
-            "DZD"
-        ], 
-        "rupia esrilanquesa": [
-            "LKR"
-        ], 
-        "kyrgyz som": [
-            "KGS"
-        ], 
-        "turkmeense manat": [
-            "TMT"
-        ], 
-        "hryvnia ukrainienne": [
-            "UAH"
-        ], 
-        "dollaro di singapore": [
-            "SGD"
-        ], 
-        "dolar de belize": [
-            "BZD"
-        ], 
-        "boli\u0301vares": [
-            "VEF"
-        ], 
-        "sterlina di gibilterra": [
-            "GIP"
-        ], 
-        "shilling ougandais": [
-            "UGX"
-        ], 
-        "rupia pakistani\u0301": [
-            "PKR"
-        ], 
-        "united arab emirates dirham": [
-            "AED"
-        ], 
-        "php": [
-            "PHP"
-        ], 
-        "\u03b4\u03c1": [
-            "GRD"
-        ], 
-        "lari georgiano": [
-            "GEL"
-        ], 
-        "kip laotien": [
-            "LAK"
-        ], 
-        "uquiya": [
-            "MRO"
-        ], 
-        "francs or": [
-            "XFO"
-        ], 
-        "dinar": [
-            "TND", 
-            "DZD"
-        ], 
-        "shilling tanzanien": [
-            "TZS"
-        ], 
-        "kongo\u0301i frank": [
-            "CDF"
-        ], 
-        "franco de yibuti": [
-            "DJF"
-        ], 
-        "dirham marroqui\u0301": [
-            "MAD"
-        ], 
-        "florin hungaro": [
-            "HUF"
-        ], 
-        "tyjyn": [
-            "KGS"
-        ], 
-        "di\u0301rham de los emiratos a\u0301rabes unidos": [
-            "AED"
-        ], 
-        "florin arubais": [
-            "AWG"
-        ], 
-        "la couronne danoise": [
-            "DKK"
-        ], 
-        "gambian dalasi": [
-            "GMD"
-        ], 
-        "szuda\u0301ni font": [
-            "SDG"
-        ], 
-        "corona svedese": [
-            "SEK"
-        ], 
-        "colombiaanse peso": [
-            "COP"
-        ], 
-        "dirham marocchino": [
-            "MAD"
-        ], 
-        "won sud core\u0301en": [
-            "KRW"
-        ], 
-        "seychellois rupee": [
-            "SCR"
-        ], 
-        "gibraltarees pond": [
-            "GIP"
-        ], 
-        "franc fort": [
-            "FRF"
-        ], 
-        "schweizerfranken": [
-            "CHF"
-        ], 
-        "livre soudanaise": [
-            "SDG"
-        ], 
-        "manat aze\u0301ri": [
-            "AZN"
-        ], 
-        "nuevo she\u0301kel": [
-            "ILS"
-        ], 
-        "paraguayaanse guarani": [
-            "PYG"
-        ], 
-        "trinidad and tobago dollar": [
-            "TTD"
-        ], 
-        "tiyin": [
-            "UZS"
-        ], 
-        "dollar de belize": [
-            "BZD"
-        ], 
-        "nuovo siclo": [
-            "ILS"
-        ], 
-        "pyas": [
-            "MMK"
-        ], 
-        "liberiaanse dollar": [
-            "LRD"
-        ], 
-        "quetzal guatemalteco": [
-            "GTQ"
-        ], 
-        "naira nige\u0301rian": [
-            "NGN"
-        ], 
-        "balboa panameno": [
-            "PAB"
-        ], 
-        "indian rupee": [
-            "INR"
-        ], 
-        "bahreini dina\u0301r": [
-            "BHD"
-        ], 
-        "zuid afrikaanse rand": [
-            "ZAR"
-        ], 
-        "roepia": [
-            "IDR"
-        ], 
-        "dollar bermudien": [
-            "BMD"
-        ], 
-        "loti del lesotho": [
-            "LSL"
-        ], 
-        "hondurese lempira": [
-            "HNL"
-        ], 
-        "tsjecho slowaakse kroon": [
-            "CSK"
-        ], 
-        "do\u0301lar de barbados": [
-            "BBD"
-        ], 
-        "su\u0308dafrikanischer rand": [
-            "ZAR"
-        ], 
-        "szau\u0301di ria\u0301l": [
-            "SAR"
-        ], 
-        "szerb dina\u0301r": [
-            "RSD"
-        ], 
-        "roupie du ne\u0301pal": [
-            "NPR"
-        ], 
-        "dinaro": [
-            "BHD"
-        ], 
-        "balboa": [
-            "PAB"
-        ], 
-        "rublo sovie\u0301tico": [
-            "SUR"
-        ], 
-        "dollar de la caraibe orientale": [
-            "XCD"
-        ], 
-        "dolar bruneano": [
-            "BND"
-        ], 
-        "dollaro canadese": [
-            "CAD"
-        ], 
-        "arubai florin": [
-            "AWG"
-        ], 
-        "somali shilling": [
-            "SOS"
-        ], 
-        "peso oro dominicano": [
-            "DOP"
-        ], 
-        "bangladesi taka": [
-            "BDT"
-        ], 
-        "lettischer lats": [
-            "LVL"
-        ], 
-        "marco della repubblica democratica tedesca": [
-            "DDM"
-        ], 
-        "ijslandse kroon": [
-            "ISK"
-        ], 
-        "burundi franc": [
-            "BIF"
-        ], 
-        "rand sud africain": [
-            "ZAR"
-        ], 
-        "corone norvegesi": [
-            "NOK"
-        ], 
-        "do\u0301lar caimano": [
-            "KYD"
-        ], 
-        "burundi frank": [
-            "BIF"
-        ], 
-        "new israeli sheqel": [
-            "ILS"
-        ], 
-        "metical mozambicain": [
-            "MZN"
-        ], 
-        "dolar de surinam": [
-            "SRD"
-        ], 
-        "falkland islands pound": [
-            "FKP"
-        ], 
-        "maurita\u0301niai ouguiya": [
-            "MRO"
-        ], 
-        "u\u0301j ze\u0301landi dolla\u0301r": [
-            "NZD"
-        ], 
-        "lats leton": [
-            "LVL"
-        ], 
-        "somoni tagico": [
-            "TJS"
-        ], 
-        "mozambikaanse metical": [
-            "MZN"
-        ], 
-        "dollaro delle bermuda": [
-            "BMD"
-        ], 
-        "dolar de hong kong": [
-            "HKD"
-        ], 
-        "dollaro delle bermude": [
-            "BMD"
-        ], 
-        "balboa panamense": [
-            "PAB"
-        ], 
-        "roupie srilankaise": [
-            "LKR"
-        ], 
-        "fya\u0308n": [
-            "THB"
-        ], 
-        "dolar guyanes": [
-            "GYD"
-        ], 
-        "franc suisse": [
-            "CHF"
-        ], 
-        "rial irani\u0301": [
-            "IRR"
-        ], 
-        "myanmarese kyat": [
-            "MMK"
-        ], 
-        "costa ricaanse colo\u0301n": [
-            "CRC"
-        ], 
-        "corona checa": [
-            "CZK"
-        ], 
-        "thai baht": [
-            "THB"
-        ], 
-        "djiboutiaanse frank": [
-            "DJF"
-        ], 
-        "schkalim": [
-            "ILS"
-        ], 
-        "\u17db": [
-            "KHR"
-        ], 
-        "franc djiboutien": [
-            "DJF"
-        ], 
-        "dinar koweitien": [
-            "KWD"
-        ], 
-        "loonie": [
-            "CAD"
-        ], 
-        "denari": [
-            "MKD"
-        ], 
-        "lvl": [
-            "LVL"
-        ], 
-        "hryvnja": [
-            "UAH"
-        ], 
-        "lempira hondurien": [
-            "HNL"
-        ], 
-        "franc guineen": [
-            "GNF"
-        ], 
-        "seychelles rupee": [
-            "SCR"
-        ], 
-        "leu rumeno": [
-            "RON"
-        ], 
-        "dirham emirati": [
-            "AED"
-        ], 
-        "co\u0301rdoba nicarague\u0301en": [
-            "NIO"
-        ], 
-        "neuseeland dollar": [
-            "NZD"
-        ], 
-        "\u20aa": [
-            "ILS"
-        ], 
-        "bahamai dolla\u0301r": [
-            "BSD"
-        ], 
-        "szi\u0301r font": [
-            "SYP"
-        ], 
-        "nieuwe israelische sjekel": [
-            "ILS"
-        ], 
-        "franc francais": [
-            "FRF"
-        ], 
-        "jamaicaanse dollar": [
-            "JMD"
-        ], 
-        "burmese kyat": [
-            "MMK"
-        ], 
-        "do\u0301lar de belize": [
-            "BZD"
-        ], 
-        "tunis dinar": [
-            "TND"
-        ], 
-        "hrywnja": [
-            "UAH"
-        ], 
-        "do\u0301lar de belice": [
-            "BZD"
-        ], 
-        "koeweitse dinar": [
-            "KWD"
-        ], 
-        "rial yemeni": [
-            "YER"
-        ], 
-        "quetzal": [
-            "GTQ"
-        ], 
-        "livres sterlings": [
-            "GBP"
-        ], 
-        "hnl": [
-            "HNL"
-        ], 
-        "franco cfa de a\u0301frica central": [
+        ],
+        "דירהם מרוקאי": "MAD",
+        "marokanski dirham": "MAD",
+        "marokkói dirham": "MAD",
+        "dirham marocchino": "MAD",
+        "モロッコ・ディルハム": "MAD",
+        "maroko dirhamas": "MAD",
+        "marokkaanse dirham": "MAD",
+        "dirham marokański": "MAD",
+        "dirrã marroquino": "MAD",
+        "dirham marocan": "MAD",
+        "марокканский дирхам": "MAD",
+        "marockansk dirham": "MAD",
+        "fas dirhemi": "MAD",
+        "марокканський дирхам": "MAD",
+        "摩洛哥迪尔汗": "MAD",
+        "فرنك موناكو": "MCF",
+        "монакски франк": "MCF",
+        "franc monegasc": "MCF",
+        "monacký frank": "MCF",
+        "monegassischer franc": "MCF",
+        "φράγκο μονακό": "MCF",
+        "monégasque franc": "MCF",
+        "franco monegasco": "MCF",
+        "فرانک موناکو": "MCF",
+        "franc monégasque": "MCF",
+        "monegaški franak": "MCF",
+        "モネガスク・フラン": "MCF",
+        "monako frankas": "MCF",
+        "monegaskische frank": "MCF",
+        "frank monakijski": "MCF",
+        "монегасский франк": "MCF",
+        "франк монако": "MCF",
+        "摩納哥法郎": "MCF",
+        "ليو مولدوفي": "MDL",
+        "молдовска лея": "MDL",
+        "leu moldau": "MDL",
+        "moldavský lei": "MDL",
+        "moldauischer leu": "MDL",
+        "λέου μολδαβίας": "MDL",
+        "moldovan leu": "MDL",
+        "moldava leo": "MDL",
+        "leu moldavo": "MDL",
+        "moldova leu": "MDL",
+        "لئوی مولداوی": "MDL",
+        "leu moldave": "MDL",
+        "לאו מולדובני": "MDL",
+        "moldavski lej": "MDL",
+        "moldáv lej": "MDL",
+        "モルドバ・レウ": "MDL",
+        "moldavijos lėja": "MDL",
+        "moldavische leu": "MDL",
+        "lej mołdawii": "MDL",
+        "leu moldávio": "MDL",
+        "leu moldovenesc": "MDL",
+        "молдавский лей": "MDL",
+        "moldavski lev": "MDL",
+        "молдавски леј": "MDL",
+        "moldavisk leu": "MDL",
+        "மல்டோவிய லியு": "MDL",
+        "moldova leyi": "MDL",
+        "молдовський лей": "MDL",
+        "摩爾多瓦列伊": "MDL",
+        "أرياري مدغشقري": "MGA",
+        "ariary": "MGA",
+        "malgašský ariary": "MGA",
+        "αριάρι": "MGA",
+        "malagasy ariary": "MGA",
+        "malagasa ariaro": "MGA",
+        "ariary malgache": "MGA",
+        "آریاری": "MGA",
+        "madagaskarin ariary": "MGA",
+        "אריארי": "MGA",
+        "malgaški arijari": "MGA",
+        "madagaszkári ariary": "MGA",
+        "ariary malgascio": "MGA",
+        "マダガスカル・アリアリ": "MGA",
+        "madagaskaro ariaris": "MGA",
+        "malagassische ariary": "MGA",
+        "ariary malgaxe": "MGA",
+        "малагасийский ариари": "MGA",
+        "аријари": "MGA",
+        "малагасійський аріарі": "MGA",
+        "馬達加斯加阿里亞里": "MGA",
+        "دينار مقدوني": "MKD",
+        "македонски денар": "MKD",
+        "denar": "MKD",
+        "makedonský denár": "MKD",
+        "makedonske denarer": "MKD",
+        "mazedonischer denar": "MKD",
+        "δηνάριο βόρειας μακεδονίας": "MKD",
+        "macedonian denar": "MKD",
+        "makedona denaro": "MKD",
+        "denar normacedonio": "MKD",
+        "põhja makedoonia denaar": "MKD",
+        "دینار مقدونیه": "MKD",
+        "pohjois makedonian denaari": "MKD",
+        "denar macédonien": "MKD",
+        "denar macedonio": "MKD",
+        "דינר מקדוני": "MKD",
+        "makedonski denar": "MKD",
+        "macedón dénár": "MKD",
+        "dinaro macedone": "MKD",
+        "マケドニア・デナール": "MKD",
+        "makedonijos denaras": "MKD",
+        "macedonische denar": "MKD",
+        "denar macedoński": "MKD",
+        "dinar macedónio": "MKD",
+        "denar macedonean": "MKD",
+        "македонский денар": "MKD",
+        "macedónsky denár": "MKD",
+        "makedonisk denar": "MKD",
+        "மாசிடோனிய தெனார்": "MKD",
+        "makedon denarı": "MKD",
+        "македонський денар": "MKD",
+        "denar bắc macedonia": "MKD",
+        "北馬其頓代納爾": "MKD",
+        "كيات ميانماري": "MMK",
+        "kyat": "MMK",
+        "myanmarský kyat": "MMK",
+        "burmese kyat": "MMK",
+        "birma kjato": "MMK",
+        "kyat birmano": "MMK",
+        "کیات میانمار": "MMK",
+        "myanmarin kyat": "MMK",
+        "mijanmarski kjat": "MMK",
+        "mianmari kjap": "MMK",
+        "チャット": "MMK",
+        "kijatas": "MMK",
+        "myanmarese kyat": "MMK",
+        "kiat": "MMK",
+        "quiate": "MMK",
+        "кьят": "MMK",
+        "мјанмарски кјат": "MMK",
+        "м'янмський к'ят": "MMK",
+        "缅甸元": "MMK",
+        "توغروغ منغولي": "MNT",
+        "монголски тугрик": "MNT",
+        "tögrög": "MNT",
+        "tugrik": "MNT",
+        "τουγκρίκ": "MNT",
+        "mongolian tögrög": "MNT",
+        "mongola tugriko": "MNT",
+        "tugrik mongol": "MNT",
+        "توگروگ مغولستان": "MNT",
+        "mongolian tugrik": "MNT",
+        "טוגרוג": "MNT",
+        "mongolski tugrik": "MNT",
+        "mongol tugrik": "MNT",
+        "tugrik mongolo": "MNT",
+        "トゥグルグ": "MNT",
+        "tugrikas": "MNT",
+        "mongoolse tugrik": "MNT",
+        "тугрик": "MNT",
+        "mongolský tugrik": "MNT",
+        "монгольський тугрик": "MNT",
+        "蒙古图格里克": "MNT",
+        "باتاكا ماكاوية": "MOP",
+        "pataca": "MOP",
+        "macajská pataca": "MOP",
+        "macau pataca": "MOP",
+        "πατάκα": "MOP",
+        "macanese pataca": "MOP",
+        "makaa patako": "MOP",
+        "pataca macaense": "MOP",
+        "pataca macautar": "MOP",
+        "پاتاکای ماکائو": "MOP",
+        "macaon pataca": "MOP",
+        "פטקה": "MOP",
+        "makaonska pataka": "MOP",
+        "makaói pataca": "MOP",
+        "pataca di macao": "MOP",
+        "マカオ・パタカ": "MOP",
+        "pataka": "MOP",
+        "macause pataca": "MOP",
+        "pataca de macau": "MOP",
+        "патака макао": "MOP",
+        "makao patakası": "MOP",
+        "аоминська патака": "MOP",
+        "pataca ma cao": "MOP",
+        "澳門幣": "MOP",
+        "ouguiya": "MRO",
+        "روبي موريشي": "MUR",
+        "rupia de maurici": "MUR",
+        "mauricijská rupie": "MUR",
+        "mauritiske rupee": "MUR",
+        "mauritius rupie": "MUR",
+        "ρουπία του μαυρίκιου": "MUR",
+        "mauritian rupee": "MUR",
+        "maŭricia rupio": "MUR",
+        "rupia de mauricio": "MUR",
+        "errupia mauriziar": "MUR",
+        "روپیه موریس": "MUR",
+        "mauritiuksen rupia": "MUR",
+        "roupie mauricienne": "MUR",
+        "mauricijska rupija": "MUR",
+        "mauritiusi rúpia": "MUR",
+        "rupia mauriziana": "MUR",
+        "モーリシャス・ルピー": "MUR",
+        "mauricijaus rupija": "MUR",
+        "mauritiaanse roepie": "MUR",
+        "rupia mauritiusu": "MUR",
+        "rupia mauriciana": "MUR",
+        "маврикийская рупия": "MUR",
+        "маурицијска рупија": "MUR",
+        "mauritisk rupie": "MUR",
+        "mauritius rupisi": "MUR",
+        "маврикійська рупія": "MUR",
+        "模里西斯盧比": "MUR",
+        "روفيه مالديفية": "MVR",
+        "малдивска рупия": "MVR",
+        "rupia de les maldives": "MVR",
+        "maledivská rupie": "MVR",
+        "rufiyaa": "MVR",
+        "ρουφίγια": "MVR",
+        "maldivian rufiyaa": "MVR",
+        "maldiva rufijao": "MVR",
+        "rupia de maldivas": "MVR",
+        "errupia maldivar": "MVR",
+        "روفیه مالدیو": "MVR",
+        "malediivien rufiyaa": "MVR",
+        "maldivska rufija": "MVR",
+        "maldív rúfia": "MVR",
+        "rufiyaa delle maldive": "MVR",
+        "ルフィヤ": "MVR",
+        "maldyvų rufija": "MVR",
+        "maldivische rufiyaa": "MVR",
+        "rupia malediwska": "MVR",
+        "rupia maldívia": "MVR",
+        "мальдивская руфия": "MVR",
+        "малдивска руфија": "MVR",
+        "rufiyah": "MVR",
+        "மாலத்தீவின் ருஃபியா": "MVR",
+        "мальдівська руфія": "MVR",
+        "馬爾地夫拉菲亞": "MVR",
+        "كواشا ملاوية": "MWK",
+        "kwacha malawià": "MWK",
+        "malawiská kwacha": "MWK",
+        "malawi kwacha": "MWK",
+        "κουάτσα του μαλάουι": "MWK",
+        "malawian kwacha": "MWK",
+        "malavia kvaĉo": "MWK",
+        "kwacha malauí": "MWK",
+        "malawi kvatša": "MWK",
+        "کواچا مالاویا": "MWK",
+        "malawin kwacha": "MWK",
+        "kwacha malawien": "MWK",
+        "kwacha de malawi": "MWK",
+        "malavijska kvača": "MWK",
+        "kwacha malawiano": "MWK",
+        "マラウイ・クワチャ": "MWK",
+        "malavio kvača": "MWK",
+        "malawische kwacha": "MWK",
+        "kwacha malawijska": "MWK",
+        "kwacha do maláui": "MWK",
+        "малавийская квача": "MWK",
+        "малавијска квача": "MWK",
+        "malawisk kwacha": "MWK",
+        "malavi kvaçası": "MWK",
+        "малавійська квача": "MWK",
+        "馬拉威克瓦查": "MWK",
+        "بيزو مكسيكي": "MXN",
+        "мексиканско песо": "MXN",
+        "peso mexicà": "MXN",
+        "mexické peso": "MXN",
+        "mexikanischer peso": "MXN",
+        "μεξικάνικο πέσο": "MXN",
+        "mexican peso": "MXN",
+        "meksika peso": "MXN",
+        "peso mexicano": "MXN",
+        "peso mexikar": "MXN",
+        "پزو مکزیک": "MXN",
+        "meksikon peso": "MXN",
+        "peso mexicain": "MXN",
+        "פסו מקסיקני": "MXN",
+        "meksički pezo": "MXN",
+        "mexikói peso": "MXN",
+        "peso mexican": "MXN",
+        "peso messicano": "MXN",
+        "メキシコ・ペソ": "MXN",
+        "meksikos pesas": "MXN",
+        "mexicaanse peso": "MXN",
+        "peso meksykańskie": "MXN",
+        "мексиканское песо": "MXN",
+        "мексички пезос": "MXN",
+        "mexikansk peso": "MXN",
+        "மெக்சிகோ பெசோ": "MXN",
+        "meksika pesosu": "MXN",
+        "мексиканський песо": "MXN",
+        "peso méxico": "MXN",
+        "墨西哥比索": "MXN",
+        "mexican unidad de inversión": "MXV",
+        "unidades de inversión": "MXV",
+        "رينغيت ماليزي": "MYR",
+        "малайзийски рингит": "MYR",
+        "ringgit": "MYR",
+        "malajsijský ringgit": "MYR",
+        "malaysischer ringgit": "MYR",
+        "ρινγκίτ": "MYR",
+        "malaysian ringgit": "MYR",
+        "malajzia ringito": "MYR",
+        "رینگیت مالزی": "MYR",
+        "malesian ringgit": "MYR",
+        "malezijski ringit": "MYR",
+        "maláj ringgit": "MYR",
+        "ringgit malaysiano": "MYR",
+        "リンギット": "MYR",
+        "malaizijos ringitas": "MYR",
+        "maleisische ringgit": "MYR",
+        "ringgit malaio": "MYR",
+        "малайзийский ринггит": "MYR",
+        "малезијски рингит": "MYR",
+        "மலேசிய ரிங்கிட்": "MYR",
+        "малайзійський рингіт": "MYR",
+        "馬來西亞令吉": "MYR",
+        "متكال موزمبيقي": "MZN",
+        "metical": "MZN",
+        "mosambický metical": "MZN",
+        "μετικάλ": "MZN",
+        "mozambican metical": "MZN",
+        "mozambika metikalo": "MZN",
+        "metical mozambiqueño": "MZN",
+        "متیکال موزامبیک": "MZN",
+        "mosambikin metical": "MZN",
+        "mozambički metikal": "MZN",
+        "mozambiki metical": "MZN",
+        "metical mozambicano": "MZN",
+        "メティカル": "MZN",
+        "metikalis": "MZN",
+        "mozambikaanse metical": "MZN",
+        "мозамбикский метикал": "MZN",
+        "мозамбички метикал": "MZN",
+        "мозамбіцький метікал": "MZN",
+        "莫三比克梅蒂卡爾": "MZN",
+        "دولار ناميبي": "NAD",
+        "намибийски долар": "NAD",
+        "dòlar namibià": "NAD",
+        "namibijský dolar": "NAD",
+        "namibisk dollar": "NAD",
+        "namibia dollar": "NAD",
+        "namibian dollar": "NAD",
+        "namibia dolaro": "NAD",
+        "dólar namibio": "NAD",
+        "دلار نامیبیا": "NAD",
+        "namibian dollari": "NAD",
+        "dollar namibien": "NAD",
+        "דולר נמיבי": "NAD",
+        "namibijski dolar": "NAD",
+        "namíbiai dollár": "NAD",
+        "dollaro namibiano": "NAD",
+        "ナミビア・ドル": "NAD",
+        "namibijos doleris": "NAD",
+        "namibische dollar": "NAD",
+        "dolar namibian": "NAD",
+        "dolar namibijski": "NAD",
+        "dólar da namíbia": "NAD",
+        "доллар намибии": "NAD",
+        "намибијски долар": "NAD",
+        "namibya doları": "NAD",
+        "намібійський долар": "NAD",
+        "納米比亞元": "NAD",
+        "نيرة نيجيرية": "NGN",
+        "naira": "NGN",
+        "nigerijská naira": "NGN",
+        "nigerian naira": "NGN",
+        "niĝeria najro": "NGN",
+        "نایرا نیجریه": "NGN",
+        "נאירה": "NGN",
+        "nigerijska naira": "NGN",
+        "nigériai naira": "NGN",
+        "naira nigeriana": "NGN",
+        "ナイラ": "NGN",
+        "nigeriaanse naira": "NGN",
+        "найра": "NGN",
+        "нигеријска наира": "NGN",
+        "nijerya nairası": "NGN",
+        "нігерійська найра": "NGN",
+        "奈及利亞奈拉": "NGN",
+        "كوردبا نيكاراغوا": "NIO",
+        "никарагуанска кордоба": "NIO",
+        "córdoba": "NIO",
+        "nikaragujská córdoba": "NIO",
+        "córdoba oro": "NIO",
+        "κόρδοβα νικαράγουας": "NIO",
+        "nicaraguan córdoba": "NIO",
+        "nikaragva kordovo": "NIO",
+        "کوردوبا نیکاراگوئه": "NIO",
+        "cordoba": "NIO",
+        "קורדובה": "NIO",
+        "nikaragvanska kordoba": "NIO",
+        "nicaraguai córdoba": "NIO",
+        "córdoba nicaraguense": "NIO",
+        "ニカラグア・コルドバ": "NIO",
+        "nikaragvos kordoba": "NIO",
+        "nicaraguaanse córdoba": "NIO",
+        "cordoba oro": "NIO",
+        "никарагуанская кордоба": "NIO",
+        "никарагванска кордоба": "NIO",
+        "kordoba": "NIO",
+        "нікарагуанська кордоба": "NIO",
+        "尼加拉瓜科多巴": "NIO",
+        "درام أرتساخي": "NKD",
+        "bergkarabach dram": "NKD",
+        "artsakh dram": "NKD",
+        "dram de artsaj": "NKD",
+        "درام آرتساخ": "NKD",
+        "artsakhin dram": "NKD",
+        "dram de l'artsakh": "NKD",
+        "dram de artsakh": "NKD",
+        "gorskokarabaški dram": "NKD",
+        "arcahi dram": "NKD",
+        "dram karabakho": "NKD",
+        "karabacho dramas": "NKD",
+        "карабахский драм": "NKD",
+        "nagorno karabach dram": "NKD",
+        "karabağ dramı": "NKD",
+        "карабаський драм": "NKD",
+        "纳戈尔诺 卡拉巴赫德拉姆": "NKD",
+        "كرونة نروجية": "NOK",
+        "норвежка крона": "NOK",
+        "corona noruega": "NOK",
+        "norská koruna": "NOK",
+        "norske kroner": "NOK",
+        "norwegische krone": "NOK",
+        "κορόνα νορβηγίας": "NOK",
+        "norwegian krone": "NOK",
+        "norvega krono": "NOK",
+        "norra kroon": "NOK",
+        "norvegiar koroa": "NOK",
+        "کرون نروژ": "NOK",
+        "norjan kruunu": "NOK",
+        "couronne norvégienne": "NOK",
+        "coroa norueguesa": "NOK",
+        "כתר נורווגי": "NOK",
+        "norveška kruna": "NOK",
+        "norvég korona": "NOK",
+        "corona norvegese": "NOK",
+        "ノルウェー・クローネ": "NOK",
+        "norvegijos krona": "NOK",
+        "noorse kroon": "NOK",
+        "korona norweska": "NOK",
+        "coroană norvegiană": "NOK",
+        "норвежская крона": "NOK",
+        "nórska koruna": "NOK",
+        "norveška krona": "NOK",
+        "норвешка круна": "NOK",
+        "norsk krona": "NOK",
+        "நார்வே குரோனா": "NOK",
+        "norveç kronu": "NOK",
+        "норвезька крона": "NOK",
+        "krone na uy": "NOK",
+        "挪威克朗": "NOK",
+        "روبية نيبالية": "NPR",
+        "непалска рупия": "NPR",
+        "rupia nepalesa": "NPR",
+        "nepálská rupie": "NPR",
+        "nepalesiske rupee": "NPR",
+        "nepalesische rupie": "NPR",
+        "ρουπία νεπάλ": "NPR",
+        "nepalese rupee": "NPR",
+        "nepala rupio": "NPR",
+        "rupia nepalí": "NPR",
+        "nepali ruupia": "NPR",
+        "errupia nepaldar": "NPR",
+        "روپیه نپال": "NPR",
+        "nepalin rupia": "NPR",
+        "roupie népalaise": "NPR",
+        "רופי נפאלי": "NPR",
+        "nepalska rupija": "NPR",
+        "nepáli rúpia": "NPR",
+        "rupia nepalese": "NPR",
+        "ネパール・ルピー": "NPR",
+        "nepalo rupija": "NPR",
+        "nepalese roepie": "NPR",
+        "rupia nepalska": "NPR",
+        "непальская рупия": "NPR",
+        "непалска рупија": "NPR",
+        "nepalesisk rupie": "NPR",
+        "நேபாள ரூபாய்": "NPR",
+        "nepal rupisi": "NPR",
+        "непальська рупія": "NPR",
+        "rupee nepal": "NPR",
+        "尼泊尔卢比": "NPR",
+        "niue dollar": "NUD",
+        "دلار نیوئه": "NUD",
+        "niuen dollari": "NUD",
+        "доллар ниуэ": "NUD",
+        "纽埃元": "NUD",
+        "دولار نيوزيلندي": "NZD",
+        "новозеландски долар": "NZD",
+        "dòlar neozelandès": "NZD",
+        "novozélandský dolar": "NZD",
+        "newzealandske dollar": "NZD",
+        "neuseeland dollar": "NZD",
+        "δολάριο νέας ζηλανδίας": "NZD",
+        "new zealand dollar": "NZD",
+        "novzelanda dolaro": "NZD",
+        "dólar neozelandés": "NZD",
+        "zeelandaberritar dolar": "NZD",
+        "دلار نیوزیلند": "NZD",
+        "uuden seelannin dollari": "NZD",
+        "dollar néo zélandais": "NZD",
+        "דולר ניו זילנדי": "NZD",
+        "novozelandski dolar": "NZD",
+        "új zélandi dollár": "NZD",
+        "dollaro neozelandese": "NZD",
+        "ニュージーランド・ドル": "NZD",
+        "naujosios zelandijos doleris": "NZD",
+        "nieuw zeelandse dollar": "NZD",
+        "dolar nowozelandzki": "NZD",
+        "dólar neozelandês": "NZD",
+        "dolar neozeelandez": "NZD",
+        "новозеландский доллар": "NZD",
+        "novozélandský dolár": "NZD",
+        "nyzeeländsk dollar": "NZD",
+        "yeni zelanda doları": "NZD",
+        "новозеландський долар": "NZD",
+        "đô la new zealand": "NZD",
+        "紐西蘭元": "NZD",
+        "ريال عماني": "OMR",
+        "омански риял": "OMR",
+        "rial omanita": "OMR",
+        "ománský rijál": "OMR",
+        "omansk rial": "OMR",
+        "omanischer rial": "OMR",
+        "ριάλ του ομάν": "OMR",
+        "omani rial": "OMR",
+        "omana rialo": "OMR",
+        "rial omaní": "OMR",
+        "ریال عمان": "OMR",
+        "omanin rial": "OMR",
+        "rial omanais": "OMR",
+        "ריאל עומאני": "OMR",
+        "omanski rijal": "OMR",
+        "ománi riál": "OMR",
+        "riyal dell'oman": "OMR",
+        "オマーン・リアル": "OMR",
+        "omano rialas": "OMR",
+        "omaanse rial": "OMR",
+        "rial omański": "OMR",
+        "rial omanense": "OMR",
+        "оманский риал": "OMR",
+        "омански ријал": "OMR",
+        "ஓமானி ரியால்": "OMR",
+        "umman riyali": "OMR",
+        "оманський ріал": "OMR",
+        "阿曼里亞爾": "OMR",
+        "بالبوا بنمي": "PAB",
+        "панамска балбоа": "PAB",
+        "balboa": "PAB",
+        "panamská balboa": "PAB",
+        "panamaischer balboa": "PAB",
+        "μπαλμπόα παναμά": "PAB",
+        "panamanian balboa": "PAB",
+        "panama balboo": "PAB",
+        "بالبوآ پاناما": "PAB",
+        "panaman balboa": "PAB",
+        "בלבואה": "PAB",
+        "panamska balboa": "PAB",
+        "panamai balboa": "PAB",
+        "balboa panamense": "PAB",
+        "バルボア": "PAB",
+        "panamese balboa": "PAB",
+        "панамский бальбоа": "PAB",
+        "panama balboası": "PAB",
+        "панамське бальбоа": "PAB",
+        "巴拿馬巴波亞": "PAB",
+        "سول بيروفي جديد": "PEN",
+        "sol": "PEN",
+        "peruanischer sol": "PEN",
+        "σολ περού": "PEN",
+        "peruvian sol": "PEN",
+        "perua nova suno": "PEN",
+        "سول پرو": "PEN",
+        "perun sol": "PEN",
+        "nuevo sol": "PEN",
+        "סול": "PEN",
+        "peruanski novi sol": "PEN",
+        "perui sol": "PEN",
+        "nuevo sol peruviano": "PEN",
+        "ヌエボ・ソル": "PEN",
+        "naujasis solis": "PEN",
+        "peruviaanse sol": "PEN",
+        "novo sol": "PEN",
+        "перуанский новый соль": "PEN",
+        "перуански нови сол": "PEN",
+        "перуанський соль": "PEN",
+        "sol peru": "PEN",
+        "秘魯新索爾": "PEN",
+        "كينا بابوا غينيا الجديدة": "PGK",
+        "кина на папуа нова гвинея": "PGK",
+        "kina": "PGK",
+        "papuánská kina": "PGK",
+        "κίνα παπούα νέας γουινέας": "PGK",
+        "papua new guinean kina": "PGK",
+        "papuonovgvinea kinao": "PGK",
+        "کینای پاپوآ گینه نو": "PGK",
+        "papua uuden guinean kina": "PGK",
+        "papuanska kina": "PGK",
+        "pápua új guineai kina": "PGK",
+        "kina papuana": "PGK",
+        "キナ": "PGK",
+        "кина": "PGK",
+        "папуанска кина": "PGK",
+        "papua yeni gine kinası": "PGK",
+        "кіна": "PGK",
+        "kina papua new guinea": "PGK",
+        "巴布亞紐幾內亞基那": "PGK",
+        "بيسو فلبيني": "PHP",
+        "филипинско песо": "PHP",
+        "peso filipí": "PHP",
+        "filipínské peso": "PHP",
+        "philippinischer peso": "PHP",
+        "πέσο φιλιππίνων": "PHP",
+        "philippine peso": "PHP",
+        "filipina peso": "PHP",
+        "peso filipino": "PHP",
+        "پزو فیلیپین": "PHP",
+        "filippiinien peso": "PHP",
+        "peso philippin": "PHP",
+        "פסו פיליפיני": "PHP",
+        "filipinski pezo": "PHP",
+        "fülöp szigeteki peso": "PHP",
+        "peso filippino": "PHP",
+        "フィリピン・ペソ": "PHP",
+        "filipinų pesas": "PHP",
+        "filipijnse peso": "PHP",
+        "peso filipińskie": "PHP",
+        "филиппинское песо": "PHP",
+        "filipínske peso": "PHP",
+        "филипински пезо": "PHP",
+        "filippinsk peso": "PHP",
+        "பிலிப்பைன் பெசோ": "PHP",
+        "filipinler pesosu": "PHP",
+        "філіппінський песо": "PHP",
+        "peso philippines": "PHP",
+        "菲律賓披索": "PHP",
+        "روبية باكستانية": "PKR",
+        "пакистанска рупия": "PKR",
+        "rupia pakistanesa": "PKR",
+        "pákistánská rupie": "PKR",
+        "pakistanske rupier": "PKR",
+        "pakistanische rupie": "PKR",
+        "ρουπία πακιστάν": "PKR",
+        "pakistani rupee": "PKR",
+        "pakistana rupio": "PKR",
+        "rupia pakistaní": "PKR",
+        "errupia pakistandar": "PKR",
+        "روپیه پاکستان": "PKR",
+        "pakistanin rupia": "PKR",
+        "roupie pakistanaise": "PKR",
+        "pakistanska rupija": "PKR",
+        "pakisztáni rúpia": "PKR",
+        "rupia pakistana": "PKR",
+        "パキスタン・ルピー": "PKR",
+        "pakistano rupija": "PKR",
+        "pakistaanse roepie": "PKR",
+        "ropia de paquistan": "PKR",
+        "rupia pakistańska": "PKR",
+        "rupia do paquistão": "PKR",
+        "пакистанская рупия": "PKR",
+        "пакистанска рупија": "PKR",
+        "pakistansk rupie": "PKR",
+        "பாக்கித்தானிய ரூபாய்": "PKR",
+        "pakistan rupisi": "PKR",
+        "пакистанська рупія": "PKR",
+        "rupee pakistan": "PKR",
+        "巴基斯坦盧比": "PKR",
+        "زلوتي بولندي": "PLN",
+        "полска злота": "PLN",
+        "złoty": "PLN",
+        "zlotý": "PLN",
+        "polske zloty": "PLN",
+        "ζλότι": "PLN",
+        "polish złoty": "PLN",
+        "zloto": "PLN",
+        "esloti": "PLN",
+        "poola zlott": "PLN",
+        "زلوتی لهستان": "PLN",
+        "puolan zloty": "PLN",
+        "זלוטי": "PLN",
+        "poljski zlot": "PLN",
+        "lengyel złoty": "PLN",
+        "ズウォティ": "PLN",
+        "zlotas": "PLN",
+        "poolse złoty": "PLN",
+        "zlot polonez": "PLN",
+        "польский злотый": "PLN",
+        "poľský zlotý": "PLN",
+        "пољски злот": "PLN",
+        "ஸ்வாட்டெ": "PLN",
+        "злотий": "PLN",
+        "złoty ba lan": "PLN",
+        "波兰兹罗提": "PLN",
+        "pitcairn islands dollar": "PND",
+        "دلار جزایر پیتکرن": "PND",
+        "pitcairnin dollari": "PND",
+        "доллар островов питкэрн": "PND",
+        "روبل ترانسنيستري": "PRB",
+        "приднестровска рубла": "PRB",
+        "ruble de transnístria": "PRB",
+        "podněsterský rubl": "PRB",
+        "transnistrischer rubel": "PRB",
+        "transnistrian ruble": "PRB",
+        "ĉednestria rublo": "PRB",
+        "rublo transnistrio": "PRB",
+        "روبل ترانسنیسترین": "PRB",
+        "transnistrian rupla": "PRB",
+        "rouble de transnistrie": "PRB",
+        "rublo de transnistria": "PRB",
+        "רובל טרנסדנייסטרי": "PRB",
+        "pridnjestrovski rubalj": "PRB",
+        "dnyeszter menti rubel": "PRB",
+        "rublo transnistriano": "PRB",
+        "沿ドニエストル・ルーブル": "PRB",
+        "padniestrės rublis": "PRB",
+        "transnistrische roebel": "PRB",
+        "rubel naddniestrzański": "PRB",
+        "rublo transnístrio": "PRB",
+        "rublă transnistreană": "PRB",
+        "приднестровский рубль": "PRB",
+        "podnesterský rubeľ": "PRB",
+        "придњестровска рубља": "PRB",
+        "transnistrisk rubel": "PRB",
+        "transdinyester rublesi": "PRB",
+        "придністровський рубль": "PRB",
+        "德涅斯特河沿岸盧布": "PRB",
+        "غواراني باراغواي": "PYG",
+        "guaraní": "PYG",
+        "paraguayský guaraní": "PYG",
+        "paraguayischer guaraní": "PYG",
+        "γκουαρανί": "PYG",
+        "paraguayan guaraní": "PYG",
+        "paragvaja gvaranio": "PYG",
+        "guarani": "PYG",
+        "گوارانی پاراگوئه": "PYG",
+        "paraguayn guaraní": "PYG",
+        "paragvajski gvarani": "PYG",
+        "paraguayi guaraní": "PYG",
+        "guaraní paraguaiano": "PYG",
+        "グアラニー": "PYG",
+        "gvaranis": "PYG",
+        "paraguayaanse guarani": "PYG",
+        "парагвайский гуарани": "PYG",
+        "парагвајски гварани": "PYG",
+        "paraguay guaranísi": "PYG",
+        "парагвайський гуарані": "PYG",
+        "巴拉圭瓜拉尼": "PYG",
+        "ريال قطري": "QAR",
+        "катарски риал": "QAR",
+        "riyal de qatar": "QAR",
+        "katar riyal": "QAR",
+        "ριγιάλ του κατάρ": "QAR",
+        "qatari riyal": "QAR",
+        "katara rialo": "QAR",
+        "riyal catarí": "QAR",
+        "ریال قطر": "QAR",
+        "qatarin rial": "QAR",
+        "riyal qatarien": "QAR",
+        "ריאל קטרי": "QAR",
+        "katarski rijal": "QAR",
+        "katari riál": "QAR",
+        "riyal del qatar": "QAR",
+        "カタール・リヤル": "QAR",
+        "kataro rialas": "QAR",
+        "qatarese rial": "QAR",
+        "rial katarski": "QAR",
+        "rial catarense": "QAR",
+        "катарский риал": "QAR",
+        "катарски ријал": "QAR",
+        "qatarisk rial": "QAR",
+        "கத்தாரி ரியால்": "QAR",
+        "katar riyali": "QAR",
+        "катарський ріал": "QAR",
+        "riyal qatar": "QAR",
+        "卡達里亞爾": "QAR",
+        "ليو روماني": "RON",
+        "румънска лея": "RON",
+        "leu romanès": "RON",
+        "rumunský lei": "RON",
+        "rumænske lei": "RON",
+        "rumänischer leu": "RON",
+        "λέου ρουμανίας": "RON",
+        "romanian leu": "RON",
+        "rumana leo": "RON",
+        "leu rumano": "RON",
+        "rumeenia leu": "RON",
+        "لئوی رومانی": "RON",
+        "leu roumain": "RON",
+        "leu romanés": "RON",
+        "לאו רומני": "RON",
+        "rumunjski lej": "RON",
+        "román lej": "RON",
+        "leu romeno": "RON",
+        "ルーマニア・レウ": "RON",
+        "naujoji rumunijos lėja": "RON",
+        "roemeense leu": "RON",
+        "lej rumuński": "RON",
+        "leu românesc": "RON",
+        "румынский лей": "RON",
+        "nový rumunský lei": "RON",
+        "romunski lev": "RON",
+        "румунски леј": "RON",
+        "rumänsk leu": "RON",
+        "ரொமேனிய லியு": "RON",
+        "rumen leyi": "RON",
+        "румунський лей": "RON",
+        "leu românia": "RON",
+        "罗马尼亚列伊": "RON",
+        "دينار صربي": "RSD",
+        "сръбски динар": "RSD",
+        "dinar serbi": "RSD",
+        "srbský dinár": "RSD",
+        "serbiske dinarer": "RSD",
+        "serbischer dinar": "RSD",
+        "δηνάριο σερβίας": "RSD",
+        "serbian dinar": "RSD",
+        "serba dinaro": "RSD",
+        "dinar serbio": "RSD",
+        "serbia dinaar": "RSD",
+        "serbiar dinar": "RSD",
+        "دینار صربستان": "RSD",
+        "serbian dinaari": "RSD",
+        "dinar serbe": "RSD",
+        "דינר סרבי": "RSD",
+        "srpski dinar": "RSD",
+        "szerb dinár": "RSD",
+        "dinaro serbo": "RSD",
+        "セルビア・ディナール": "RSD",
+        "serbijos dinaras": "RSD",
+        "servische dinar": "RSD",
+        "dinar serbski": "RSD",
+        "dinar sérvio": "RSD",
+        "dinar sârbesc": "RSD",
+        "сербский динар": "RSD",
+        "srbski dinar": "RSD",
+        "српски динар": "RSD",
+        "serbisk dinar": "RSD",
+        "செர்பிய தினார்": "RSD",
+        "sırp dinarı": "RSD",
+        "сербський динар": "RSD",
+        "塞爾維亞第納爾": "RSD",
+        "روبل روسي": "RUB",
+        "руска рубла": "RUB",
+        "ruble rus": "RUB",
+        "ruský rubl": "RUB",
+        "rŵbl rwsiaidd": "RUB",
+        "russiske rubler": "RUB",
+        "russischer rubel": "RUB",
+        "ρούβλι ρωσίας": "RUB",
+        "russian ruble": "RUB",
+        "rusia rublo": "RUB",
+        "rublo ruso": "RUB",
+        "venemaa rubla": "RUB",
+        "errublo errusiar": "RUB",
+        "روبل روسیه": "RUB",
+        "venäjän rupla": "RUB",
+        "rouble russe": "RUB",
+        "רובל רוסי": "RUB",
+        "ruski rubalj": "RUB",
+        "orosz rubel": "RUB",
+        "rublo russo": "RUB",
+        "ロシア・ルーブル": "RUB",
+        "rusijos rublis": "RUB",
+        "russische roebel": "RUB",
+        "rubel rosyjski": "RUB",
+        "rublă rusă": "RUB",
+        "российский рубль": "RUB",
+        "ruský rubeľ": "RUB",
+        "руска рубља": "RUB",
+        "rysk rubel": "RUB",
+        "உருசிய ரூபிள்": "RUB",
+        "rus rublesi": "RUB",
+        "російський рубль": "RUB",
+        "rúp nga": "RUB",
+        "俄罗斯卢布": "RUB",
+        "فرنك رواندي": "RWF",
+        "руандийски франк": "RWF",
+        "franc ruandès": "RWF",
+        "rwandský frank": "RWF",
+        "rwandiske franc": "RWF",
+        "ruanda franc": "RWF",
+        "φράγκο της ρουάντα": "RWF",
+        "rwandan franc": "RWF",
+        "ruanda franko": "RWF",
+        "franco ruandés": "RWF",
+        "rwanda frank": "RWF",
+        "فرانک رواندا": "RWF",
+        "ruandan frangi": "RWF",
+        "franc rwandais": "RWF",
+        "פרנק רואנדי": "RWF",
+        "ruandski franak": "RWF",
+        "ruandai frank": "RWF",
+        "franco ruandese": "RWF",
+        "ルワンダ・フラン": "RWF",
+        "ruandos frankas": "RWF",
+        "rwandese frank": "RWF",
+        "frank rwandyjski": "RWF",
+        "franco ruandês": "RWF",
+        "франк руанды": "RWF",
+        "руандски франак": "RWF",
+        "rwandisk franc": "RWF",
+        "ruanda frangı": "RWF",
+        "руандійський франк": "RWF",
+        "卢旺达法郎": "RWF",
+        "ريال سعودي": "SAR",
+        "саудитски риал": "SAR",
+        "riyal saudita": "SAR",
+        "saudi riyal": "SAR",
+        "ριάλ σαουδικής αραβίας": "SAR",
+        "sauda rialo": "SAR",
+        "riyal saudí": "SAR",
+        "saudi araabia riaal": "SAR",
+        "ریال سعودی": "SAR",
+        "saudi arabian rial": "SAR",
+        "riyal saoudien": "SAR",
+        "ריאל סעודי": "SAR",
+        "saudijski rijal": "SAR",
+        "szaúdi riál": "SAR",
+        "サウジアラビア・リヤル": "SAR",
+        "saudo arabijos rialas": "SAR",
+        "saoedi arabische riyal": "SAR",
+        "rial saudyjski": "SAR",
+        "rial saudit": "SAR",
+        "саудовский риял": "SAR",
+        "саудијски ријал": "SAR",
+        "saudiarabisk rial": "SAR",
+        "சவூதி ரியால்": "SAR",
+        "suudi arabistan riyali": "SAR",
+        "саудівський ріал": "SAR",
+        "riyal ả rập xê út": "SAR",
+        "沙特里亚尔": "SAR",
+        "دولار جزر سليمان": "SBD",
+        "соломоновски долар": "SBD",
+        "dòlar de salomó": "SBD",
+        "dolar šalomounových ostrovů": "SBD",
+        "salomondollar": "SBD",
+        "salomonen dollar": "SBD",
+        "δολάριο νήσων σολομώντα": "SBD",
+        "solomon islands dollar": "SBD",
+        "salomona dolaro": "SBD",
+        "dólar de las islas salomón": "SBD",
+        "دلار جزایر سلیمان": "SBD",
+        "salomonsaarten dollari": "SBD",
+        "dollar des îles salomon": "SBD",
+        "dólar das illas salomón": "SBD",
+        "דולר איי שלמה": "SBD",
+        "salomonskootočni dolar": "SBD",
+        "salamon szigeteki dollár": "SBD",
+        "dollaro delle salomone": "SBD",
+        "ソロモン諸島ドル": "SBD",
+        "saliamono salų doleris": "SBD",
+        "salomon dollar": "SBD",
+        "dolar wysp salomona": "SBD",
+        "dólar das ilhas salomão": "SBD",
+        "dolar din insulele solomon": "SBD",
+        "доллар соломоновых островов": "SBD",
+        "соломонски долар": "SBD",
+        "solomon adaları doları": "SBD",
+        "долар соломонових островів": "SBD",
+        "所罗门群岛元": "SBD",
+        "روبية سيشلية": "SCR",
+        "сейшелска рупия": "SCR",
+        "rupia de les seychelles": "SCR",
+        "seychelská rupie": "SCR",
+        "seychelliske rupee": "SCR",
+        "seychellen rupie": "SCR",
+        "ρουπία σεϋχελλών": "SCR",
+        "seychellois rupee": "SCR",
+        "sejŝela rupio": "SCR",
+        "rupia seychellense": "SCR",
+        "seišelli ruupia": "SCR",
+        "errupia seychelletar": "SCR",
+        "روپیه سیشل": "SCR",
+        "seychellien rupia": "SCR",
+        "roupie seychelloise": "SCR",
+        "sejšelska rupija": "SCR",
+        "seychelle i rúpia": "SCR",
+        "rupia delle seychelles": "SCR",
+        "セーシェル・ルピー": "SCR",
+        "seišelių rupija": "SCR",
+        "seychelse roepie": "SCR",
+        "rupia seszelska": "SCR",
+        "rupia das seicheles": "SCR",
+        "сейшельская рупия": "SCR",
+        "сејшелска рупија": "SCR",
+        "seychellisk rupie": "SCR",
+        "seyşeller rupisi": "SCR",
+        "сейшельська рупія": "SCR",
+        "塞席爾盧比": "SCR",
+        "جنيه سوداني": "SDG",
+        "lliura sudanesa": "SDG",
+        "súdánská libra": "SDG",
+        "sudanesisches pfund": "SDG",
+        "λίρα του σουδάν": "SDG",
+        "sudanese pound": "SDG",
+        "sudana pundo": "SDG",
+        "libra sudanesa": "SDG",
+        "پوند سودان": "SDG",
+        "sudanin punta": "SDG",
+        "livre soudanaise": "SDG",
+        "sudanska funta": "SDG",
+        "szudáni font": "SDG",
+        "sterlina sudanese": "SDG",
+        "スーダン・ポンド": "SDG",
+        "sudano svaras": "SDG",
+        "soedanees pond": "SDG",
+        "funt sudański": "SDG",
+        "liră sudaneză": "SDG",
+        "суданский фунт": "SDG",
+        "суданска фунта": "SDG",
+        "sudanesiskt pund": "SDG",
+        "sudan sterlini": "SDG",
+        "суданський фунт": "SDG",
+        "蘇丹鎊": "SDG",
+        "كرونة سويدية": "SEK",
+        "шведска крона": "SEK",
+        "corona sueca": "SEK",
+        "švédská koruna": "SEK",
+        "svenske kronor": "SEK",
+        "schwedische krone": "SEK",
+        "κορόνα σουηδίας": "SEK",
+        "swedish krona": "SEK",
+        "sveda krono": "SEK",
+        "rootsi kroon": "SEK",
+        "suediar koroa": "SEK",
+        "کرون سوئد": "SEK",
+        "ruotsin kruunu": "SEK",
+        "couronne suédoise": "SEK",
+        "coroa sueca": "SEK",
+        "קרונה שוודית": "SEK",
+        "švedska kruna": "SEK",
+        "svéd korona": "SEK",
+        "corona svedese": "SEK",
+        "スウェーデン・クローナ": "SEK",
+        "švedijos krona": "SEK",
+        "zweedse kroon": "SEK",
+        "korona szwedzka": "SEK",
+        "coroană suedeză": "SEK",
+        "шведская крона": "SEK",
+        "švédska koruna": "SEK",
+        "švedska krona": "SEK",
+        "шведска круна": "SEK",
+        "svensk krona": "SEK",
+        "சுவீடிய குரோனா": "SEK",
+        "i̇sveç kronu": "SEK",
+        "шведська крона": "SEK",
+        "krona thụy điển": "SEK",
+        "瑞典克朗": "SEK",
+        "دولار سنغافوري": "SGD",
+        "сингапурски долар": "SGD",
+        "dòlar de singapur": "SGD",
+        "singapurský dolar": "SGD",
+        "singaporeanske dollar": "SGD",
+        "singapur dollar": "SGD",
+        "δολάριο σιγκαπούρης": "SGD",
+        "singapore dollar": "SGD",
+        "singapura dolaro": "SGD",
+        "dólar de singapur": "SGD",
+        "dolar singapurtar": "SGD",
+        "دلار سنگاپور": "SGD",
+        "singaporen dollari": "SGD",
+        "dollar de singapour": "SGD",
+        "דולר סינגפורי": "SGD",
+        "singapurski dolar": "SGD",
+        "szingapúri dollár": "SGD",
+        "dollaro di singapore": "SGD",
+        "シンガポールドル": "SGD",
+        "singapūro doleris": "SGD",
+        "singaporese dollar": "SGD",
+        "dolar singapurski": "SGD",
+        "dólar de singapura": "SGD",
+        "сингапурский доллар": "SGD",
+        "singaporiansk dollar": "SGD",
+        "சிங்கப்பூர் வெள்ளி": "SGD",
+        "singapur doları": "SGD",
+        "сінгапурський долар": "SGD",
+        "đô la singapore": "SGD",
+        "新加坡元": "SGD",
+        "جنيه سانت هيليني": "SHP",
+        "lliura de santa helena": "SHP",
+        "svatohelenská libra": "SHP",
+        "st. helena pfund": "SHP",
+        "λίρα αγίας ελένης": "SHP",
+        "saint helena pound": "SHP",
+        "sankthelena pundo": "SHP",
+        "libra de santa elena": "SHP",
+        "پوند سنت هلن": "SHP",
+        "saint helenan punta": "SHP",
+        "livre de sainte hélène": "SHP",
+        "svetohelenska funta": "SHP",
+        "szent ilona i font": "SHP",
+        "sterlina di sant'elena": "SHP",
+        "セントヘレナ・ポンド": "SHP",
+        "sint heleens pond": "SHP",
+        "funt świętej heleny": "SHP",
+        "libra de santa helena": "SHP",
+        "liră din sfânta elena": "SHP",
+        "фунт святой елены": "SHP",
+        "sankthelenskt pund": "SHP",
+        "saint helena sterlini": "SHP",
+        "фунт святої єлени": "SHP",
+        "圣赫勒拿镑": "SHP",
+        "ليون سيراليوني": "SLL",
+        "леоне на сиера леоне": "SLL",
+        "leone": "SLL",
+        "sierraleonský leone": "SLL",
+        "sierra leonischer leone": "SLL",
+        "λεόνε της σιέρα λεόνε": "SLL",
+        "sierra leonean leone": "SLL",
+        "sieraleona leono": "SLL",
+        "لئون سیرالئون": "SLL",
+        "sierra leonen leone": "SLL",
+        "ליאון": "SLL",
+        "sijeraleonski leone": "SLL",
+        "sierra leone i leone": "SLL",
+        "leone sierraleonese": "SLL",
+        "レオン": "SLL",
+        "leonė": "SLL",
+        "sierra leoonse leone": "SLL",
+        "леоне": "SLL",
+        "сијералеонски леоне": "SLL",
+        "sierra leone leonesi": "SLL",
+        "леоне сьєрра леоне": "SLL",
+        "塞拉利昂利昂": "SLL",
+        "شلن صومالي": "SOS",
+        "сомалийски шилинг": "SOS",
+        "xíling somali": "SOS",
+        "somálský šilink": "SOS",
+        "somalisk shilling": "SOS",
+        "somalia schilling": "SOS",
+        "somali shilling": "SOS",
+        "somalia ŝilingo": "SOS",
+        "chelín somalí": "SOS",
+        "شیلینگ سومالی": "SOS",
+        "somalian šillinki": "SOS",
+        "shilling somalien": "SOS",
+        "שילינג סומלי": "SOS",
+        "somalijski šiling": "SOS",
+        "szomáliai shilling": "SOS",
+        "scellino somalo": "SOS",
+        "ソマリア・シリング": "SOS",
+        "somalio šilingas": "SOS",
+        "somalische shilling": "SOS",
+        "szyling somalijski": "SOS",
+        "xelim somaliano": "SOS",
+        "сомалийский шиллинг": "SOS",
+        "сомалијски шилинг": "SOS",
+        "somali şilini": "SOS",
+        "сомалійський шилінг": "SOS",
+        "索馬利亞先令": "SOS",
+        "دولار سورينامي": "SRD",
+        "суринамски долар": "SRD",
+        "dòlar de surinam": "SRD",
+        "surinamský dolar": "SRD",
+        "suriname dollar": "SRD",
+        "δολάριο σουρινάμ": "SRD",
+        "surinamese dollar": "SRD",
+        "surinama dolaro": "SRD",
+        "dólar surinamés": "SRD",
+        "dolar surinamdar": "SRD",
+        "دلار سورینام": "SRD",
+        "surinamen dollari": "SRD",
+        "dollar du suriname": "SRD",
+        "surinamski dolar": "SRD",
+        "suriname i dollár": "SRD",
+        "dollaro surinamese": "SRD",
+        "スリナム・ドル": "SRD",
+        "surinamo doleris": "SRD",
+        "surinaamse dollar": "SRD",
+        "dolar surinamski": "SRD",
+        "dólar do suriname": "SRD",
+        "суринамский доллар": "SRD",
+        "surinamesisk dollar": "SRD",
+        "surinam doları": "SRD",
+        "суринамський долар": "SRD",
+        "蘇利南元": "SRD",
+        "جنيه جنوب سوداني": "SSP",
+        "южносудански паунд": "SSP",
+        "lliura sud sudanesa": "SSP",
+        "jihosúdánská libra": "SSP",
+        "südsudanesisches pfund": "SSP",
+        "south sudanese pound": "SSP",
+        "libra sursudanesa": "SSP",
+        "lõuna sudaani nael": "SSP",
+        "پوند سودان جنوبی": "SSP",
+        "etelä sudanin punta": "SSP",
+        "livre sud soudanaise": "SSP",
+        "לירה דרום סודאנית": "SSP",
+        "južnosudanska funta": "SSP",
+        "dél szudáni font": "SSP",
+        "sterlina sudsudanese": "SSP",
+        "南スーダン・ポンド": "SSP",
+        "pietų sudano svaras": "SSP",
+        "zuid soedanees pond": "SSP",
+        "funt południowosudański": "SSP",
+        "libra sul sudanesa": "SSP",
+        "liră sud sudaneză": "SSP",
+        "южносуданский фунт": "SSP",
+        "juhosudánska libra": "SSP",
+        "јужносуданска фунта": "SSP",
+        "sydsudanesiskt pund": "SSP",
+        "південносуданський фунт": "SSP",
+        "bảng nam sudan": "SSP",
+        "南蘇丹鎊": "SSP",
+        "دوبرا ساو تومي وبرينسيب": "STN",
+        "dobra": "STN",
+        "svatotomášská dobra": "STN",
+        "são toméischer dobra": "STN",
+        "ντόμπρα": "STN",
+        "são tomé and príncipe dobra": "STN",
+        "santomea dobro": "STN",
+        "dobra santotomense": "STN",
+        "دبرای سائوتومه و پرنسیپ": "STN",
+        "são tomén ja príncipen dobra": "STN",
+        "svetotomska dobra": "STN",
+        "são tomé és príncipe i dobra": "STN",
+        "dobra di são tomé e príncipe": "STN",
+        "ドブラ": "STN",
+        "santomese dobra": "STN",
+        "dobra são tomense": "STN",
+        "добра сан томе и принсипи": "STN",
+        "саотомска добра": "STN",
+        "são tomé ve príncipe dobrası": "STN",
+        "добра сан томе і принсіпі": "STN",
+        "圣多美和普林西比多布拉": "STN",
+        "ليرة سورية": "SYP",
+        "сирийска лира": "SYP",
+        "lliura siriana": "SYP",
+        "syrská libra": "SYP",
+        "syrische lira": "SYP",
+        "λίρα συρίας": "SYP",
+        "syrian pound": "SYP",
+        "siria pundo": "SYP",
+        "libra siria": "SYP",
+        "لیره سوریه": "SYP",
+        "syyrian punta": "SYP",
+        "livre syrienne": "SYP",
+        "לירה סורית": "SYP",
+        "sirijska funta": "SYP",
+        "szír font": "SYP",
+        "lira siriana": "SYP",
+        "シリア・ポンド": "SYP",
+        "sirijos svaras": "SYP",
+        "syrisch pond": "SYP",
+        "funt syryjski": "SYP",
+        "libra síria": "SYP",
+        "сирийский фунт": "SYP",
+        "sirski funt": "SYP",
+        "сиријска фунта": "SYP",
+        "syriskt pund": "SYP",
+        "suriye lirası": "SYP",
+        "сирійський фунт": "SYP",
+        "敘利亞鎊": "SYP",
+        "ليلانغيني سوازيلندي": "SZL",
+        "lilangeni": "SZL",
+        "svazijský lilangeni": "SZL",
+        "λιλανγκένι": "SZL",
+        "swazi lilangeni": "SZL",
+        "svazilanda lilangenio": "SZL",
+        "لیلانگنی سوازی": "SZL",
+        "לילנגני": "SZL",
+        "esvatinijski lilangeni": "SZL",
+        "szváziföldi lilangeni": "SZL",
+        "lilangeni dell'eswatini": "SZL",
+        "リランゲニ": "SZL",
+        "lilangenis": "SZL",
+        "swazische lilangeni": "SZL",
+        "lilanguéni": "SZL",
+        "лилангени": "SZL",
+        "свазілендський ліланґені": "SZL",
+        "lilangeni swaziland": "SZL",
+        "史瓦帝尼里蘭吉尼": "SZL",
+        "بات تايلاندي": "THB",
+        "тайландски бат": "THB",
+        "baht": "THB",
+        "thajský baht": "THB",
+        "thailandske baht": "THB",
+        "μπατ": "THB",
+        "thai baht": "THB",
+        "tajlanda bahto": "THB",
+        "baht tailandés": "THB",
+        "baat": "THB",
+        "thailandiar baht": "THB",
+        "بات تایلند": "THB",
+        "באט": "THB",
+        "tajlandski baht": "THB",
+        "thai bát": "THB",
+        "baht thailandese": "THB",
+        "バーツ": "THB",
+        "tailando batas": "THB",
+        "thaise baht": "THB",
+        "bat": "THB",
+        "тайский бат": "THB",
+        "тајландски бат": "THB",
+        "தாய்லாந்தின் பாட்": "THB",
+        "тайський бат": "THB",
+        "泰銖": "THB",
+        "ساماني طاجيكي": "TJS",
+        "таджикистански сомони": "TJS",
+        "somoni": "TJS",
+        "tádžický somoni": "TJS",
+        "σομόνι": "TJS",
+        "tajikistani somoni": "TJS",
+        "taĝika somonio": "TJS",
+        "somoni tayiko": "TJS",
+        "tadžikistani somoni": "TJS",
+        "سامانی": "TJS",
+        "tadžikistanin somoni": "TJS",
+        "tadžikistanski somoni": "TJS",
+        "tádzsik szomoni": "TJS",
+        "somoni tagiko": "TJS",
+        "ソモニ": "TJS",
+        "somonis": "TJS",
+        "tadzjiekse somoni": "TJS",
+        "somoni tadjik": "TJS",
+        "сомони": "TJS",
+        "таџикистански сомони": "TJS",
+        "таджицький сомоні": "TJS",
+        "塔吉克斯坦索莫尼": "TJS",
+        "النقود المعدنية في تيمور الشرقية": "TLD",
+        "východotimorské centavové mince": "TLD",
+        "münzen osttimors": "TLD",
+        "east timor centavo coins": "TLD",
+        "centavos de dólar de timor oriental": "TLD",
+        "سکه کنتاووی تیمور شرقی": "TLD",
+        "סנתאבוס מזרח טימוריים": "TLD",
+        "istočnotimorski sentavo": "TLD",
+        "kelet timori centavoérmék": "TLD",
+        "centavo est timorense": "TLD",
+        "東ティモール・センターボ": "TLD",
+        "centavos de timor leste": "TLD",
+        "тиморское сентаво": "TLD",
+        "východotimorské obehové mince": "TLD",
+        "східнотиморське сентаво": "TLD",
+        "centavo": "TLD",
+        "منات تركمانستاني": "TMT",
+        "туркменистански манат": "TMT",
+        "manat turcman": "TMT",
+        "turkmenský manat": "TMT",
+        "turkmenistan manat": "TMT",
+        "μανάτ του τουρκμενιστάν": "TMT",
+        "turkmena manato": "TMT",
+        "manat turcomano": "TMT",
+        "منات ترکمنستان": "TMT",
+        "turkmenistanin manat": "TMT",
+        "manat turkmène": "TMT",
+        "manat turcomán": "TMT",
+        "turkmenistanski manat": "TMT",
+        "türkmén manat": "TMT",
+        "manat turkmeno": "TMT",
+        "トルクメニスタン・マナト": "TMT",
+        "turkmėnijos manatas": "TMT",
+        "turkmeense manat": "TMT",
+        "manat turkmeński": "TMT",
+        "manate turcomeno": "TMT",
+        "manat turkmen": "TMT",
+        "туркменский манат": "TMT",
+        "turkménsky manat": "TMT",
+        "turkmenistansk manat": "TMT",
+        "türkmenistan manatı": "TMT",
+        "туркменський манат": "TMT",
+        "土库曼斯坦马纳特": "TMT",
+        "دينار تونسي": "TND",
+        "тунизийски динар": "TND",
+        "dinar tunisià": "TND",
+        "tuniský dinár": "TND",
+        "dinar tiwnisaidd": "TND",
+        "tunesischer dinar": "TND",
+        "tunisian dinar": "TND",
+        "tunizia dinaro": "TND",
+        "dinar tunecino": "TND",
+        "tuneesia dinaar": "TND",
+        "دینار تونس": "TND",
+        "tunisian dinaari": "TND",
+        "dinar tunisien": "TND",
+        "דינר תוניסאי": "TND",
+        "tuniski dinar": "TND",
+        "tunéziai dinár": "TND",
+        "dinaro tunisino": "TND",
+        "チュニジア・ディナール": "TND",
+        "tuniso dinaras": "TND",
+        "tunesische dinar": "TND",
+        "dinar tunezyjski": "TND",
+        "dinar tunisiano": "TND",
+        "тунисский динар": "TND",
+        "tunizijski dinar": "TND",
+        "туниски динар": "TND",
+        "tunisisk dinar": "TND",
+        "tunus dinarı": "TND",
+        "туніський динар": "TND",
+        "突尼斯第納爾": "TND",
+        "بانغا تونغي": "TOP",
+        "paʻanga": "TOP",
+        "tonžská paʻanga": "TOP",
+        "παάνγκα": "TOP",
+        "tongan paʻanga": "TOP",
+        "tonga paangao": "TOP",
+        "پاآنگای تونگا": "TOP",
+        "פאנגה טונגאית": "TOP",
+        "tonška pa’anga": "TOP",
+        "tongai paʻanga": "TOP",
+        "paʻanga tongano": "TOP",
+        "パアンガ": "TOP",
+        "tongos paanga": "TOP",
+        "tongaanse pa'anga": "TOP",
+        "pa'anga": "TOP",
+        "паанга": "TOP",
+        "тонганска панга": "TOP",
+        "тонганська паанга": "TOP",
+        "paʻanga tonga": "TOP",
+        "汤加潘加": "TOP",
+        "ليرة تركية": "TRY",
+        "турска лира": "TRY",
+        "lira turca": "TRY",
+        "turecká lira": "TRY",
+        "lira twrcaidd": "TRY",
+        "tyrkisk lira": "TRY",
+        "türkische lira": "TRY",
+        "τουρκική λίρα": "TRY",
+        "turkish lira": "TRY",
+        "turka liro": "TRY",
+        "türgi liir": "TRY",
+        "turkiar lira": "TRY",
+        "لیره ترک": "TRY",
+        "turkin liira": "TRY",
+        "lire turque": "TRY",
+        "לירה טורקית": "TRY",
+        "turska lira": "TRY",
+        "török líra": "TRY",
+        "トルコリラ": "TRY",
+        "naujoji turkijos lira": "TRY",
+        "turkse lira": "TRY",
+        "lira turecka": "TRY",
+        "liră turcească": "TRY",
+        "турецкая лира": "TRY",
+        "turecká líra": "TRY",
+        "turkisk lira": "TRY",
+        "துருக்கிய லிரா": "TRY",
+        "türk lirası": "TRY",
+        "турецька ліра": "TRY",
+        "lira thổ nhĩ kỳ": "TRY",
+        "土耳其里拉": "TRY",
+        "دولار ترينيداد وتوباغو": "TTD",
+        "долар на тринидад и тобаго": "TTD",
+        "dòlar de trinitat i tobago": "TTD",
+        "dolar trinidadu a tobaga": "TTD",
+        "trinidad und tobago dollar": "TTD",
+        "δολάριο τρινιδάδ και τομπάγκο": "TTD",
+        "trinidad and tobago dollar": "TTD",
+        "trinidada dolaro": "TTD",
+        "dólar trinitense": "TTD",
+        "trinidadi ja tobago dollar": "TTD",
+        "trinidad eta tobagoko dolar": "TTD",
+        "دلار ترینیداد و توباگو": "TTD",
+        "trinidadin ja tobagon dollari": "TTD",
+        "dollar de trinité et tobago": "TTD",
+        "dólar de trinidad e tobago": "TTD",
+        "trinidadtobaški dolar": "TTD",
+        "trinidad és tobagó i dollár": "TTD",
+        "dollaro di trinidad e tobago": "TTD",
+        "トリニダード・トバゴ・ドル": "TTD",
+        "trinidado ir tobago doleris": "TTD",
+        "trinidad en tobagodollar": "TTD",
+        "dolar trynidadu i tobago": "TTD",
+        "доллар тринидада и тобаго": "TTD",
+        "долар тринидада и тобага": "TTD",
+        "trinidaddollar": "TTD",
+        "trinidad ve tobago doları": "TTD",
+        "долар тринідаду і тобаго": "TTD",
+        "特立尼达和多巴哥元": "TTD",
+        "دولار توفالو": "TVD",
+        "dòlar de tuvalu": "TVD",
+        "tuvalský dolar": "TVD",
+        "tuvaluischer dollar": "TVD",
+        "δολάριο τουβαλού": "TVD",
+        "tuvaluan dollar": "TVD",
+        "tuvala dolaro": "TVD",
+        "dólar tuvaluano": "TVD",
+        "دلار تووالوان": "TVD",
+        "tuvalun dollari": "TVD",
+        "dollar tuvaluan": "TVD",
+        "dólar tuvalés": "TVD",
+        "tuvaluski dolar": "TVD",
+        "tuvalui dollár": "TVD",
+        "dollaro di tuvalu": "TVD",
+        "ツバル・ドル": "TVD",
+        "dolar tuvalu": "TVD",
+        "dolar din tuvalu": "TVD",
+        "доллар тувалу": "TVD",
+        "тувалуански долар": "TVD",
+        "tuvaluansk dollar": "TVD",
+        "tuvalu doları": "TVD",
+        "долар тувалу": "TVD",
+        "吐瓦魯元": "TVD",
+        "دولار تايواني جديد": "TWD",
+        "нов тайвански долар": "TWD",
+        "nou dòlar de taiwan": "TWD",
+        "tchajwanský dolar": "TWD",
+        "neuer taiwan dollar": "TWD",
+        "νεο δολάριο ταϊβάν": "TWD",
+        "new taiwan dollar": "TWD",
+        "nova tajvana dolaro": "TWD",
+        "nuevo dólar taiwanés": "TWD",
+        "uus taiwani dollar": "TWD",
+        "دلار جدید تایوان": "TWD",
+        "uusi taiwanin dollari": "TWD",
+        "nouveau dollar de taïwan": "TWD",
+        "novotajvanski dolar": "TWD",
+        "tajvani új dollár": "TWD",
+        "dollaro taiwanese": "TWD",
+        "新台湾ドル": "TWD",
+        "naujasis taivano doleris": "TWD",
+        "taiwanese dollar": "TWD",
+        "dolar tajwański": "TWD",
+        "novo dólar taiwanês": "TWD",
+        "новый тайваньский доллар": "TWD",
+        "нови тајвански долар": "TWD",
+        "taiwanesisk dollar": "TWD",
+        "yeni tayvan doları": "TWD",
+        "новий тайванський долар": "TWD",
+        "tân đài tệ": "TWD",
+        "新臺幣": "TWD",
+        "شيلينغ تانزاني": "TZS",
+        "танзанийски шилинг": "TZS",
+        "xíling tanzà": "TZS",
+        "tanzanský šilink": "TZS",
+        "swllt tansanïa": "TZS",
+        "tansania schilling": "TZS",
+        "tanzanian shilling": "TZS",
+        "tanzania ŝilingo": "TZS",
+        "chelín tanzano": "TZS",
+        "شیلینگ تانزانیا": "TZS",
+        "tansanian šillinki": "TZS",
+        "shilling tanzanien": "TZS",
+        "שילינג טנזני": "TZS",
+        "tanzanijski šiling": "TZS",
+        "tanzániai shilling": "TZS",
+        "scellino tanzaniano": "TZS",
+        "タンザニア・シリング": "TZS",
+        "tanzanijos šilingas": "TZS",
+        "tanzaniaanse shilling": "TZS",
+        "szyling tanzański": "TZS",
+        "xelim tanzaniano": "TZS",
+        "танзанийский шиллинг": "TZS",
+        "tanzánijský šiling": "TZS",
+        "танзанијски шилинг": "TZS",
+        "tanzanisk shilling": "TZS",
+        "tanzanya şilini": "TZS",
+        "танзанійський шилінг": "TZS",
+        "坦尚尼亞先令": "TZS",
+        "هريفنا أوكرانية": "UAH",
+        "украинска гривна": "UAH",
+        "hrívnia": "UAH",
+        "ukrajinská hřivna": "UAH",
+        "ukrainske hryvnia": "UAH",
+        "hrywnja": "UAH",
+        "χρίβνια": "UAH",
+        "ukrainian hryvnia": "UAH",
+        "ukraina hrivno": "UAH",
+        "grivna": "UAH",
+        "ukraina grivna": "UAH",
+        "گریونا اوکراین": "UAH",
+        "ukrainan hryvnia": "UAH",
+        "hryvnia": "UAH",
+        "hrivna": "UAH",
+        "הריבניה": "UAH",
+        "ukrajinska grivnja": "UAH",
+        "ukrán hrivnya": "UAH",
+        "grivnia ucraina": "UAH",
+        "フリヴニャ": "UAH",
+        "grivina": "UAH",
+        "oekraïense grivna": "UAH",
+        "hrywna": "UAH",
+        "grívnia": "UAH",
+        "grivnă": "UAH",
+        "украинская гривна": "UAH",
+        "ukrajinská hrivna": "UAH",
+        "ukrajinska grivna": "UAH",
+        "украјинска гривна": "UAH",
+        "ஹிருன்யா": "UAH",
+        "гривня": "UAH",
+        "hryvnia ukraina": "UAH",
+        "乌克兰格里夫纳": "UAH",
+        "شيلينغ أوغندي": "UGX",
+        "угандийски шилинг": "UGX",
+        "xíling ugandès": "UGX",
+        "ugandský šilink": "UGX",
+        "uganda schilling": "UGX",
+        "σελίνι της ουγκάντας": "UGX",
+        "ugandan shilling": "UGX",
+        "uganda ŝilingo": "UGX",
+        "chelín ugandés": "UGX",
+        "شیلینگ اوگاندا": "UGX",
+        "ugandan šillinki": "UGX",
+        "shilling ougandais": "UGX",
+        "שילינג אוגנדי": "UGX",
+        "ugandski šiling": "UGX",
+        "ugandai shilling": "UGX",
+        "scellino ugandese": "UGX",
+        "ウガンダ・シリング": "UGX",
+        "ugandos šilingas": "UGX",
+        "oegandese shilling": "UGX",
+        "shilling ogandés": "UGX",
+        "szyling ugandyjski": "UGX",
+        "xelim ugandês": "UGX",
+        "угандийский шиллинг": "UGX",
+        "ugandský šiling": "UGX",
+        "угандски шилинг": "UGX",
+        "ugandisk shilling": "UGX",
+        "uganda şilini": "UGX",
+        "угандійський шилінг": "UGX",
+        "烏干達先令": "UGX",
+        "دولار أمريكي": "USD",
+        "щатски долар": "USD",
+        "dòlar dels estats units": "USD",
+        "americký dolar": "USD",
+        "doler yr unol daleithiau": "USD",
+        "amerikanske dollar": "USD",
+        "us dollar": "USD",
+        "δολάριο ηπα": "USD",
+        "united states dollar": "USD",
+        "usona dolaro": "USD",
+        "dólar estadounidense": "USD",
+        "usa dollar": "USD",
+        "estatubatuar dolar": "USD",
+        "دلار آمریکا": "USD",
+        "yhdysvaltain dollari": "USD",
+        "dollar américain": "USD",
+        "דולר אמריקני": "USD",
+        "američki dolar": "USD",
+        "amerikai dollár": "USD",
+        "dollar statounitese": "USD",
+        "dollaro statunitense": "USD",
+        "アメリカ合衆国ドル": "USD",
+        "jungtinių valstijų doleris": "USD",
+        "amerikaanse dollar": "USD",
+        "dolar american": "USD",
+        "dolar amerykański": "USD",
+        "dólar dos estados unidos": "USD",
+        "доллар сша": "USD",
+        "americký dolár": "USD",
+        "ameriški dolar": "USD",
+        "амерички долар": "USD",
+        "amerikansk dollar": "USD",
+        "அமெரிக்க டாலர்": "USD",
+        "amerikan doları": "USD",
+        "долар сша": "USD",
+        "đô la mỹ": "USD",
+        "美元": "USD",
+        "بيزو أوروغواي": "UYU",
+        "уругвайско песо": "UYU",
+        "peso uruguaià": "UYU",
+        "uruguayské peso": "UYU",
+        "uruguayischer peso": "UYU",
+        "uruguayan peso": "UYU",
+        "urugvaja peso": "UYU",
+        "peso uruguayo": "UYU",
+        "peso uruguaitar": "UYU",
+        "پزوی اروگوئه": "UYU",
+        "uruguayn peso": "UYU",
+        "peso uruguayen": "UYU",
+        "peso uruguaio": "UYU",
+        "urugvajski pezo": "UYU",
+        "uruguayi peso": "UYU",
+        "peso uruguaiano": "UYU",
+        "ウルグアイ・ペソ": "UYU",
+        "urugvajaus pesas": "UYU",
+        "uruguayaanse peso": "UYU",
+        "peso urugwajskie": "UYU",
+        "уругвайское песо": "UYU",
+        "уругвајски пезос": "UYU",
+        "uruguayansk peso": "UYU",
+        "uruguay pesosu": "UYU",
+        "уругвайський песо": "UYU",
+        "烏拉圭比索": "UYU",
+        "سوم أوزبكستاني": "UZS",
+        "узбекистански сом": "UZS",
+        "som uzbek": "UZS",
+        "uzbecký sum": "UZS",
+        "soʻm": "UZS",
+        "σομ του ουζμπεκιστάν": "UZS",
+        "uzbekistani soʻm": "UZS",
+        "uzbeka somo": "UZS",
+        "som uzbeko": "UZS",
+        "سوم ازبکستان": "UZS",
+        "uzbekistanin som": "UZS",
+        "sum": "UZS",
+        "סום אוזבקי": "UZS",
+        "uzbekistanski som": "UZS",
+        "üzbég szom": "UZS",
+        "スム": "UZS",
+        "uzbekijos sumas": "UZS",
+        "oezbeekse sum": "UZS",
+        "som uzbec": "UZS",
+        "узбекский сум": "UZS",
+        "uzbekistansk som": "UZS",
+        "özbekistan somu": "UZS",
+        "узбецький сум": "UZS",
+        "乌兹别克斯坦索姆": "UZS",
+        "sovereign bolivar": "VES",
+        "bolívar soberano": "VES",
+        "bolivar souverain": "VES",
+        "venezuelai bolívar": "VES",
+        "ボリバル・ソベラノ": "VES",
+        "суверенный боливар": "VES",
+        "суверенний болівар": "VES",
+        "دونغ فيتنامي": "VND",
+        "виетнамски донг": "VND",
+        "dong": "VND",
+        "vietnamský dong": "VND",
+        "vietnamesischer đồng": "VND",
+        "ντονγκ": "VND",
+        "vietnamese đồng": "VND",
+        "vjetnama dongo": "VND",
+        "đồng vietnamita": "VND",
+        "vietnamdar dong": "VND",
+        "دانگ ویتنام": "VND",
+        "vietnamin đồng": "VND",
+        "vijetnamski dong": "VND",
+        "vietnámi đồng": "VND",
+        "đồng": "VND",
+        "ドン": "VND",
+        "vietnamo dongas": "VND",
+        "vietnamese dong": "VND",
+        "донг": "VND",
+        "вијетнамски донг": "VND",
+        "в'єтнамський донг": "VND",
+        "越南盾": "VND",
+        "فاتو فانواتي": "VUV",
+        "vatu": "VUV",
+        "vanuatský vatu": "VUV",
+        "βάτου": "VUV",
+        "vanuatu vatu": "VUV",
+        "vanuatua vatuo": "VUV",
+        "واتوی وانواتو": "VUV",
+        "vanuatun vatu": "VUV",
+        "ואטו": "VUV",
+        "vanuatski vatu": "VUV",
+        "vanuatui vatu": "VUV",
+        "バツ": "VUV",
+        "vanuatuaanse vatu": "VUV",
+        "вату": "VUV",
+        "вануатски вату": "VUV",
+        "вануатський вату": "VUV",
+        "vatu vanuatu": "VUV",
+        "萬那杜瓦圖": "VUV",
+        "تالا ساموي": "WST",
+        "tala": "WST",
+        "samojská tala": "WST",
+        "samoanischer tala": "WST",
+        "τάλα σαμόα": "WST",
+        "samoan tālā": "WST",
+        "samoa talao": "WST",
+        "tālā": "WST",
+        "samoa tala": "WST",
+        "طلای ساموآ": "WST",
+        "samoan tala": "WST",
+        "tala samoana": "WST",
+        "samoanska tala": "WST",
+        "szamoai tala": "WST",
+        "tala samoano": "WST",
+        "タラ": "WST",
+        "samoaanse tala": "WST",
+        "tala samoan": "WST",
+        "самоанская тала": "WST",
+        "самоанска тала": "WST",
+        "самоанська тала": "WST",
+        "薩摩亞塔拉": "WST",
+        "فرنك وسط أفريقي": "XAF",
+        "централноафрикански cfa франк": "XAF",
+        "franc cfa de l'àfrica central": "XAF",
+        "středoafrický frank": "XAF",
+        "cfa franc beac": "XAF",
+        "φράγκο cfa κεντρικής αφρικής": "XAF",
+        "central african cfa franc": "XAF",
+        "franco cfa de áfrica central": "XAF",
+        "فرانک سیافای آفریقای میانه": "XAF",
+        "franc cfa": [
+            "XOF",
             "XAF"
-        ], 
-        "scellino keniota": [
+        ],
+        "srednjoafrički cfa franak": "XAF",
+        "中央アフリカcfaフラン": "XAF",
+        "franc cfa d'africa centrala": "XAF",
+        "franco cfa da áfrica central": "XAF",
+        "franc cfa beac": "XAF",
+        "франк кфа beac": "XAF",
+        "stredoafrický frank": "XAF",
+        "orta afrika cfa frangı": "XAF",
+        "центральноафриканський франк": "XAF",
+        "franc cfa trung phi": "XAF",
+        "中非金融合作法郎": "XAF",
+        "فضة": "XAG",
+        "сребро": "XAG",
+        "དངུལ།": "XAG",
+        "argent": "XAG",
+        "stříbro": "XAG",
+        "arian": "XAG",
+        "sølv": "XAG",
+        "silber": "XAG",
+        "άργυρος": "XAG",
+        "silver": "XAG",
+        "arĝento": "XAG",
+        "plata": "XAG",
+        "hõbe": "XAG",
+        "zilar": "XAG",
+        "نقره": "XAG",
+        "hopea": "XAG",
+        "prata": "XAG",
+        "כסף": "XAG",
+        "srebro": "XAG",
+        "ezüst": "XAG",
+        "argento": "XAG",
+        "銀": "XAG",
+        "sidabras": "XAG",
+        "zilver": "XAG",
+        "argint": "XAG",
+        "серебро": "XAG",
+        "striebro": "XAG",
+        "வெள்ளி": "XAG",
+        "వెండి": "XAG",
+        "gümüş": "XAG",
+        "срібло": "XAG",
+        "bạc": "XAG",
+        "ذهب": "XAU",
+        "злато": "XAU",
+        "གསེར།": "XAU",
+        "or": "XAU",
+        "zlato": "XAU",
+        "aur": "XAU",
+        "guld": "XAU",
+        "gold": "XAU",
+        "χρυσός": "XAU",
+        "oro": "XAU",
+        "kuld": "XAU",
+        "urre": "XAU",
+        "طلا": "XAU",
+        "kulta": "XAU",
+        "ouro": "XAU",
+        "זהב": "XAU",
+        "arany": "XAU",
+        "auro": "XAU",
+        "金": "XAU",
+        "auksas": "XAU",
+        "goud": "XAU",
+        "złoto": "XAU",
+        "золото": "XAU",
+        "தங்கம்": "XAU",
+        "బంగారం": "XAU",
+        "altın": "XAU",
+        "vàng": "XAU",
+        "بيتكوين": "XBT",
+        "биткойн": "XBT",
+        "bitcoin": "XBT",
+        "bitmono": "XBT",
+        "بیتکوین": "XBT",
+        "ביטקוין": "XBT",
+        "ビットコイン": "XBT",
+        "биткојн": "XBT",
+        "பிட்காயின்": "XBT",
+        "బిట్ కాయిన్": "XBT",
+        "біткоїн": "XBT",
+        "比特币": "XBT",
+        "دولار شرق الكاريبي": "XCD",
+        "източнокарибски долар": "XCD",
+        "dòlar del carib oriental": "XCD",
+        "východokaribský dolar": "XCD",
+        "doler dwyrain y caribî": "XCD",
+        "ostkaribischer dollar": "XCD",
+        "δολάριο ανατολικής καραϊβικής": "XCD",
+        "eastern caribbean dollar": "XCD",
+        "orientkaribia dolaro": "XCD",
+        "dólar del caribe oriental": "XCD",
+        "ekialdeko karibeko dolar": "XCD",
+        "دلار کارائیب شرقی": "XCD",
+        "itä karibian dollari": "XCD",
+        "dollar des caraïbes orientales": "XCD",
+        "dólar do caribe oriental": "XCD",
+        "דולר מזרח קריבי": "XCD",
+        "istočnokaripski dolar": "XCD",
+        "kelet karibi dollár": "XCD",
+        "dollaro dei caraibi orientali": "XCD",
+        "東カリブ・ドル": "XCD",
+        "rytų karibų doleris": "XCD",
+        "oost caribische dollar": "XCD",
+        "dolar wschodniokaraibski": "XCD",
+        "восточнокарибский доллар": "XCD",
+        "vzhodnokaribski dolar": "XCD",
+        "источнокарипски долар": "XCD",
+        "östkaribisk dollar": "XCD",
+        "doğu karayip doları": "XCD",
+        "східнокарибський долар": "XCD",
+        "đô la đông caribe": "XCD",
+        "東加勒比元": "XCD",
+        "حقوق السحب الخاصة": "XDR",
+        "специални права на тираж": "XDR",
+        "drets especials de gir": "XDR",
+        "zvláštní práva čerpání": "XDR",
+        "sonderziehungsrecht": "XDR",
+        "special drawing rights": "XDR",
+        "specialaj rajtoj de enspezo": "XDR",
+        "derechos especiales de giro": "XDR",
+        "erityisnosto oikeus": "XDR",
+        "droits de tirage spéciaux": "XDR",
+        "posebna prava vučenja": "XDR",
+        "sdr": "XDR",
+        "diritti speciali di prelievo": "XDR",
+        "特別引出権": "XDR",
+        "specialiosios skolinimosi teisės": "XDR",
+        "speciale trekkingsrechten": "XDR",
+        "drechs de tiratge especials": "XDR",
+        "specjalne prawa ciągnienia": "XDR",
+        "direitos especiais de saque": "XDR",
+        "drepturi speciale de tragere": "XDR",
+        "специальные права заимствования": "XDR",
+        "zvláštne práva čerpania": "XDR",
+        "posebne pravice črpanja": "XDR",
+        "särskilda dragningsrätter": "XDR",
+        "özel çekme hakları": "XDR",
+        "спеціальні права запозичення": "XDR",
+        "quyền rút vốn đặc biệt": "XDR",
+        "特别提款权": "XDR",
+        "екю": "XEU",
+        "unitat monetària europea": "XEU",
+        "evropská měnová jednotka": "XEU",
+        "european currency unit": "XEU",
+        "europäische währungseinheit": "XEU",
+        "ευρωπαϊκή λογιστική μονάδα": "XEU",
+        "unidad monetaria europea": "XEU",
+        "euroopa valuutaühik": "XEU",
+        "europako kontu unitate": "XEU",
+        "واحد ارزی اروپا": "XEU",
+        "euroopan valuuttayksikkö": "XEU",
+        "ecu": "XEU",
+        "יחידת מטבע אירופית": "XEU",
+        "európai valutaegység": "XEU",
+        "unità di conto europea": "XEU",
+        "欧州通貨単位": "XEU",
+        "ekiu": "XEU",
+        "europese rekeneenheid": "XEU",
+        "unidade monetária europeia": "XEU",
+        "экю": "XEU",
+        "európska menová jednotka": "XEU",
+        "europeiska valutaenheten": "XEU",
+        "avrupa para birimi": "XEU",
+        "欧洲货币单位": "XEU",
+        "مونيرو": "XMR",
+        "монеро": "XMR",
+        "monero": "XMR",
+        "مونرو": "XMR",
+        "מונרו": "XMR",
+        "门罗币": "XMR",
+        "فرنك غرب أفريقي": "XOF",
+        "западноафрикански cfa франк": "XOF",
+        "franc cfa de l'àfrica occidental": "XOF",
+        "cfa franc bceao": "XOF",
+        "φράγκο cfa δυτικής αφρικής": "XOF",
+        "west african cfa franc": "XOF",
+        "franco cfa de áfrica occidental": "XOF",
+        "فرانک سیافای آفریقای غربی": "XOF",
+        "zapadnoafrički cfa franak": "XOF",
+        "西アフリカcfaフラン": "XOF",
+        "franc cfa d'africa occidentala": "XOF",
+        "franco cfa da áfrica ocidental": "XOF",
+        "franc cfa bceao": "XOF",
+        "франк кфа bceao": "XOF",
+        "západoafrický frank": "XOF",
+        "batı afrika cfa frangı": "XOF",
+        "західноафриканський франк": "XOF",
+        "franc cfa tây phi": "XOF",
+        "非洲金融共同体法郎": "XOF",
+        "بالاديوم": "XPD",
+        "паладий": "XPD",
+        "པྰེ་ལེ་ཌིམ།": "XPD",
+        "pal·ladi": "XPD",
+        "palladium": "XPD",
+        "paladiwm": "XPD",
+        "παλλάδιο": "XPD",
+        "paladio": "XPD",
+        "pallaadium": "XPD",
+        "پالادیم": "XPD",
+        "פלדיום": "XPD",
+        "paladij": "XPD",
+        "palládium": "XPD",
+        "palladio": "XPD",
+        "パラジウム": "XPD",
+        "paladis": "XPD",
+        "palladi": "XPD",
+        "pallad": "XPD",
+        "paládio": "XPD",
+        "paladiu": "XPD",
+        "палладий": "XPD",
+        "paládium": "XPD",
+        "паладијум": "XPD",
+        "பலேடியம்": "XPD",
+        "పెల్లేడియం": "XPD",
+        "paladyum": "XPD",
+        "паладій": "XPD",
+        "palađi": "XPD",
+        "钯": "XPD",
+        "فرنك س ف ب": "XPF",
+        "franc cfp": "XPF",
+        "cfp frank": "XPF",
+        "cfp franc": "XPF",
+        "φράγκο cfp": "XPF",
+        "pacifika franko": "XPF",
+        "franco cfp": "XPF",
+        "cfp libera": "XPF",
+        "فرانک اقیانوسیه": "XPF",
+        "cfp frangi": "XPF",
+        "franc pacifique": "XPF",
+        "cfp franak": "XPF",
+        "csendes óceáni valutaközösségi frank": "XPF",
+        "cfpフラン": "XPF",
+        "cfp frankas": "XPF",
+        "frank cfp": "XPF",
+        "тихоокеанский франк": "XPF",
+        "cfp frangı": "XPF",
+        "французький тихоокеанський франк": "XPF",
+        "太平洋法郎": "XPF",
+        "بلاتين": "XPT",
+        "платина": "XPT",
+        "བེ་ལེ་ཊི་ནམ།": "XPT",
+        "platí": "XPT",
+        "platina": "XPT",
+        "platinwm": "XPT",
+        "platin": "XPT",
+        "λευκόχρυσος": "XPT",
+        "platinum": "XPT",
+        "plateno": "XPT",
+        "platino": "XPT",
+        "plaatina": "XPT",
+        "پلاتین": "XPT",
+        "platine": "XPT",
+        "פלטינה": "XPT",
+        "白金": "XPT",
+        "platyna": "XPT",
+        "platină": "XPT",
+        "பிளாட்டினம்": "XPT",
+        "ప్లాటినం": "XPT",
+        "铂": "XPT",
+        "sucre": "XSU",
+        "域内統一決済システム": "XSU",
+        "сукре": "XSU",
+        "ريال اليمن الشمالي": "YER",
+        "ريال يمني": "YER",
+        "йеменски риал": "YER",
+        "rial iemenita": "YER",
+        "jemen rial": "YER",
+        "ριάλ υεμένης": "YER",
+        "north yemeni rial": "YER",
+        "yemeni rial": "YER",
+        "jemena rialo": "YER",
+        "rial de yemen del norte": "YER",
+        "rial yemení": "YER",
+        "ریال یمن": "YER",
+        "ریال یمن شمالی": "YER",
+        "jemenin rial": "YER",
+        "riyal yéménite": "YER",
+        "rial iemení": "YER",
+        "ריאל תימני": "YER",
+        "jemenski rijal": "YER",
+        "jemeni riál": "YER",
+        "riyal yemenita": "YER",
+        "イエメン・リアル": "YER",
+        "jemeno rialas": "YER",
+        "jemenitische rial": "YER",
+        "noord jemenitische rial": "YER",
+        "rial jemeński": "YER",
+        "rial północnojemeński": "YER",
+        "йеменский риал": "YER",
+        "риал северного йемена": "YER",
+        "jemenský rial": "YER",
+        "јеменски ријал": "YER",
+        "jemenitisk rial": "YER",
+        "yemen riyali": "YER",
+        "єменський ріал": "YER",
+        "葉門里亞爾": "YER",
+        "راند جنوب أفريقي": "ZAR",
+        "южноафрикански ранд": "ZAR",
+        "rand": "ZAR",
+        "jihoafrický rand": "ZAR",
+        "südafrikanischer rand": "ZAR",
+        "ραντ": "ZAR",
+        "south african rand": "ZAR",
+        "sudafrika rando": "ZAR",
+        "rand sudafricano": "ZAR",
+        "hegoafrikar rand": "ZAR",
+        "رند آفریقای جنوبی": "ZAR",
+        "etelä afrikan randi": "ZAR",
+        "rand surafricano": "ZAR",
+        "ראנד דרום אפריקאי": "ZAR",
+        "južnoafrički rand": "ZAR",
+        "dél afrikai rand": "ZAR",
+        "ランド": "ZAR",
+        "randas": "ZAR",
+        "zuid afrikaanse rand": "ZAR",
+        "rand sudafrican": "ZAR",
+        "rand sud african": "ZAR",
+        "южноафриканский рэнд": "ZAR",
+        "јужноафрички ранд": "ZAR",
+        "güney afrika randı": "ZAR",
+        "ранд": "ZAR",
+        "南非兰特": "ZAR",
+        "zcash": "ZEC",
+        "زیکش": "ZEC",
+        "كواشا زامبي": "ZMW",
+        "kwacha zambià": "ZMW",
+        "zambijská kwacha": "ZMW",
+        "zambianske kwacha": "ZMW",
+        "sambischer kwacha": "ZMW",
+        "κουάτσα της ζάμπιας": "ZMW",
+        "zambian kwacha": "ZMW",
+        "zambia kvaĉo": "ZMW",
+        "kwacha zambiano": "ZMW",
+        "sambia kvatša": "ZMW",
+        "کواچای زامبیا": "ZMW",
+        "sambian kwacha": "ZMW",
+        "kwacha zambien": "ZMW",
+        "קוואצ'ה זמבי": "ZMW",
+        "zambijska kvača": "ZMW",
+        "zambiai kwacha": "ZMW",
+        "ザンビア・クワチャ": "ZMW",
+        "zambijos kvača": "ZMW",
+        "zambiaanse kwacha": "ZMW",
+        "kwacha zambijska": "ZMW",
+        "замбийская квача": "ZMW",
+        "замбијска квача": "ZMW",
+        "zambisk kwacha": "ZMW",
+        "zambiya kwachası": "ZMW",
+        "замбійська квача": "ZMW",
+        "尚比亞克瓦查": "ZMW",
+        "Аҧ": "ABA",
+        "abcházský apsar": "ABA",
+        "apsar abjasio": "ABA",
+        "аҧ": "ABA",
+        "آپسار": "ABA",
+        "اپسار": "ABA",
+        "اپسار ابخاز": "ABA",
+        "アプサラ": "ABA",
+        "апсар": "ABA",
+        "аҧсар": "ABA",
+        "абхаски апсар": "ABA",
+        "درهم": "AED",
+        "DH": [
+            "MAD",
+            "AED"
+        ],
+        "درهم الإمارات": "AED",
+        "dirham uea": "AED",
+        "dirham de l'uea": "AED",
+        "dirham de la uea": "AED",
+        "dirham de la unió dels emirats àrabs": "AED",
+        "dirham dels eau": "AED",
+        "dirham dels emirats": "AED",
+        "dirham dels emirats àrabs units": "AED",
+        "aed": "AED",
+        "sae dirham": "AED",
+        "dirham sae": "AED",
+        "emirata arabiske dirham": "AED",
+        "uae dirham": "AED",
+        "ντιρχάμ των ηνωμένων αραβικών εμιράτων": "AED",
+        "emirati dirham": "AED",
+        "u.a.e. dirham": "AED",
+        "unuiĝintaj arabaj emirlandoj dirhamo": "AED",
+        "dirham de emiratos arabes unidos": "AED",
+        "dirham de emiratos árabes unidos": "AED",
+        "dirham de los emiratos arabes unidos": "AED",
+        "dirham de los emiratos árabes unidos": "AED",
+        "درهم امارات متحده عربی": "AED",
+        "درهم امارات متحدهٔ عربی": "AED",
+        "arabiemiirikuntien dirhami": "AED",
+        "dirham emirati": "AED",
+        "dirham des emirats arabes unis": "AED",
+        "dirham des émirats": "AED",
+        "verenigde arabische emiraten dirham": "AED",
+        "diram": [
+            "TJS",
+            "AED"
+        ],
+        "dircham": "AED",
+        "dirham dos emirados árabes unidos": "AED",
+        "dirame dos emirados árabes unidos": "AED",
+        "dirame emiradense": "AED",
+        "dirame emiradês": "AED",
+        "dirham dos emirados": "AED",
+        "dirham emiradense": "AED",
+        "dirham emiradês": "AED",
+        "dirham arab emirat": "AED",
+        "валюта объединённых арабских эмиратов": "AED",
+        "дирхам": [
+            "MAD",
+            "AED"
+        ],
+        "уае дирмах": "AED",
+        "அமீரக திர்கம்": "AED",
+        "அமீரக திர்ஹம்": "AED",
+        "யூஏஈ திராம்": "AED",
+        "阿联酋迪尔汗": "AED",
+        "迪拉姆": "AED",
+        "迪爾汗": "AED",
+        "阿聯酋迪拉姆": "AED",
+        "؋": "AFN",
+        "Afs": "AFN",
+        "afghání": "AFN",
+        "afn": "AFN",
+        "af": "AFN",
+        "afg": "AFN",
+        "afgaani": "AFN",
+        "afganistani afgaan": "AFN",
+        "uus afgaani": "AFN",
+        "افغانی افغانستان": "AFN",
+        "afgani afgán": "AFN",
+        "afghani afgano": "AFN",
+        "afghanis": "AFN",
+        "afegani": "AFN",
+        "novo afegani": "AFN",
+        "afgan afgan": "AFN",
+        "афганистанский афгани": "AFN",
+        "афганский афгани": "AFN",
+        "валюта афганистана": "AFN",
+        "afganistanski afgan": "AFN",
+        "авганистански афган": "AFN",
+        "ஆப்கான் ஆப்கானி": "AFN",
+        "阿富汗尼": "AFN",
+        "L": [
+            "MDL",
+            "HNL",
+            "ALL"
+        ],
+        "лек": "ALL",
+        "qindarka": "ALL",
+        "leko": "ALL",
+        "all": "ALL",
+        "lek albanes": "ALL",
+        "albaania lek": "ALL",
+        "lek albanais": "ALL",
+        "アルバニアの通貨": "ALL",
+        "アルバニア・レク": "ALL",
+        "lekas": "ALL",
+        "lekë": "ALL",
+        "lek albanês": "ALL",
+        "lek novo": "ALL",
+        "lek albanez": "ALL",
+        "lekă albaneză": "ALL",
+        "валюта албании": "ALL",
+        "валютный лек": "ALL",
+        "arnavutluk leki": "ALL",
+        "درام": "AMD",
+        "֏": "AMD",
+        "dram armenia": "AMD",
+        "armensk dram": "AMD",
+        "amd": "AMD",
+        "armeenia drahm": "AMD",
+        "armeenia dram": "AMD",
+        "dramm": "AMD",
+        "dram arménien": "AMD",
+        "armenijski dram": "AMD",
+        "dramas": "AMD",
+        "dram armeński": "AMD",
+        "dram karabachski": "AMD",
+        "dram armênio": "AMD",
+        "dram da arménia": "AMD",
+        "dram da armênia": "AMD",
+        "drame arménio": "AMD",
+        "dram armean": "AMD",
+        "валюта армении": "AMD",
+        "драм": [
+            "NKD",
+            "AMD"
+        ],
+        "ஆர்மீனிய டிராம்": "AMD",
+        "ermenistan dramı": "AMD",
+        "CMg": "ANG",
+        "fiorino caraibico": "ANG",
+        "加勒比盾": "ANG",
+        "ƒ": [
+            "AWG",
+            "ANG"
+        ],
+        "NAƒ": "ANG",
+        "ang": "ANG",
+        "naf": "ANG",
+        "naƒ": "ANG",
+        "f": "ANG",
+        "florin antillano neerlandes": "ANG",
+        "גילדן אנטילי": "ANG",
+        "Kz": "AOA",
+        "kwanza reajustado": "AOA",
+        "lwei": "AOA",
+        "novo kwanza": "AOA",
+        "κβάνζα": "AOA",
+        "aoa": "AOA",
+        "kz": "AOA",
+        "קואנזה": "AOA",
+        "kwanza angolana": "AOA",
+        "アンゴラ・クワンザ": "AOA",
+        "валюта анголы": "AOA",
+        "восстановленная кванза": "AOA",
+        "кванза": "AOA",
+        "кванза ангольская": "AOA",
+        "кванза реюстадо": "AOA",
+        "новая кванза": "AOA",
+        "скорректированная кванза": "AOA",
+        "анголска нова кванза": "AOA",
+        "kwansa": "AOA",
+        "அங்கோலா குவான்சா": "AOA",
+        "angola kwanzası": "AOA",
+        "安哥拉寬扎": "AOA",
+        "寬扎": "AOA",
+        "$": [
+            "XCD",
+            "WST",
+            "USD",
+            "TWD",
+            "TVD",
+            "TTD",
+            "SRD",
+            "SGD",
+            "SBD",
+            "PND",
+            "NZD",
+            "NUD",
+            "NAD",
+            "MXN",
+            "MOP",
+            "LRD",
+            "KYD",
+            "KID",
+            "JMD",
+            "HKD",
+            "GYD",
+            "FJD",
+            "CUP",
+            "COP",
+            "CLP",
+            "CKD",
+            "CAD",
+            "BZD",
+            "BSD",
+            "BRL",
+            "BND",
+            "BMD",
+            "BBD",
+            "AUD",
+            "ARS",
+            "ARG"
+        ],
+        "o$s": "ARG",
+        "ars": "ARS",
+        "peso d'argentina": "ARS",
+        "peso de l'argentina": "ARS",
+        "pesos argentins": "ARS",
+        "arg$": "ARS",
+        "peso ley": "ARS",
+        "peso moneda nacional": "ARS",
+        "pesos argentinos": "ARS",
+        "nuevo peso argentino": "ARS",
+        "peso convertible": "ARS",
+        "peso convertible argentino": "ARS",
+        "peso de argentina": "ARS",
+        "peso dolar": "ARS",
+        "peso dólar": "ARS",
+        "argentinar peso": "ARS",
+        "nuevo peso": [
+            "UYU",
+            "ARS"
+        ],
+        "pesification": "ARS",
+        "פזו ארגנטינאי": "ARS",
+        "פסו ארגנטיני": "ARS",
+        "argentinski peso": "ARS",
+        "nuovo peso argentino": "ARS",
+        "peso da argentina": "ARS",
+        "валюта аргентины": "ARS",
+        "песо": [
+            "UYU",
+            "PHP",
+            "MXN",
+            "DOP",
+            "CUP",
+            "COP",
+            "CLP",
+            "ARS"
+        ],
+        "аргентински песо": "ARS",
+        "аргентинське песо": "ARS",
+        "ars$": "ARS",
+        "阿根廷披索": "ARS",
+        "阿根廷皮索": "ARS",
+        "A$": "AUD",
+        "a$": "AUD",
+        "au$": "AUD",
+        "aud": "AUD",
+        "aussie dollar": "AUD",
+        "dollar": [
+            "USD",
+            "SGD",
+            "NZD",
+            "HKD",
+            "FJD",
+            "CAD",
+            "AUD"
+        ],
+        "dollars": [
+            "USD",
+            "SGD",
+            "NZD",
+            "HKD",
+            "CAD",
+            "AUD"
+        ],
+        "aŭ$": "AUD",
+        "dolar australiano": "AUD",
+        "валюта австралии": "AUD",
+        "валюта кирибати": "AUD",
+        "валюта науру": "AUD",
+        "валюта норфолка": "AUD",
+        "валюта тувалу": "AUD",
+        "доллар": [
+            "WST",
+            "USD",
+            "TVD",
+            "TTD",
+            "SRD",
+            "SBD",
+            "PND",
+            "NZD",
+            "NUD",
+            "NAD",
+            "KYD",
+            "KID",
+            "JMD",
+            "HKD",
+            "FJD",
+            "CKD",
+            "CAD",
+            "BZD",
+            "BSD",
+            "AUD"
+        ],
+        "доллар австралии": "AUD",
+        "அவுத்திரேலிய வெள்ளி": "AUD",
+        "அவுத்திரேலிய டொலர்": "AUD",
+        "ஆத்திரேலிய டொலர்": "AUD",
+        "ஆத்திரேலிய வெள்ளி": "AUD",
+        "ஆஸ்திரேலிய டொலர்": "AUD",
+        "AU$": "AUD",
+        "AUD": "AUD",
+        "florí d’aruba": "AWG",
+        "arubský gulden": "AWG",
+        "afl.": "AWG",
+        "aruba gulden": "AWG",
+        "awg": "AWG",
+        "florin arubeno": "AWG",
+        "florin arubeño": "AWG",
+        "florín arubeno": "AWG",
+        "aruba kulden": "AWG",
+        "florin arubain": "AWG",
+        "florin d'aruba": "AWG",
+        "florin d’aruba": "AWG",
+        "פלורין ארובה": "AWG",
+        "arupski gulden": "AWG",
+        "fiorino di aruba": "AWG",
+        "アルバフロリン": "AWG",
+        "アルバ・フローリン": "AWG",
+        "arubos guldenas": "AWG",
+        "arubaanse florijn": "AWG",
+        "arubaanse gulden": "AWG",
+        "florim de aruba": "AWG",
+        "арубанский гульден": "AWG",
+        "валюта арубы": "AWG",
+        "арупски флорин": "AWG",
+        "arubas florin": "AWG",
+        "அரூபா ஃபுளோரின்": "AWG",
+        "арубський флорін": "AWG",
+        "£": [
+            "SYP",
+            "SSP",
+            "SHP",
+            "SDG",
+            "LBP",
+            "JEP",
+            "IMP",
+            "GIP",
+            "GGP",
+            "GBP",
+            "FKP",
+            "EGP",
+            "AYP"
+        ],
+        "alderneja pundo": "AYP",
+        "libra de alderney": "AYP",
+        "オルダニー・ポンド": "AYP",
+        "фунт острова олдерни": "AYP",
+        "фунт": [
+            "SSP",
+            "SHP",
+            "JEP",
+            "IMP",
+            "GBP",
+            "FKP",
+            "EGP",
+            "AYP"
+        ],
+        "مانات": "AZN",
+        "₼": "AZN",
+        "manat d'azerbaidjan": "AZN",
+        "manat de l'azerbaidjan": "AZN",
+        "manat àzeri": "AZN",
+        "ruble azerbaidjanès": "AZN",
+        "manat aserbaijan": "AZN",
+        "aserbajdsjansk manat": "AZN",
+        "azn": "AZN",
+        "aserbaidschanischer manat": "AZN",
+        "gepik": "AZN",
+        "qäpik": "AZN",
+        "qəpik": "AZN",
+        "manat azeri": "AZN",
+        "manat azerí": "AZN",
+        "manat azerbaijandar": "AZN",
+        "منات جمهوری آذربایجان": "AZN",
+        "منات جمهوری اذربایجان": "AZN",
+        "manat azéri": "AZN",
+        "nouveau manat azéri": "AZN",
+        "manat azarí": "AZN",
+        "manat de acerbaixán": "AZN",
+        "azerbejdžanski manat": "AZN",
+        "azm": "AZN",
+        "manat azerski": "AZN",
+        "manat azerbaijano": "AZN",
+        "manat azerbaijanês": "AZN",
+        "manat do azerbaijão": "AZN",
+        "novo manat": "AZN",
+        "aym": "AZN",
+        "валюта азербайджана": "AZN",
+        "манат азербайджанский": "AZN",
+        "манат": [
+            "TMT",
+            "AZN"
+        ],
+        "அசர்பைச்சானிய மனாத்து": "AZN",
+        "azerbaycan yeni manatı": "AZN",
+        "yeni manat": "AZN",
+        "亞賽拜然馬納特": "AZN",
+        "A.M.": "AZN",
+        "KM": "BAM",
+        "bosenská konvertibilní marka": "BAM",
+        "mark cyfnewidiol": "BAM",
+        "bosnisch herzegowinische konvertible mark": "BAM",
+        "fening": "BAM",
+        "feninga": "BAM",
+        "μετατρέψιμο μάρκο": "BAM",
+        "convertible mark": "BAM",
+        "bam": "BAM",
+        "km": "BAM",
+        "marka convertible": "BAM",
+        "marco bosnio": "BAM",
+        "mark convertible": "BAM",
+        "mark convertible bosniaque": "BAM",
+        "marka": "BAM",
+        "המרק הסחיר": "BAM",
+        "bosna i hercegovina konvertibilna marka": "BAM",
+        "mark convertibile de bosnia herzegovina": "BAM",
+        "marco convertibile": "BAM",
+        "ボスニア・ヘルツェゴビナ・マルカ": "BAM",
+        "ボスニア・マルカ": "BAM",
+        "bosnijos ir hercegovinos markė": "BAM",
+        "bosnische convertibele mark": "BAM",
+        "bosnische konvertibilna marka": "BAM",
+        "marka de bòsnia e ercegovina": "BAM",
+        "marka konwertybilna": "BAM",
+        "marka transferowa": "BAM",
+        "marco convertível": "BAM",
+        "marca convertibilă a bosniei şi herţegovinei": "BAM",
+        "marca convertibilă a bosniei și herțegovinei": "BAM",
+        "marca bosniacă convertibilă": "BAM",
+        "marcă convertibilă a bosniei şi herţegovinei": "BAM",
+        "marcă convertibilă a bosniei și herțegovinei": "BAM",
+        "боснийская конвертируемая марка": "BAM",
+        "боснийская марка": "BAM",
+        "валюта боснии и герцеговины": "BAM",
+        "конвертируемая марка боснии и герцеговины": "BAM",
+        "марка": "BAM",
+        "konvertibilna marka bosne in hercegovine": "BAM",
+        "босанскохерцеговачка конвертибилна марка": "BAM",
+        "км": "BAM",
+        "конвертабилна марка": "BAM",
+        "konvertibel mark": "BAM",
+        "konvertibla mark": "BAM",
+        "கன்வர்டிபிள் மார்க்கு": "BAM",
+        "பொசுனியா எர்செகோவினா கன்வர்டிபிள் மார்க்": "BAM",
+        "பொஸ்னியா ஹெர்செகோவினா கன்வர்டிபிள் மார்க்": "BAM",
+        "konvertibıl mark": "BAM",
+        "конвертована марка": "BAM",
+        "可兑换马克": "BAM",
+        "波斯尼亞黑塞哥維那可兌換馬克": "BAM",
+        "الدولار البربادوسي": "BBD",
+        "Bds$": "BBD",
+        "bbd": "BBD",
+        "bds$": "BBD",
+        "δολάριο των μπαρμπάντος": "BBD",
+        "dolar de barbados": "BBD",
+        "dolar barbadense": "BBD",
+        "dollar de la barbade": "BBD",
+        "dollaro": [
+            "BZD",
+            "BBD"
+        ],
+        "dollaro delle barbados": "BBD",
+        "dólar barbadiano": "BBD",
+        "dólar dos barbados": "BBD",
+        "валюта барбадоса": "BBD",
+        "долар барбадоса": "BBD",
+        "பார்படோஸ் டாலர்": "BBD",
+        "৳": "BDT",
+        "така": "BDT",
+        "bdt": [
+            "BTN",
+            "BDT"
+        ],
+        "lakhs": "BDT",
+        "poisha": "BDT",
+        "ṭākā": "BDT",
+        "τάκα": "BDT",
+        "taka bangladeshi": "BDT",
+        "taka bangladeshí": "BDT",
+        "taka bangladesi": "BDT",
+        "טאקה": "BDT",
+        "taka bengalska": "BDT",
+        "валюта бангладеш": "BDT",
+        "bangladéšska taka": "BDT",
+        "৲": "BDT",
+        "塔卡": "BDT",
+        "ليف بلغارية": "BGN",
+        "лв.": "BGN",
+        "bgj": "BGN",
+        "bgk": "BGN",
+        "bgl": "BGN",
+        "bgn": "BGN",
+        "българския лев": "BGN",
+        "лев": "BGN",
+        "levo": "BGN",
+        "bulgarsk lev": "BGN",
+        "bulgarischer lew": "BGN",
+        "stotinka": "BGN",
+        "stotinki": "BGN",
+        "bulgaria levo": "BGN",
+        "nova bulgara levo": "BGN",
+        "לב בולגרי": "BGN",
+        "ブルガリア・レフ": "BGN",
+        "lev da bulgária": "BGN",
+        "lev bulgar": "BGN",
+        "leva bulgară": "BGN",
+        "levă bulgară": "BGN",
+        "валюта болгарии": "BGN",
+        "лев болгарский": "BGN",
+        "bulgarisk lev": "BGN",
+        "bulgariska lev": "BGN",
+        "bulgariska leva": "BGN",
+        "பல்காரிய லெவ்": "BGN",
+        "bulgar levası": "BGN",
+        "bulgar levi": "BGN",
+        "лв": "BGN",
+        "الدينار البحريني": "BHD",
+        "BD": "BHD",
+        "δηνάριο του μπαχρέιν": "BHD",
+        "bhd": "BHD",
+        "dinar bahraini": "BHD",
+        "dinar bahrainí": "BHD",
+        "dinar bahreini": "BHD",
+        "dinar bahreiní": "BHD",
+        "dinar bareini": "BHD",
+        "dinar de bahrein": "BHD",
+        "dinar de barein": "BHD",
+        "dinar de baréin": "BHD",
+        "dinar bahreïnien": "BHD",
+        "dinar de bahreïn": "BHD",
+        "dinar du bahreïn": "BHD",
+        "dinaro del bahrain": "BHD",
+        "dinaro": "BHD",
+        "dinar de bahrayn": "BHD",
+        "dinar bahrajnu": "BHD",
+        "denar bareinita": "BHD",
+        "denar baremense": "BHD",
+        "denar baremita": "BHD",
+        "denar baremês": "BHD",
+        "denar barenita": "BHD",
+        "dinar baremense": "BHD",
+        "dinar baremita": "BHD",
+        "dinar baremês": "BHD",
+        "dinar barenita": "BHD",
+        "dinar do bahrein": "BHD",
+        "валюта бахрейна": "BHD",
+        "динар": [
+            "TND",
+            "RSD",
+            "LYD",
+            "KWD",
+            "IQD",
+            "DZD",
+            "BHD"
+        ],
+        "динар бахрейна": "BHD",
+        "பஹ்ரேன் தினார்": "BHD",
+        "فرنك بروندي": "BIF",
+        "FBu": "BIF",
+        "fbu": "BIF",
+        "φράγκο του μπουρούντι": "BIF",
+        "bif": "BIF",
+        "franco burundes": "BIF",
+        "פרנק בורונדי": "BIF",
+        "franco do burúndi": "BIF",
+        "franco burundiano": "BIF",
+        "franco burundinense": "BIF",
+        "franco burundinês": "BIF",
+        "franco de burundi": "BIF",
+        "franc burundez": "BIF",
+        "валюта бурунди": "BIF",
+        "франк": [
+            "XPF",
+            "XOF",
+            "RWF",
+            "CDF",
+            "BIF"
+        ],
+        "франк бурунди": "BIF",
+        "BD$": "BMD",
+        "dòlar de bermuda": "BMD",
+        "dòlar de les illes bermudes": "BMD",
+        "bd$": "BMD",
+        "δολάριο των βερμούδων": "BMD",
+        "bmd": "BMD",
+        "dolar bermudeno": "BMD",
+        "dolar bermudeño": "BMD",
+        "dolar de bermuda": "BMD",
+        "dolar de bermudas": "BMD",
+        "dólar bermudeno": "BMD",
+        "dólar de bermuda": "BMD",
+        "dólar de bermudas": "BMD",
+        "dollar des bermudes": "BMD",
+        "דולר ברמודה ": "BMD",
+        "dollaro delle bermuda": "BMD",
+        "dollaro delle bermude": "BMD",
+        "валюта бермуд": "BMD",
+        "பெர்முடா டாலர்": "BMD",
+        "B$": [
+            "BSD",
+            "BND"
+        ],
+        "b$": [
+            "BSD",
+            "BND"
+        ],
+        "br$": "BND",
+        "δολάριο μπρουνέι": "BND",
+        "bnd": "BND",
+        "dolar bruneano": "BND",
+        "dolar de brunei": "BND",
+        "dolar de brunéi": "BND",
+        "dólar bruneano": "BND",
+        "dollar de brunéi": "BND",
+        "ringgit brunei": "BND",
+        "ブルネイドル": "BND",
+        "dolar brunei": "BND",
+        "dólar bruneíno": "BND",
+        "dólar do brunei": "BND",
+        "валюта брунея": "BND",
+        "bruney doları": "BND",
+        "dollar brunei": "BND",
+        "البوليفاريو": "BOB",
+        "Bs": "BOB",
+        "بوليفاريو": "BOB",
+        "bolivianos": "BOB",
+        "bolivià": "BOB",
+        "bolivianischer boliviano": "BOB",
+        "bob": "BOB",
+        "bolivjano": "BOB",
+        "bs": [
+            "BSD",
+            "BOB"
+        ],
+        "bs.": "BOB",
+        "boliviano bolivien": "BOB",
+        "bolivijski boliviano": "BOB",
+        "боливийский боливиано": "BOB",
+        "валюта боливии": "BOB",
+        "боливијано": "BOB",
+        "боливски боливијано": "BOB",
+        "பொலிவியானோ": "BOB",
+        "பொலிவிய பொலிவியானோ": "BOB",
+        "bolivya bolivianosu": "BOB",
+        "болівіано": "BOB",
+        "玻利維亞諾": "BOB",
+        "boliviano con mantenimiento de valor respecto al dolar estadounidense": "BOV",
+        "R$": "BRL",
+        "r$": "BRL",
+        "brl": "BRL",
+        "reais": "BRL",
+        "realoj": "BRL",
+        "rs": "BRL",
+        "real brasileno": "BRL",
+        "brasildar real": "BRL",
+        "رئال": "BRL",
+        "real bresilien": "BRL",
+        "réal": "BRL",
+        "réaux brésiliens": "BRL",
+        "ヘアウ": "BRL",
+        "real brazilian": "BRL",
+        "валюта бразилии": "BRL",
+        "реал бразильский": "BRL",
+        "бразилски рејал": "BRL",
+        "பிரசிலியன் ரியால்": "BRL",
+        "ரியால்": "BRL",
+        "бразiльський ріал": "BRL",
+        "бразильський ріал": "BRL",
+        "бразільський ріал": "BRL",
+        "巴西雷亞爾": "BRL",
+        "巴西貨幣": "BRL",
+        "巴西雷阿爾": "BRL",
+        "瑞亞爾": "BRL",
+        "雷亞爾": "BRL",
+        "黑奧": "BRL",
+        "الدولار البهامي": "BSD",
+        "dòlar de bahames": "BSD",
+        "bahamas dollar": "BSD",
+        "bsd": "BSD",
+        "bs$": "BSD",
+        "dolar bahameno": "BSD",
+        "dolar bahames": "BSD",
+        "dolar bahameño": "BSD",
+        "dolar bahamés": "BSD",
+        "dolar de bahamas": "BSD",
+        "dolar de las bahamas": "BSD",
+        "dólar bahameno": "BSD",
+        "dólar bahames": "BSD",
+        "dólar de bahamas": "BSD",
+        "dólar de las bahamas": "BSD",
+        "dollaro bahamense": "BSD",
+        "dólar baamense": "BSD",
+        "dólar baamês": "BSD",
+        "dólar bahamense": "BSD",
+        "dólar bahamiano": "BSD",
+        "dólar bahamês": "BSD",
+        "dólar das baamas": "BSD",
+        "dólar das bahamas": "BSD",
+        "валюта багамских островов": "BSD",
+        "பஹ்மானிய டாலர்": "BSD",
+        "نجولترم": "BTN",
+        "Nu": "BTN",
+        "نغولترم": "BTN",
+        "نولتوم": "BTN",
+        "nglultrum": "BTN",
+        "ngultrum bhutanès": "BTN",
+        "νγκούλντρουμ": "BTN",
+        "btn": "BTN",
+        "bhutan currency": "BTN",
+        "ngultrumo": "BTN",
+        "ngultrum butanes": "BTN",
+        "chetrum": "BTN",
+        "נגולטורם": "BTN",
+        "ブータン・ルピー": "BTN",
+        "бутанский нгултрум": "BTN",
+        "валюта бутана": "BTN",
+        "努尔特鲁姆": "BTN",
+        "努爾特魯姆": "BTN",
+        "بوتسوانا بولا": "BWP",
+        "P": "BWP",
+        "пула": "BWP",
+        "botsuanischer pula": "BWP",
+        "bwp": "BWP",
+        "pula de botsuana": "BWP",
+        "thebe": "BWP",
+        "botswanan pula": "BWP",
+        "pula botswanais": "BWP",
+        "pula de botswana": "BWP",
+        "ボツワナ・プラ": "BWP",
+        "pula do botsuana": "BWP",
+        "pula botswaniană": "BWP",
+        "pula, unitate monetară": "BWP",
+        "валюта ботсваны": "BWP",
+        "botswansk pula": "BWP",
+        "போட்ஸ்வானா பூலா": "BWP",
+        "الروبل البلاروسي": "BYN",
+        "Br": [
+            "ETB",
+            "BYN"
+        ],
+        "ruble de bielorússia": "BYN",
+        "byr": "BYN",
+        "hviderussisk rubel": "BYN",
+        "belarus rubel": "BYN",
+        "belarussischer rubel": "BYN",
+        "weissrussischer rubel": "BYN",
+        "ρούβλι λευκορωσίας": "BYN",
+        "belarusia rublo": "BYN",
+        "belorusa rublo": "BYN",
+        "belarusa rublo": "BYN",
+        "rublo de belarus": "BYN",
+        "rublo de belarús": "BYN",
+        "rublo de bielorrusia": "BYN",
+        "rouble bielorusse": "BYN",
+        "רובל בלרוסי": "BYN",
+        "bjeloruska rublja": "BYN",
+        "rublo bielorusse": "BYN",
+        "rublo": "BYN",
+        "robla bielorussa": "BYN",
+        "rublo da bielorrússia": "BYN",
+        "rubla belarusă": "BYN",
+        "rubla bielorusă": "BYN",
+        "rublă bielorusă": "BYN",
+        "byb": "BYN",
+        "byl": "BYN",
+        "валюта белоруссии": "BYN",
+        "расчётный рубль белоруссии": "BYN",
+        "бел руб": "BYN",
+        "зайчик": "BYN",
+        "рубль": [
+            "RUB",
+            "PRB",
+            "BYN"
+        ],
+        "беларускі рубель": "BYN",
+        "бјелоруска рубља": "BYN",
+        "beyaz rusya rublesi": "BYN",
+        "білоруський рубль": "BYN",
+        "Bz$": "BZD",
+        "bz$": "BZD",
+        "bzd": "BZD",
+        "doler": [
+            "CAD",
+            "BZD"
+        ],
+        "δολάριο μπελίζε": "BZD",
+        "δολάριο του μπελίζε": "BZD",
+        "dolar beliceno": "BZD",
+        "dolar beliceño": "BZD",
+        "dolar de belice": "BZD",
+        "dolar de belize": "BZD",
+        "dólar beliceno": "BZD",
+        "dólar de belice": "BZD",
+        "dollar de belize": "BZD",
+        "dollar du belize": "BZD",
+        "dollar du bélize": "BZD",
+        "דולר בליזאי": "BZD",
+        "belizeanski dolar": "BZD",
+        "dolar belize": "BZD",
+        "dólar belizenho": "BZD",
+        "dólar belizense": "BZD",
+        "dólar do belize": "BZD",
+        "валюта белиза": "BZD",
+        "доллар белиза": "BZD",
+        "белизе долар": "BZD",
+        "белиски долар": "BZD",
+        "பெலலீசு டாலர்": "BZD",
+        "белізський долар": "BZD",
+        "الدولار الكندي": "CAD",
+        "dòlar de canadà": "CAD",
+        "dòlar del canadà": "CAD",
+        "dòlars canadencs": "CAD",
+        "c$": [
+            "NIO",
+            "CAD"
+        ],
+        "canadisk dollar": "CAD",
+        "can$": "CAD",
+        "canadischer dollar": "CAD",
+        "kanadische dollar": "CAD",
+        "loonie": "CAD",
+        "καναδικό δολάριο": "CAD",
+        "δολάρριο καναδά": "CAD",
+        "καναδικό δολλάριο": "CAD",
+        "ca$": "CAD",
+        "cad": "CAD",
+        "dolar canadiense": "CAD",
+        "moneda canadiense": "CAD",
+        "kanadar dolar": "CAD",
+        "$ ca": "CAD",
+        "$ can": "CAD",
+        "$can": "CAD",
+        "$ca": "CAD",
+        "dollars canadiens": "CAD",
+        "huard canadien": "CAD",
+        "monnaie canadienne": "CAD",
+        "カナダ・ドル": "CAD",
+        "加ドル": "CAD",
+        "dólar canadiano": "CAD",
+        "dólar do canadá": "CAD",
+        "dólares canadenses": "CAD",
+        "moeda canadaense": "CAD",
+        "валюта канады": "CAD",
+        "доллар канады": "CAD",
+        "canadadollar": "CAD",
+        "kanadadollar": "CAD",
+        "kanadensiska dollar": "CAD",
+        "கனடா டாலர்": "CAD",
+        "கனடிய டாலர்": "CAD",
+        "கனேடிய டாலர்": "CAD",
+        "கனேடிய டொலர்": "CAD",
+        "cdn": "CAD",
+        "canada dollar": "CAD",
+        "dollar canada": "CAD",
+        "cad$": "CAD",
+        "加元": "CAD",
+        "加幣": "CAD",
+        "C$": [
+            "NIO",
+            "CAD"
+        ],
+        "CAD$": "CAD",
+        "¢": "CAD",
+        "CF": [
+            "KMF",
+            "CDF"
+        ],
+        "franc del congo": "CDF",
+        "franc del congo belga": "CDF",
+        "ffranc y congo": "CDF",
+        "belgian congolese franc": "CDF",
+        "cdf": "CDF",
+        "franco": [
+            "XPF",
+            "XAF",
+            "RWF",
+            "DJF",
+            "CDF"
+        ],
+        "franco congoles": "CDF",
+        "פרנק קונגיני": "CDF",
+        "zaïre": "CDF",
+        "franc congolés": "CDF",
+        "franco congolense": "CDF",
+        "franco conguês": "CDF",
+        "franco da república democrática do congo": "CDF",
+        "franco do congo": "CDF",
+        "franco do congo kinshasa": "CDF",
+        "franco do congo quinxasa": "CDF",
+        "валюта демократической республики конго": "CDF",
+        "франк бельгийского конго": "CDF",
+        "франк дрк": "CDF",
+        "kongo frankı": "CDF",
+        "الفرنك السويسري": "CHF",
+        "Fr": "CHF",
+        "chf": "CHF",
+        "franc de suïssa": "CHF",
+        "francs suïssos": "CHF",
+        "franc swisaidd": "CHF",
+        "rappen": "CHF",
+        "schweizerfranc": "CHF",
+        "confœderatio helvetica franc": "CHF",
+        "sfr": "CHF",
+        "sfr.": "CHF",
+        "schweizerfranken": "CHF",
+        "φράγκο ελβετίας": "CHF",
+        "franc": "CHF",
+        "swiss frank": "CHF",
+        "swiss franken": "CHF",
+        "swiss franco": "CHF",
+        "swiss francs": "CHF",
+        "s₣": "CHF",
+        "svisaj frankoj": "CHF",
+        "francos suizos": "CHF",
+        "suitzar libera": "CHF",
+        "suitzako libera": "CHF",
+        "francs suisse": "CHF",
+        "francs suisses": "CHF",
+        "franc switze": "CHF",
+        "franchi svizzeri": "CHF",
+        "スイスの通貨": "CHF",
+        "スイスフラン": "CHF",
+        "リヒテンシュタインの通貨": "CHF",
+        "zwitserse franc": "CHF",
+        "franco da suíça": "CHF",
+        "franco suiço": "CHF",
+        "francos suíços": "CHF",
+        "franc elveţian": "CHF",
+        "валюта лихтенштейна": "CHF",
+        "валюта швейцарии": "CHF",
+        "schweiziska franc": "CHF",
+        "சுவிஸ் ஃபிராங்க்": "CHF",
+        "சுவிஸ் பிராங்க்": "CHF",
+        "i̇sviçre frankı": "CHF",
+        "瑞朗": "CHF",
+        "瑞郎": "CHF",
+        "cookinsel dollar": "CKD",
+        "dolar de las islas cook": "CKD",
+        "クック諸島ドル": "CKD",
+        "クックアイランド・ドル": "CKD",
+        "cookeilandendollar": "CKD",
+        "UF": "CLF",
+        "clf": "CLF",
+        "uf": "CLF",
+        "ウニダ・デ・フォメント": "CLF",
+        "بيسو تشيلي": "CLP",
+        "CLP$": "CLP",
+        "pes xilè": "CLP",
+        "peso de xile": "CLP",
+        "chil$": "CLP",
+        "cl$": "CLP",
+        "clp": "CLP",
+        "clp$": "CLP",
+        "clps": "CLP",
+        "پسو شیلی": "CLP",
+        "čileanski peso": "CLP",
+        "チリの通貨": "CLP",
+        "peso do chile": "CLP",
+        "валюта чили": "CLP",
+        "чилийский песо": "CLP",
+        "čilenski pezo": "CLP",
+        "čilski peso": "CLP",
+        "čilski pezo": "CLP",
+        "чилеански песо": "CLP",
+        "чилійське песо": "CLP",
+        "智利披索": "CLP",
+        "cnh": "CNH",
+        "¥": [
+            "JPY",
+            "CNY",
+            "CNH"
+        ],
+        "chinese yuan": [
+            "CNY",
+            "CNH"
+        ],
+        "yuan offshore": "CNH",
+        "cny": "CNY",
+        "rmb": "CNY",
+        "юан": "CNY",
+        "iuan renminbi": "CNY",
+        "iuan xinès": "CNY",
+        "žen min pi": "CNY",
+        "chinesischer renminbi": "CNY",
+        "renminbi yuan": "CNY",
+        "元": [
+            "HKD",
+            "CNY"
+        ],
+        "ρενμίνμπι": "CNY",
+        "ĉina juano": "CNY",
+        "yuan chino": "CNY",
+        "yuán chino": "CNY",
+        "argent chinois": "CNY",
+        "yuans": "CNY",
+        "ז'נמינבי": "CNY",
+        "יו'אן": "CNY",
+        "יואן": "CNY",
+        "יואן סיני": "CNY",
+        "kínai jüan": "CNY",
+        "zsenminpi": "CNY",
+        "yuan cinese": "CNY",
+        "人民幣": "CNY",
+        "中国元": "CNY",
+        "中華人民共和国の通貨": "CNY",
+        "renmibi": "CNY",
+        "ženminbi juanis": "CNY",
+        "iuan": "CNY",
+        "iuan renmimbi": "CNY",
+        "iuane": "CNY",
+        "iuane renminbi": "CNY",
+        "iuã": "CNY",
+        "yuan renmimbi": "CNY",
+        "fen": "CNY",
+        "jiao": "CNY",
+        "yuan chinezesc": "CNY",
+        "валюта кнр": "CNY",
+        "валюта китая": "CNY",
+        "женьминби": "CNY",
+        "женьминьби": "CNY",
+        "жэньминби": "CNY",
+        "жэньминьби": "CNY",
+        "ренминби": "CNY",
+        "юань ренминби": "CNY",
+        "юань жэньминьби": "CNY",
+        "jüan": "CNY",
+        "čínsky juan": "CNY",
+        "juan": "CNY",
+        "renminb": "CNY",
+        "јуан": "CNY",
+        "кинески јуан": "CNY",
+        "юань": "CNY",
+        "китайський юань": "CNY",
+        "nhân dân tệ trung quốc": "CNY",
+        "中国人民银行币": "CNY",
+        "COL$": "COP",
+        "peso de colòmbia": "COP",
+        "col$": "COP",
+        "kolomba peso": "COP",
+        "cop": "COP",
+        "peso de colombia": "COP",
+        "kolumbijski peso": "COP",
+        "コロンビアの通貨": "COP",
+        "peso colombian": "COP",
+        "peso da colômbia": "COP",
+        "валюта колумбии": "COP",
+        "колумбийский песо": "COP",
+        "песо оро": "COP",
+        "колумбијски песо": "COP",
+        "unidad de valor real": "COU",
+        "COU$": "COU",
+        "unidad de valor real colombienne": "COU",
+        "₡": [
+            "STN",
+            "CRC"
+        ],
+        "colon costa riqueny": "CRC",
+        "colón de costa rica": "CRC",
+        "costa rica colon": "CRC",
+        "crc": "CRC",
+        "costa rican colon": "CRC",
+        "colón costarricense": "CRC",
+        "colon": "CRC",
+        "colon costarricense": "CRC",
+        "colon costaricain": "CRC",
+        "colon costaricien": "CRC",
+        "colón costaricain": "CRC",
+        "colon costaricano": "CRC",
+        "costa ricaanse colón": "CRC",
+        "costaricaanse colon": "CRC",
+        "costaricaanse colón": "CRC",
+        "colón costa ricense": "CRC",
+        "colón costa riquense": "CRC",
+        "colón costarriquenho": "CRC",
+        "colón costarriquense": "CRC",
+        "colón da costa rica": "CRC",
+        "костариканский колон": "CRC",
+        "валюта коста рики": "CRC",
+        "колон": "CRC",
+        "колон коста рики": "CRC",
+        "البيزو الكوبي": "CUP",
+        "$MN": "CUP",
+        "بيزو البكوبي": "CUP",
+        "peso de cuba": "CUP",
+        "cub$": "CUP",
+        "cup": "CUP",
+        "moneda nacional": "CUP",
+        "פסו קובני": "CUP",
+        "פזו קובני": "CUP",
+        "キューバペソ": "CUP",
+        "валюта кубы": "CUP",
+        "кубинский песо": "CUP",
+        "кубански песо": "CUP",
+        "küba pezosu": "CUP",
+        "кубинське песо": "CUP",
+        "ايسكودو": "CVE",
+        "ايسكودو الرأس الأخضر": "CVE",
+        "ايسكودو كاب فيردي": "CVE",
+        "кабо верде ескудо": "CVE",
+        "εσκούδο πρασίνου ακρωτηρίου": "CVE",
+        "εσκούδο του πρασίνου ακρωτηρίου": "CVE",
+        "cape verde escudo": "CVE",
+        "escudo de cabo verde": "CVE",
+        "escudo capverdien": "CVE",
+        "אשקודו כף ורדי": "CVE",
+        "kapverdski eskudo": "CVE",
+        "zöld foki köztársasági escudo": "CVE",
+        "cve": "CVE",
+        "zöld foki szigeteki escudo": "CVE",
+        "escudo di capo verde": "CVE",
+        "scudo capoverdiano": "CVE",
+        "escudos cabo verdianos": "CVE",
+        "валюта кабо верде": "CVE",
+        "埃斯庫多": "CVE",
+        "كرونه تشيكيه": "CZK",
+        "Kč": "CZK",
+        "крони": "CZK",
+        "czk": "CZK",
+        "corona de txèquia": "CZK",
+        "corona de la república txeca": "CZK",
+        "kč": "CZK",
+        "česká měna": "CZK",
+        "tjekkisk koruna": "CZK",
+        "tjekkiske kroner": "CZK",
+        "tjekkoslovakiske kroner": "CZK",
+        "tschechische währung": "CZK",
+        "heller": "CZK",
+        "ĉeĥia krono": "CZK",
+        "koruna": "CZK",
+        "koruna ceská": "CZK",
+        "koruna ceska": "CZK",
+        "koruna česka": "CZK",
+        "tsehhi kroon": "CZK",
+        "کرونا چک": "CZK",
+        "tsekin koruna": "CZK",
+        "tshekin koruna": "CZK",
+        "tshekin kruunu": "CZK",
+        "tšekin kruunu": "CZK",
+        "couronne tcheque": "CZK",
+        "couronnes tchèques": "CZK",
+        "corona tchec": "CZK",
+        "corone ceche": "CZK",
+        "チェコ・クローネ": "CZK",
+        "coroa da república checa": "CZK",
+        "coroa tcheca": "CZK",
+        "валюта чехии": "CZK",
+        "крона": [
+            "NOK",
+            "DKK",
+            "CZK"
+        ],
+        "чешка коруна": "CZK",
+        "tjeckisk koruna": "CZK",
+        "крона чеська": "CZK",
+        "الفرنك الجيبوتي": "DJF",
+        "Fdj": "DJF",
+        "φράγκο τζιμπουτί": "DJF",
+        "djf": "DJF",
+        "djibouti franc": "DJF",
+        "franco de yibuti": "DJF",
+        "franco yibuti": "DJF",
+        "franco de djibouti": "DJF",
+        "franco yibutiense": "DJF",
+        "franco yibutí": "DJF",
+        "franc djiboutien": "DJF",
+        "פרנק ג'יבוטי": "DJF",
+        "המטבע של ג'יבוטי": "DJF",
+        "franco di gibuti": "DJF",
+        "djiboutische frank": "DJF",
+        "franco djibutiano": "DJF",
+        "franco djibutiense": "DJF",
+        "franco do djibuti": "DJF",
+        "franco do djibouti": "DJF",
+        "franco jibutiano": "DJF",
+        "franco jibutiense": "DJF",
+        "валюта джибути": "DJF",
+        "джибутийский франк": "DJF",
+        "џибутијски франак": "DJF",
+        "cibuti frankı": "DJF",
+        "kr.": [
+            "FOK",
+            "DKK"
+        ],
+        "corona de dinamarca": "DKK",
+        "krone danaidd": "DKK",
+        "dkk": "DKK",
+        "dansk krone": "DKK",
+        "kronemønt": "DKK",
+        "δανέζικη κορόνα": "DKK",
+        "kr": [
+            "SEK",
+            "NOK",
+            "ISK",
+            "DKK"
+        ],
+        "krone": [
+            "NOK",
+            "DKK"
+        ],
+        "monnaie danoise": "DKK",
+        "coroa danesa": "DKK",
+        "קרונה דנית": "DKK",
+        "デンマーククローネ": "DKK",
+        "coroa da dinamarca": "DKK",
+        "øre": "DKK",
+        "валюта дании": "DKK",
+        "dansk valuta": "DKK",
+        "danska kronor": "DKK",
+        "டானிஷ் குரோன்": "DKK",
+        "டானிஷ் க்ரோன்": "DKK",
+        "டென்மார்க் குரோன": "DKK",
+        "டென்மார்க் குரோன்": "DKK",
+        "валюта данії": "DKK",
+        "丹麦克朗": "DKK",
+        "بيسو دومنيكاني": "DOP",
+        "RD$": "DOP",
+        "dom$": "DOP",
+        "rd$": "DOP",
+        "dop": "DOP",
+        "peso de republica dominicana": "DOP",
+        "peso de república dominicana": "DOP",
+        "peso oro": "DOP",
+        "peso oro dominicano": "DOP",
+        "dominikanski peso": "DOP",
+        "ドミニカ共和国ペソ": "DOP",
+        "peso da república dominicana": "DOP",
+        "peso dominican": "DOP",
+        "валюта доминиканской республики": "DOP",
+        "песо доминиканской республики": "DOP",
+        "доминикански песо": "DOP",
+        "домініканське песо": "DOP",
+        "多米尼加比索": "DOP",
+        "DA": "DZD",
+        "dinar d'algèria": "DZD",
+        "δηνάριο της αλγερίας": "DZD",
+        "dzd": "DZD",
+        "dinar": [
+            "TND",
+            "RSD",
+            "LYD",
+            "JOD",
+            "DZD"
+        ],
+        "da": "DZD",
+        "dinar algerino": "DZD",
+        "dinar algerien": "DZD",
+        "dinars algérien": "DZD",
+        "מטבע אלג'יריה": "DZD",
+        "denar argelino": "DZD",
+        "denar da argélia": "DZD",
+        "dinar da argélia": "DZD",
+        "валюта алжира": "DZD",
+        "அல்ஜீரிய தினார்": "DZD",
+        "الجنية المصري": "EGP",
+        "LE": "EGP",
+        "الجنيه المصرى": "EGP",
+        "الجنيه المصري": "EGP",
+        "ج.م": "EGP",
+        "جنية مصري": "EGP",
+        "lliura d'egipte": "EGP",
+        "ginē": "EGP",
+        "guinee": "EGP",
+        "l.e.": "EGP",
+        "le": "EGP",
+        "£e": "EGP",
+        "e£": "EGP",
+        "egp": "EGP",
+        "egiptoar libera": "EGP",
+        "livre egyptienne": "EGP",
+        "מטבע מצרים": "EGP",
+        "lira egiziana": "EGP",
+        "エジプトポンド": "EGP",
+        "ギニー": "EGP",
+        "egyptische pond": "EGP",
+        "liura egipciana": "EGP",
+        "libra do egipto": "EGP",
+        "libra do egito": "EGP",
+        "libră egipteană": "EGP",
+        "валюта египта": "EGP",
+        "египатска фунта": "EGP",
+        "egyptiska pund": "EGP",
+        "mısır paundu": "EGP",
+        "埃及镑": "EGP",
+        "埃镑": "EGP",
+        "نقفة": "ERN",
+        "Nfk": "ERN",
+        "نقفة إريترية": "ERN",
+        "ern": "ERN",
+        "nkf": "ERN",
+        "eritrea nagfo": "ERN",
+        "nafka eritrea": "ERN",
+        "מטבע אריתריאה": "ERN",
+        "nafka": "ERN",
+        "nakfa eritreo": "ERN",
+        "エリトリア・ナクファ": "ERN",
+        "валюта эритреи": "ERN",
+        "накфа": "ERN",
+        "纳克法": "ERN",
+        "بير": "ETB",
+        "dòlar etíop": "ETB",
+        "gersh": "ETB",
+        "mätonya": "ETB",
+        "μπιρ αιθιοπίας": "ETB",
+        "μπιρρ": "ETB",
+        "etb": "ETB",
+        "ethiopian dollar": "ETB",
+        "birr éthiopien": "ETB",
+        "ביר אתיופי": "ETB",
+        "エチオピア・ブル": "ETB",
+        "biras": "ETB",
+        "birr da etiópia": "ETB",
+        "birre da etiópia": "ETB",
+        "birre etíope": "ETB",
+        "абиссинский талер": "ETB",
+        "быр": "ETB",
+        "валюта эфиопии": "ETB",
+        "талари": "ETB",
+        "эфиопский доллар": "ETB",
+        "эфиопский талер": "ETB",
+        "إثريوم": "ETH",
+        "eth": "ETH",
+        "éter/ether": "ETH",
+        "verde": "ETH",
+        "اتیریم": "ETH",
+        "אית'ריום": "ETH",
+        "איתריום": "ETH",
+        "את'ריום": "ETH",
+        "eteris": "ETH",
+        "эфириум": "ETH",
+        "етеријум": "ETH",
+        "اليورو": "EUR",
+        "€": "EUR",
+        "eur": "EUR",
+        "euros": "EUR",
+        "e": "EUR",
+        "யூரோ": "EUR",
+        "avro": "EUR",
+        "F$": "FJD",
+        "dòlar de fiji": "FJD",
+        "fjd": "FJD",
+        "fijiansk dollar": "FJD",
+        "f$": "FJD",
+        "δολάριο νησιών φίτζι": "FJD",
+        "δολάριο των φίτζι": "FJD",
+        "fijan dollar": "FJD",
+        "dolar de fiji": "FJD",
+        "dolar fijiano": "FJD",
+        "dólar fijiano": "FJD",
+        "dolar": "FJD",
+        "dolar fiyiano": "FJD",
+        "dólar": "FJD",
+        "fidzhin dollari": "FJD",
+        "fidzin dollari": "FJD",
+        "dollar des îles fidji": "FJD",
+        "dollar fidjien": "FJD",
+        "דולר פיג'י": "FJD",
+        "dólar das fiji": "FJD",
+        "dolarul fijian": "FJD",
+        "фиджийский доллар": "FJD",
+        "фиџи долар": "FJD",
+        "долар фіджі": "FJD",
+        "FJ$": "FJD",
+        "FK£": "FKP",
+        "lliura de les falkland": "FKP",
+        "lliura de les illes falkland": "FKP",
+        "lliura de les illes malvines": "FKP",
+        "fl£": "FKP",
+        "λίρα των φώκλαντ": "FKP",
+        "fkp": "FKP",
+        "libra falkland": "FKP",
+        "livre des îles falkland": "FKP",
+        "falkland pound": "FKP",
+        "libra das malvinas": "FKP",
+        "libra das falkland": "FKP",
+        "libra das ilhas falkland": "FKP",
+        "фолклендский фунт": "FKP",
+        "corona de les illes fèroe": "FOK",
+        "färingische krone": "FOK",
+        "färöer krone": "FOK",
+        "faroese krona": "FOK",
+        "føroysk króna": "FOK",
+        "krona": [
+            "SEK",
+            "ISK",
+            "FOK"
+        ],
+        "króna": [
+            "ISK",
+            "FOK"
+        ],
+        "corona delle isole fær øer": "FOK",
+        "フェロー・クロネ": "FOK",
+        "フェロー・クローナ": "FOK",
+        "faeroerse kroon": "FOK",
+        "faerøerse kroon": "FOK",
+        "валюта фарерских островов": "FOK",
+        "färöiska kronor": "FOK",
+        "føroyska krónan": "FOK",
+        "法羅克朗": "FOK",
+        "الجنية البريطاني": "GBP",
+        "الجنيه الأسترليني": "GBP",
+        "الجنيه الإسترليني": "GBP",
+        "الجنيه الاسترليني": "GBP",
+        "باوند إسترليني": "GBP",
+        "جنيه أسترليني": "GBP",
+        "جنيه استرليني": "GBP",
+        "جنيه سترليني": "GBP",
+        "gbp": "GBP",
+        "английски паунд": "GBP",
+        "британски лири": "GBP",
+        "британски паунд": "GBP",
+        "lliures esterlines": "GBP",
+        "britská libra": "GBP",
+        "britské libry": "GBP",
+        "libra šterlinku": "GBP",
+        "punt": "GBP",
+        "sterling": "GBP",
+        "britisk pund": "GBP",
+        "engelsk pund": "GBP",
+        "engelske pund": "GBP",
+        "pund sterling": "GBP",
+        "soveregin": "GBP",
+        "sovereign": "GBP",
+        "britisches pfund": "GBP",
+        "βρετανική λίρα": "GBP",
+        "λίρα αγγλίας": "GBP",
+        "λίρα στερλίνα": "GBP",
+        "british pound": "GBP",
+        "pound": [
+            "JEP",
+            "GBP"
+        ],
+        "quid": "GBP",
+        "britaj pundoj": "GBP",
+        "sterlingo": "GBP",
+        "gpb": "GBP",
+        "neet": "GBP",
+        "libra": "GBP",
+        "libras esterlinas": "GBP",
+        "inglise nael": "GBP",
+        "naelsterling": "GBP",
+        "suurbritannia nael": "GBP",
+        "esterlindar libera": "GBP",
+        "esterlindar libra": "GBP",
+        "پوند": "GBP",
+        "پوند بریتانیا": "GBP",
+        "iso britannian punta": "GBP",
+        "ison britannian punta": "GBP",
+        "yhdistyneen kuningaskunnan punta": "GBP",
+        "livre britannique": "GBP",
+        "גיני": "GBP",
+        "לירה סטרלינג": "GBP",
+        "לירות סטרלינג": "GBP",
+        "לירות שטרלינג": "GBP",
+        "ליש\"ט": "GBP",
+        "מטבע אנגליה": "GBP",
+        "מטבע צפון אירלנד": "GBP",
+        "פאונד": "GBP",
+        "פאונד סטרלינג": "GBP",
+        "שטרלינג": "GBP",
+        "funta sterlinga": "GBP",
+        "angol font": "GBP",
+        "brit font": "GBP",
+        "észak ír font": "GBP",
+        "libra sterling": "GBP",
+        "sterlina inglese": "GBP",
+        "gbp£": "GBP",
+        "ukポンド": "GBP",
+        "イギリスの通貨": "GBP",
+        "イギリスポンド": "GBP",
+        "イギリス・ポンド": "GBP",
+        "ブリティッシュ・ポンド": "GBP",
+        "英ポンド": "GBP",
+        "jk svaras": "GBP",
+        "brits pond": "GBP",
+        "britse pond": "GBP",
+        "engels pond": "GBP",
+        "engelse pond": "GBP",
+        "liure esterlina": "GBP",
+        "funt brytyjski": "GBP",
+        "libra estrelina": "GBP",
+        "libra inglesa": "GBP",
+        "lire sterline": "GBP",
+        "penny": "GBP",
+        "ukl": "GBP",
+        "английский фунт": "GBP",
+        "английский фунт стерлингов": "GBP",
+        "британский фунт": "GBP",
+        "валюта великобритании": "GBP",
+        "фунт стерлингов соединенного королевства": "GBP",
+        "фунты стерлингов": "GBP",
+        "libra šterlingov": "GBP",
+        "angleški funt": "GBP",
+        "britanski funt": "GBP",
+        "šterling": "GBP",
+        "енглеска фунта": "GBP",
+        "фунта стерлинга": "GBP",
+        "фунта стерлинг": "GBP",
+        "brittiska pund": "GBP",
+        "பவுண்ட் ஸ்டேர்லிங்": "GBP",
+        "பவுண்ட் ஸ்ரேர்லிங்": "GBP",
+        "பிரிட்டிஷ் பவுண்டு": "GBP",
+        "பிரிட்டிஷ் பவுண்ட்": "GBP",
+        "ஸ்டேர்லிங் பவுண்ட்": "GBP",
+        "sterlin": "GBP",
+        "австралійський фунт стерлінгів": "GBP",
+        "англійський фунт стерлінгів": "GBP",
+        "британський фунт": "GBP",
+        "пенс": "GBP",
+        "anh kim": "GBP",
+        "đồng bảng anh": "GBP",
+        "لاري": "GEL",
+        "₾": "GEL",
+        "لاري الجورجي": "GEL",
+        "лари": "GEL",
+        "gruzínské lari": "GEL",
+        "georgian kupon lari": "GEL",
+        "kartvela lario": "GEL",
+        "gel": "GEL",
+        "gruusia lari": "GEL",
+        "لاری": "GEL",
+        "lari géorgien": "GEL",
+        "כארתולי לארי": "GEL",
+        "לארי גרוזי": "GEL",
+        "לארי גרוזיני": "GEL",
+        "lari georgian": "GEL",
+        "グルジアの通貨": "GEL",
+        "lari gruziński": "GEL",
+        "валюта грузии": "GEL",
+        "тетри": "GEL",
+        "சியார்சிய லாரி": "GEL",
+        "ஜோர்ஜிய லாரி": "GEL",
+        "gürcü larisi": "GEL",
+        "ларі": "GEL",
+        "拉里": "GEL",
+        "gernezeja pundo": "GGP",
+        "根西島鎊": "GGP",
+        "₵": "GHS",
+        "GH₵": "GHS",
+        "ганайско кеди": "GHS",
+        "ghs": "GHS",
+        "סדי גאני": "GHS",
+        "جنيه جبرلتار": "GIP",
+        "punt gibraltar": "GIP",
+        "gip": "GIP",
+        "gibraltar pund": "GIP",
+        "gib£": "GIP",
+        "λίρα γιβραλτάρ": "GIP",
+        "libra gibraltarena": "GIP",
+        "پوند جبل الطارق": "GIP",
+        "לירה גיברלטרית": "GIP",
+        "libra gibraltina": "GIP",
+        "liră gibraltareză": "GIP",
+        "валюта гибралтара": "GIP",
+        "ஜிப்ரால்ட்டர் பவுண்டு": "GIP",
+        "دالاسي": "GMD",
+        "D": "GMD",
+        "butut": "GMD",
+        "bututs": "GMD",
+        "gmd": "GMD",
+        "νταλάσι": "GMD",
+        "gambia dalasi": "GMD",
+        "dalasi gambien": "GMD",
+        "דלסי": "GMD",
+        "ガンビア・ダラシ": "GMD",
+        "dalase": "GMD",
+        "dalasi gambiano": "GMD",
+        "dalassi": "GMD",
+        "гамбийский даласи": "GMD",
+        "валюта гамбии": "GMD",
+        "даласі": "GMD",
+        "FG": "GNF",
+        "franc de guinea": "GNF",
+        "guinea franc": "GNF",
+        "gnf": "GNF",
+        "מטבע גינאה": "GNF",
+        "פרנק גיניאי": "GNF",
+        "franco della guinea": "GNF",
+        "guinese frank": "GNF",
+        "franco guineense": "GNF",
+        "franco guineense gnf": "GNF",
+        "franco guinné gnf": "GNF",
+        "валюта гвинеи": "GNF",
+        "كيتزال": "GTQ",
+        "Q": "GTQ",
+        "кетцал": "GTQ",
+        "quetzal gwatemala": "GTQ",
+        "gtq": "GTQ",
+        "quetzales": "GTQ",
+        "gvatemala kvecalo": "GTQ",
+        "quetzal guatémaltèque": "GTQ",
+        "quetzal guatemalteque": "GTQ",
+        "מטבע גואטמלה": "GTQ",
+        "gvatemalski quetzal": "GTQ",
+        "gvatemalos ketsalis": "GTQ",
+        "валюта гватемалы": "GTQ",
+        "гватемальский кетцаль": "GTQ",
+        "кветцал": "GTQ",
+        "кетсал": "GTQ",
+        "кетсаль": "GTQ",
+        "гватемальський кецаль": "GTQ",
+        "portugal gvinea eskudo": "GWE",
+        "escudo de guinea portuguesa": "GWE",
+        "escudo de guineoportugues": "GWE",
+        "escudo guineano": "GWE",
+        "escudo guineo portugues": "GWE",
+        "escudo guineo portugués": "GWE",
+        "escudo guineoportugues": "GWE",
+        "гвинейское эскудо": "GWE",
+        "эскудо португальской гвинеи": "GWE",
+        "دولار غوياني": "GYD",
+        "G$": "GYD",
+        "гаянски долар": "GYD",
+        "g$": "GYD",
+        "gy$": "GYD",
+        "dolar de guyana": "GYD",
+        "dolar guyanes": "GYD",
+        "dolar guyanés": "GYD",
+        "dólar de guyana": "GYD",
+        "dólar guyanes": "GYD",
+        "gyd": "GYD",
+        "dollar de guyana": "GYD",
+        "dollar du guyana": "GYD",
+        "דולר גיאני": "GYD",
+        "dólar guianense": "GYD",
+        "валюта гайаны": "GYD",
+        "гвајана долар": "GYD",
+        "圭亚那元": "GYD",
+        "GY$": "GYD",
+        "دولار هونغ كونغي": "HKD",
+        "HK$": "HKD",
+        "doler hong kong": "HKD",
+        "hkd": "HKD",
+        "hk$": "HKD",
+        "δολάριο του χονγκ κονγκ": "HKD",
+        "dolar de hong kong": "HKD",
+        "dolar hongkones": "HKD",
+        "dólar hongkonés": "HKD",
+        "dolar hongkongtar": "HKD",
+        "دلار هنگکنگ": "HKD",
+        "dollar hongkongais": "HKD",
+        "דולר הונג קונג": "HKD",
+        "honkonški dolar": "HKD",
+        "香港の通貨": "HKD",
+        "香港・ドル": "HKD",
+        "香港元": "HKD",
+        "hongkongo doleris": "HKD",
+        "dólar de hongkong": "HKD",
+        "dólar de hongue congue": "HKD",
+        "dólar de honguecongue": "HKD",
+        "dolar din hong kong": "HKD",
+        "доллар гонконга": "HKD",
+        "хонгконг долар": "HKD",
+        "гонконгзький долар": "HKD",
+        "гонконзький долар": "HKD",
+        "долар гонконґу": "HKD",
+        "dollar hong kong": "HKD",
+        "dollar hồng kông": "HKD",
+        "港圓": "HKD",
+        "港币": "HKD",
+        "港幣": "HKD",
+        "香港貨幣": "HKD",
+        "لمبيرا": "HNL",
+        "лемпира": "HNL",
+        "lempira hondwraidd": "HNL",
+        "honduranischer lempira": "HNL",
+        "λεμπίρα ονδούρας": "HNL",
+        "lempiro": "HNL",
+        "hnl": "HNL",
+        "lempira hondureña": "HNL",
+        "lempira hondurien": "HNL",
+        "lempire hondurien": "HNL",
+        "hondūro lempyra": "HNL",
+        "lempyra": "HNL",
+        "lempira hondurenha": "HNL",
+        "валюта гондураса": "HNL",
+        "хондурашка лемпира": "HNL",
+        "伦皮拉": "HNL",
+        "kn": "HRK",
+        "hrk": "HRK",
+        "lipa": "HRK",
+        "κούνα": "HRK",
+        "κροατική κούνα": "HRK",
+        "kroatia kunao": "HRK",
+        "kunao": "HRK",
+        "lipao": "HRK",
+        "cuna croata": "HRK",
+        "horvaatia kuna": "HRK",
+        "کونا": "HRK",
+        "ליפה": "HRK",
+        "クロアチアの通貨": "HRK",
+        "クロアチア・クナ": "HRK",
+        "クロアチア・クーナ": "HRK",
+        "kuna da croácia": "HRK",
+        "cună croată": "HRK",
+        "kuna croată": "HRK",
+        "kună croată": "HRK",
+        "валюта хорватии": "HRK",
+        "куна": "HRK",
+        "липа": "HRK",
+        "குரோவாசிய குனா": "HRK",
+        "குரோஷிய குனா": "HRK",
+        "hırvatistan kunası": "HRK",
+        "куна хорватська": "HRK",
+        "庫納": "HRK",
+        "Gde.": "HTG",
+        "gde.": "HTG",
+        "haitianische gourde": "HTG",
+        "haitianischer gourde": "HTG",
+        "htg": "HTG",
+        "dollar haïtien": "HTG",
+        "gourde haïtienne": "HTG",
+        "gourde haitienne": "HTG",
+        "גורד": "HTG",
+        "haitiaanse gourde": "HTG",
+        "gurde": "HTG",
+        "gurde haitiano": "HTG",
+        "валюта гаити": "HTG",
+        "гурд": "HTG",
+        "хаитски гурд": "HTG",
+        "G": "HTG",
+        "فورينت مجري": "HUF",
+        "Ft": "HUF",
+        "florí hongarès": "HUF",
+        "huf": "HUF",
+        "filler": "HUF",
+        "fillér": "HUF",
+        "ungarsk forint": "HUF",
+        "ungarischer forint": "HUF",
+        "φόριντ ουγγαρίας": "HUF",
+        "ft": "HUF",
+        "forinto": "HUF",
+        "hungaria forinto": "HUF",
+        "florin hungaro": "HUF",
+        "florin húngaro": "HUF",
+        "florín hungaro": "HUF",
+        "forint hungaro": "HUF",
+        "forint húngaro": "HUF",
+        "forinto hungaro": "HUF",
+        "ungari forint": "HUF",
+        "forintti": "HUF",
+        "forint hongrois": "HUF",
+        "forints": "HUF",
+        "florint": "HUF",
+        "florint húngaro": "HUF",
+        "forint hungare": "HUF",
+        "ハンガリーフォリント": "HUF",
+        "ハンガリー・フォリント": "HUF",
+        "forint węgierski": "HUF",
+        "forinte": "HUF",
+        "forint maghiar": "HUF",
+        "forint ungar": "HUF",
+        "венгерский форинт": "HUF",
+        "валюта венгрии": "HUF",
+        "форинта": "HUF",
+        "ungersk forint": "HUF",
+        "ஃபோரின்ட்": "HUF",
+        "அங்கேரிய ஃபோரின்ட்": "HUF",
+        "ஹங்கேரிய போரிண்ட்": "HUF",
+        "угорський форінт": "HUF",
+        "福林": "HUF",
+        "ungari pengö": "HUP",
+        "pengo hongrois": "HUP",
+        "pengő hongrois": "HUP",
+        "pengo ungherese": "HUP",
+        "ハンガリー・ペンゲー": "HUP",
+        "ペンゴ": "HUP",
+        "pengheul maghiar": "HUP",
+        "pengoe": "HUP",
+        "pengő maghiar": "HUP",
+        "венгерский пенгё": "HUP",
+        "пенге": "HUP",
+        "maďarské pengo": "HUP",
+        "мађарски пенгу": "HUP",
+        "帕戈": "HUP",
+        "روبية أندونيسية": "IDR",
+        "Rp": "IDR",
+        "روبية اندونيسية": "IDR",
+        "روبيه أندونيسيه": "IDR",
+        "rupia d'indonèsia": "IDR",
+        "idr": "IDR",
+        "indonesisk rupiah": "IDR",
+        "rp": "IDR",
+        "indoneza rupio": "IDR",
+        "rupia": [
+            "SCR",
+            "NPR",
+            "INR",
+            "IDR"
+        ],
+        "rupia de indonesia": "IDR",
+        "indonesiar errupia": "IDR",
+        "roupie indonesienne": "IDR",
+        "インドネシア・ルピア": "IDR",
+        "インドネシア・ルピー": "IDR",
+        "roepia": "IDR",
+        "roepiah": "IDR",
+        "ropia d'indonesia": "IDR",
+        "валюта индонезии": "IDR",
+        "рупия": [
+            "PKR",
+            "LKR",
+            "INR",
+            "IDR"
+        ],
+        "рупія": [
+            "INR",
+            "IDR"
+        ],
+        "rupiah indonesia": "IDR",
+        "印尼卢比": "IDR",
+        "印尼盧比": "IDR",
+        "印度尼西亚卢比": "IDR",
+        "印度尼西亞盧比": "IDR",
+        "الشيكل الإسرائيلي الجديد": "ILS",
+        "₪": "ILS",
+        "شاقل جديد": "ILS",
+        "شيقل جديد": "ILS",
+        "شيكل اسرائيلي جديد": "ILS",
+        "شيكل جديد": "ILS",
+        "израелски нов шекел": "ILS",
+        "nou shekel": "ILS",
+        "nou sheqel": "ILS",
+        "nou sheqel israelià": "ILS",
+        "nou shequel": "ILS",
+        "nou xéquel israelià": "ILS",
+        "nis": "ILS",
+        "šekel chadaš": "ILS",
+        "schekalim": "ILS",
+        "schkalim": "ILS",
+        "sheqalim": "ILS",
+        "sheqel": "ILS",
+        "νέο σέκελ ισραήλ": "ILS",
+        "new shekel": "ILS",
+        "ils": "ILS",
+        "israeli new sheqel": "ILS",
+        "new israeli shekel": "ILS",
+        "new israeli sheqel": "ILS",
+        "new sheqel": "ILS",
+        "israela nova siklo": "ILS",
+        "israela siklo": "ILS",
+        "nova israela ŝekelo": "ILS",
+        "nova siklo": "ILS",
+        "nova ŝekelo": "ILS",
+        "nuevo shekel": "ILS",
+        "nuevo sheqel": "ILS",
+        "nuevo shequel": "ILS",
+        "nuevo shékel": "ILS",
+        "nuevo sequel": "ILS",
+        "nuevo sequel israeli": "ILS",
+        "nuevo shekel israeli": "ILS",
+        "nuevo shequel israeli": "ILS",
+        "nuevo shékel israelí": "ILS",
+        "nuevo shéquel israelí": "ILS",
+        "nuevo séquel israelí": "ILS",
+        "shekel berria": "ILS",
+        "شکل": "ILS",
+        "israelin sekeli": "ILS",
+        "israelin shekeli": "ILS",
+        "shekeli": "ILS",
+        "nouveau shekel": "ILS",
+        "shekkel": "ILS",
+        "shékel": "ILS",
+        "novo sheqel": "ILS",
+        "novo shequel": "ILS",
+        "מטבע ישראל": "ILS",
+        "ש\"ח": "ILS",
+        "ש'": "ILS",
+        "שקל": "ILS",
+        "שקל ישראלי חדש": "ILS",
+        "nuovo siclo israeliano": "ILS",
+        "nuovo siclo": "ILS",
+        "siclo israeliano": "ILS",
+        "israelische lire": "ILS",
+        "israelische sjekel": "ILS",
+        "israëlische lire": "ILS",
+        "nieuwe israelische shekel": "ILS",
+        "nieuwe israelische sheqel": "ILS",
+        "nieuwe israelische sjekel": "ILS",
+        "nieuwe israëlische shekel": "ILS",
+        "nieuwe israëlische sheqel": "ILS",
+        "nieuwe israëlische sjekel": "ILS",
+        "sjekel": "ILS",
+        "shekel novèl": "ILS",
+        "novo sheqel israelense": "ILS",
+        "novo sheqel israelita": "ILS",
+        "novo shequel israelita": "ILS",
+        "novo siclo israelense": "ILS",
+        "novo siclo israelita": "ILS",
+        "shekel israelense": "ILS",
+        "shekel nou": "ILS",
+        "şekel nou": "ILS",
+        "șekel nou": "ILS",
+        "валюта израиля": "ILS",
+        "израильский новый шекель": "ILS",
+        "новый шекель": "ILS",
+        "agorot": "ILS",
+        "i̇srail yeni şekeli": "ILS",
+        "i̇srail şekeli": "ILS",
+        "şekel": "ILS",
+        "новий шекель": "ILS",
+        "новий ізраїльський шекель": "ILS",
+        "新舍客勒": "ILS",
+        "新謝克爾": "ILS",
+        "IM£": "IMP",
+        "lliura de man": "IMP",
+        "lliura manx": "IMP",
+        "manx pfund": "IMP",
+        "maninsula pundo": "IMP",
+        "libra de la isla de man": "IMP",
+        "livre de manx": "IMP",
+        "libra mannese": "IMP",
+        "マン島ポンド": "IMP",
+        "island of man pond": "IMP",
+        "funt wyspy man": "IMP",
+        "валюта острова мэн": "IMP",
+        "мэнский фунт": "IMP",
+        "мэнский фунт стерлингов": "IMP",
+        "மாண் தீவு பவுண்டு": "IMP",
+        "மான்க்ஸ் பவுண்ட்": "IMP",
+        "الروبية الهندية": "INR",
+        "₹": "INR",
+        "روبي هندية": "INR",
+        "روبيه هنديه": "INR",
+        "rupia d'índia": "INR",
+        "rupia de l'índia": "INR",
+        "rupies índies": "INR",
+        "rúpies": "INR",
+        "indisk rupee": "INR",
+        "indisk rupi": "INR",
+        "indiske rupees": "INR",
+        "inr": "INR",
+        "ινδική ρουπία": "INR",
+        "rupaya": "INR",
+        "rupee": [
+            "SCR",
+            "INR"
+        ],
+        "hinda rupio": "INR",
+        "rupias": "INR",
+        "rupias indias": "INR",
+        "indiar errupia": "INR",
+        "روپیهٔ هند": "INR",
+        "پول هندوستان": "INR",
+        "רופיה הודית": "INR",
+        "rupia dell'india": "INR",
+        "rupie indiane": "INR",
+        "indiase rupee": "INR",
+        "rupia da índia": "INR",
+        "rúpia indiana": "INR",
+        "валюта индии": "INR",
+        "индијски рупи": "INR",
+        "рупија": "INR",
+        "இந்திய ரூபா": "INR",
+        "భారత రూపాయి": "INR",
+        "భారతదేశ రూపాయి": "INR",
+        "భారతీయ రూపాయి": "INR",
+        "rs.": "INR",
+        "印度卢比": "INR",
+        "الدينار العراقي": "IQD",
+        "د.ع": "IQD",
+        "دينار": [
+            "KWD",
+            "IQD"
+        ],
+        "dinar d'iraq": "IQD",
+        "dinar de l'iraq": "IQD",
+        "irácký dinár": "IQD",
+        "iqd": "IQD",
+        "irak dinar": "IQD",
+        "ιρακινό δηνάριο": "IQD",
+        "dinar de irak": "IQD",
+        "dinar iraki": "IQD",
+        "dinar irakí": "IQD",
+        "dinar iraqui": "IQD",
+        "イラクの通貨": "IQD",
+        "denar do iraque": "IQD",
+        "denar iraquiano": "IQD",
+        "dinar do iraque": "IQD",
+        "валюта ирака": "IQD",
+        "динар ирака": "IQD",
+        "இராக்கிய தீனார்": "IQD",
+        "ஈராக் டினார்": "IQD",
+        "ஈராக் தினார்": "IQD",
+        "ஈராக்கிய டினார்": "IQD",
+        "ஈராக்கிய தினார்": "IQD",
+        "﷼": [
+            "YER",
+            "SAR",
+            "IRR"
+        ],
+        "rial d'iran": "IRR",
+        "rial de l'iran": "IRR",
+        "íránský riál": "IRR",
+        "íránský rial": "IRR",
+        "ریال": [
+            "SAR",
+            "IRR"
+        ],
+        "irr": "IRR",
+        "rial irani": "IRR",
+        "rial de iran": "IRR",
+        "rial de irán": "IRR",
+        "iranski rial": "IRR",
+        "イランの通貨": "IRR",
+        "イラン・リアル": "IRR",
+        "イラン・リヤール": "IRR",
+        "rial do irão": "IRR",
+        "валюта ирана": "IRR",
+        "иранский риял": "IRR",
+        "риал": [
+            "YER",
+            "SAR",
+            "IRR"
+        ],
+        "риал ирана": "IRR",
+        "риял ирана": "IRR",
+        "i̇ran para birimi": "IRR",
+        "i̇ran parası": "IRR",
+        "corona d'islàndia": "ISK",
+        "isk": "ISK",
+        "islandsk króna": "ISK",
+        "islandsk krone": "ISK",
+        "islandske kroner": "ISK",
+        "aurar": "ISK",
+        "eyrir": "ISK",
+        "isländische währung": "ISK",
+        "krónur": "ISK",
+        "ισλανδική κορόνα": "ISK",
+        "icelandic krona": "ISK",
+        "کرونا ایسلند": "ISK",
+        "アイスランドクローナ": "ISK",
+        "アイスランド・クローネ": "ISK",
+        "coroa da islândia": "ISK",
+        "валюта исландии": "ISK",
+        "isländsk króna": "ISK",
+        "krónor": "ISK",
+        "ஐஸ்லாந்து குரோனா": "ISK",
+        "冰島克朗": "ISK",
+        "جنيه جيرسي": "JEP",
+        "JE£": "JEP",
+        "jep": "JEP",
+        "jersey pundo": "JEP",
+        "livre jersiaise": "JEP",
+        "לירה ג'רזית": "JEP",
+        "jerseyska funta": "JEP",
+        "jersey pond": "JEP",
+        "валюта джерси": "JEP",
+        "фунт джерси": "JEP",
+        "џерзијска фунта": "JEP",
+        "џерси фунта": "JEP",
+        "ஜெர்சி பவுண்ட்": "JEP",
+        "ஜேர்சி பவுண்டு": "JEP",
+        "澤西島鎊": "JEP",
+        "澤西磅": "JEP",
+        "J$": "JMD",
+        "dòlar de jamaica": "JMD",
+        "j$": "JMD",
+        "jmd": "JMD",
+        "jay": "JMD",
+        "dolar jamaicano": "JMD",
+        "dolar jamaiquino": "JMD",
+        "libra jamaicana": "JMD",
+        "dollar de la jamaïque": "JMD",
+        "dollar jamaicain": "JMD",
+        "dollar jamaïquain": "JMD",
+        "דולר ג'מייקי": "JMD",
+        "ジャマイカドル": "JMD",
+        "dólar da jamaica": "JMD",
+        "валюта ямайки": "JMD",
+        "јамајчански долар": "JMD",
+        "الدينار الأردني": "JOD",
+        "JD": "JOD",
+        "دينار اردني": "JOD",
+        "dinar de jordània": "JOD",
+        "jod": "JOD",
+        "δηνάριο ιορδανίας": "JOD",
+        "jordana dinaro": "JOD",
+        "dinar de jordania": "JOD",
+        "dinar jordanian": "JOD",
+        "denar da jordânia": "JOD",
+        "denar jordano": "JOD",
+        "dinar da jordânia": "JOD",
+        "dinar jordaniano": "JOD",
+        "dinar jordâniano": "JOD",
+        "dinarul iordanian": "JOD",
+        "валюта иордании": "JOD",
+        "jpy": "JPY",
+        "en": "JPY",
+        "japana jeno": "JPY",
+        "yen japones": "JPY",
+        "yen japonés": "JPY",
+        "ین": "JPY",
+        "yen giapponese": "JPY",
+        "日本円": "JPY",
+        "yeni": "JPY",
+        "японская иена": "JPY",
+        "йена": "JPY",
+        "日本元": "JPY",
+        "شيلينغ كينيي": "KES",
+        "Ksh": "KES",
+        "xíling de kenya": "KES",
+        "σελλίνι της κένυας": "KES",
+        "shilling": "KES",
+        "chelin keniano": "KES",
+        "chelin keniata": "KES",
+        "chelín keniata": "KES",
+        "kenya šilling": "KES",
+        "kes": "KES",
+        "shilling kenyan": "KES",
+        "scellino": [
+            "SOS",
             "KES"
         ],
-	"bitcoin": [
-		"XBT"
-	]	
-    }, 
+        "scellino keniano": "KES",
+        "ケニアシリング": "KES",
+        "валюта кении": "KES",
+        "шиллинг": [
+            "UGX",
+            "TZS",
+            "SOS",
+            "KES"
+        ],
+        "肯亞先令": "KES",
+        "ksh": "KES",
+        "سوم قرغيزستاني": "KGS",
+        "сом": [
+            "UZS",
+            "KGS"
+        ],
+        "som de kirguizistan": "KGS",
+        "som del kirguizistan": "KGS",
+        "k.s.": "KGS",
+        "tyiyn": "KGS",
+        "tyjyn": "KGS",
+        "σομ της κιργιζίας": "KGS",
+        "kyrgyz som": "KGS",
+        "kirgizia somo": "KGS",
+        "kgs": "KGS",
+        "som de kirguistan": "KGS",
+        "som kirguis": "KGS",
+        "som de kirguistán": "KGS",
+        "kirgiski som": "KGS",
+        "som kirghizo": "KGS",
+        "som kirgiski": "KGS",
+        "som do quirguistão": "KGS",
+        "som quirguiz": "KGS",
+        "some": "KGS",
+        "валюта киргизии": "KGS",
+        "кыргызский сом": "KGS",
+        "киргистански сом": "KGS",
+        "киргишки сом": "KGS",
+        "៛": "KHR",
+        "khr": "KHR",
+        "khmer riel": "KHR",
+        "ריאל קמבודי": "KHR",
+        "kambodžanski rijel": "KHR",
+        "камбоджийский риель": "KHR",
+        "ரைல்": "KHR",
+        "கம்போடியன் ரைல்": "KHR",
+        "dòlar de kiribati": "KID",
+        "dòlar gilbertès": "KID",
+        "δολάριο του κιριμπάτι": "KID",
+        "dolar de kiribati": "KID",
+        "dollar de kiribati": "KID",
+        "dollaro di kiribati": "KID",
+        "キリバスの通貨": "KID",
+        "кирибатийский доллар": "KID",
+        "кирибатски долар": "KID",
+        "franco comorano": "KMF",
+        "komoransk franc": "KMF",
+        "₩": [
+            "KRW",
+            "KPW"
+        ],
+        "won de corea del nord": "KPW",
+        "won de la república democràtica popular de corea": "KPW",
+        "nord korea vono": "KPW",
+        "wŏn norcoreano": "KPW",
+        "põhja korea won": "KPW",
+        "kpw": "KPW",
+        "北朝鮮ウォン": "KPW",
+        "šiaurės korėjos vonas": "KPW",
+        "won da coreia do norte": "KPW",
+        "won da república democrática popular da coreia": "KPW",
+        "won da república popular democrática da coreia": "KPW",
+        "вона кндр": "KPW",
+        "валюта кндр": "KPW",
+        "северо корейская вона": "KPW",
+        "вона": [
+            "KRW",
+            "KPW"
+        ],
+        "won bắc triều tiên": "KPW",
+        "北韓元": "KPW",
+        "朝元": "KPW",
+        "朝鲜元": "KPW",
+        "朝鲜货币改革": "KPW",
+        "ون كوريا الجنوبية": "KRW",
+        "وون": "KRW",
+        "won de corea del sud": "KRW",
+        "won de la república de corea": "KRW",
+        "won": "KRW",
+        "krw": "KRW",
+        "sud korea vono": "KRW",
+        "jeon": "KRW",
+        "lõuna korea won": "KRW",
+        "وون کرهٔ جنوبی": "KRW",
+        "וון דרום קוריאני": "KRW",
+        "韓国ウォン": "KRW",
+        "won sud corean": "KRW",
+        "won da coreia do sul": "KRW",
+        "won da república da coreia": "KRW",
+        "валюта республики корея": "KRW",
+        "tamil langauges": "KRW",
+        "đại hàn dân quốc weon": "KRW",
+        "南韓圓": "KRW",
+        "南韓圜": "KRW",
+        "圜": "KRW",
+        "韓元": "KRW",
+        "韓圜": "KRW",
+        "韩元": "KRW",
+        "韩圆": "KRW",
+        "韩币": "KRW",
+        "الدينار الكويتي": "KWD",
+        "KD": "KWD",
+        "dinar de kuwait": "KWD",
+        "kwd": "KWD",
+        "dinar kuwaiti": "KWD",
+        "kwt": "KWD",
+        "dinar du koweït": "KWD",
+        "dinar koweitien": "KWD",
+        "dinar kowéitien": "KWD",
+        "denar couaitiano": "KWD",
+        "denar covaitiano": "KWD",
+        "denar coveitiano": "KWD",
+        "denar cuaitiano": "KWD",
+        "denar koweitiano": "KWD",
+        "denar kuaitiano": "KWD",
+        "denar kuweitiano": "KWD",
+        "denar quaitiano": "KWD",
+        "dinar coaitiano": "KWD",
+        "dinar couaitiano": "KWD",
+        "dinar covaitiano": "KWD",
+        "dinar coveiteano": "KWD",
+        "dinar coveitiano": "KWD",
+        "dinar cuveitiano": "KWD",
+        "dinar kuweitiano": "KWD",
+        "dinar quaitiano": "KWD",
+        "валюта кувейта": "KWD",
+        "குவைத்தி தினார்": "KWD",
+        "科威特第纳尔": "KWD",
+        "د.ك": "KWD",
+        "CI$": "KYD",
+        "kyd": "KYD",
+        "ci$": "KYD",
+        "δολάριο νησιών καϋμάν": "KYD",
+        "δολάριο νήσων καϋμάν": "KYD",
+        "δολάριο των νησιών καϋμάν": "KYD",
+        "dolar caimano": "KYD",
+        "dolar de las islas caiman": "KYD",
+        "dolar de las islas caimán": "KYD",
+        "dólar caimano": "KYD",
+        "dólar de las islas caiman": "KYD",
+        "דולר קיימני": "KYD",
+        "ケイマン諸島ドル": "KYD",
+        "kaimanų doleris": "KYD",
+        "caymaneilandse dollar": "KYD",
+        "dolar de las illas caiman": "KYD",
+        "доллар островов кайман": "KYD",
+        "кајмански долар": "KYD",
+        "₸": "KZT",
+        "тенге": "KZT",
+        "kazašské tenge": "KZT",
+        "kazašský tenge": "KZT",
+        "kzt": "KZT",
+        "〒": "KZT",
+        "تنگه": "KZT",
+        "tengue": "KZT",
+        "טנגה": "KZT",
+        "kazachijos tengė": "KZT",
+        "tengė": "KZT",
+        "tenge kazachski": "KZT",
+        "tengue cazaque": "KZT",
+        "tenge kazah": "KZT",
+        "валюта казахстана": "KZT",
+        "казахский тенге": "KZT",
+        "символ тенге": "KZT",
+        "тенге казахстана": "KZT",
+        "тенге казахстанский": "KZT",
+        "теньге": "KZT",
+        "теңге": "KZT",
+        "கசக்ஸ்தானி டெங்கே": "KZT",
+        "казахстанський тенге": "KZT",
+        "坚戈": "KZT",
+        "堅戈": "KZT",
+        "كيب": "LAK",
+        "₭": "LAK",
+        "kip laosià": "LAK",
+        "lak": "LAK",
+        "₭n": "LAK",
+        "kip laotien": "LAK",
+        "laoški kip": "LAK",
+        "ラオスの通貨": "LAK",
+        "ラオス・キープ": "LAK",
+        "kipas": "LAK",
+        "kipe": "LAK",
+        "валюта лаоса": "LAK",
+        "кип": "LAK",
+        "кип свободы": "LAK",
+        "лаоски нови кип": "LAK",
+        "нови кип": "LAK",
+        "kip lào": "LAK",
+        "kíp": "LAK",
+        "基普": "LAK",
+        "ليره لبنانيه": "LBP",
+        "ل.ل.": "LBP",
+        "lira de líban": "LBP",
+        "lira del líban": "LBP",
+        "lira libanesa": "LBP",
+        "lliura de líban": "LBP",
+        "lliura del líban": "LBP",
+        "punt libanus": "LBP",
+        "libanon pfund": "LBP",
+        "l£": "LBP",
+        "lbp": "LBP",
+        "lebanese lira": "LBP",
+        "libana pundo": "LBP",
+        "لیرهٔ لبنان": "LBP",
+        "پوند لبنان": "LBP",
+        "libanese pond": "LBP",
+        "liura libanesa": "LBP",
+        "libra do líbano": "LBP",
+        "валюта ливана": "LBP",
+        "ливанская лира": "LBP",
+        "libanonska lira": "LBP",
+        "ліванська ліра": "LBP",
+        "LL": "LBP",
+        "روبية سريلانكية": "LKR",
+        "روبيه سريلانكي": "LKR",
+        "₨": [
+            "SCR",
+            "PKR",
+            "NPR",
+            "MUR",
+            "LKR"
+        ],
+        "Rs": "LKR",
+        "rupia cingalesa": "LKR",
+        "rupia de ceilan": "LKR",
+        "rupia singalesa": "LKR",
+        "rupee sri lanca": "LKR",
+        "sri lanka rupee": "LKR",
+        "lkr": "LKR",
+        "lankan rupee": "LKR",
+        "sri lankansk rupee": "LKR",
+        "srilankan rupee": "LKR",
+        "srilankansk rupee": "LKR",
+        "slrs": "LKR",
+        "sri lankan rupees": "LKR",
+        "tamil rupee": "LKR",
+        "rupia esrilanquesa": "LKR",
+        "rupia ceilandesa": "LKR",
+        "rupia ceilanesa": "LKR",
+        "rupia de seychelles": [
+            "SCR",
+            "LKR"
+        ],
+        "rupia srilanquesa": "LKR",
+        "rupia tamil": "LKR",
+        "روپيه سري لانكا": "LKR",
+        "روپيه سريلانكا": "LKR",
+        "روپيهٔ سري لانكا": "LKR",
+        "روپیه سری لانکا": "LKR",
+        "روپیهٔ سری لانکا": "LKR",
+        "روپیهٔ سریلانکا": "LKR",
+        "roupie du sri lanka": "LKR",
+        "srilankaanse roepie": "LKR",
+        "srilankaanse rupee": "LKR",
+        "rupia sri lanki": "LKR",
+        "rúpia do sri lanka": "LKR",
+        "rupia do seri lanca": "LKR",
+        "rupia do sri lanca": "LKR",
+        "ланкийская рупия": "LKR",
+        "валюта шри ланки": "LKR",
+        "рупија шри ланке": "LKR",
+        "шриланканска рупија": "LKR",
+        "lankesisk rupie": "LKR",
+        "sri lankesisk rupee": "LKR",
+        "sri lankesisk rupie": "LKR",
+        "இலங்கை ரூபா": "LKR",
+        "ланкійська рупія": "LKR",
+        "Lib$": "LRD",
+        "dòlar de libèria": "LRD",
+        "lib$": "LRD",
+        "δολλάριο λιβερίας": "LRD",
+        "dolar liberiano": "LRD",
+        "dollar liberien": "LRD",
+        "リベリアドル": "LRD",
+        "dolar liberian": "LRD",
+        "валюта либерии": "LRD",
+        "lrd": "LRD",
+        "liberisk dollar": "LRD",
+        "L$": "LRD",
+        "لوتي": "LSL",
+        "M": "LSL",
+        "lisente": "LSL",
+        "loti lesothan": "LSL",
+        "loti del lesotho": "LSL",
+        "レソト・ロチ": "LSL",
+        "валюта лесото": "LSL",
+        "лоти": "LSL",
+        "lsl": "LSL",
+        "lesoto lotisi": "LSL",
+        "лоті": "LSL",
+        "الدينار الليبي": "LYD",
+        "LD": "LYD",
+        "الدينار ليبي": "LYD",
+        "dinar de líbia": "LYD",
+        "dinar libya": "LYD",
+        "lyd": "LYD",
+        "ld": "LYD",
+        "דינר לובי ": "LYD",
+        "dinar libian": "LYD",
+        "валюта ливии": "LYD",
+        "dirham de marroc": "MAD",
+        "dirham del marroc": "MAD",
+        "dirham marroquí": "MAD",
+        "maza": "MAD",
+        "dirham marroqui": "MAD",
+        "דירהם מרוקני": "MAD",
+        "dirham marroquino": "MAD",
+        "dirame de marrocos": "MAD",
+        "dirame do marrocos": "MAD",
+        "dirame marroquino": "MAD",
+        "dirham de marrocos": "MAD",
+        "dirham do marrocos": "MAD",
+        "валюта марокко": "MAD",
+        "марокканский дирхем": "MAD",
+        "дирхем": "MAD",
+        "摩洛哥迪拉姆": "MAD",
+        "монаски франк": "MCF",
+        "franc de mònaco": "MCF",
+        "monegassischer franken": "MCF",
+        "φράγκο του μονακό": "MCF",
+        "monegasque franc": "MCF",
+        "mcf": "MCF",
+        "monaka franko": "MCF",
+        "franco de monaco": "MCF",
+        "franco de mónaco": "MCF",
+        "franc monegasque": "MCF",
+        "monacói frank": "MCF",
+        "モナコ・フラン": "MCF",
+        "монакский франк": "MCF",
+        "монегаскский франк": "MCF",
+        "франк монегасский": "MCF",
+        "молдовска леа": "MDL",
+        "молдовски леи": "MDL",
+        "leu de moldàvia": "MDL",
+        "mdl": "MDL",
+        "moldavský leu": "MDL",
+        "moldawischer leu": "MDL",
+        "μολδαβικό λέου": "MDL",
+        "moldava leŭo": "MDL",
+        "moldavia leŭo": "MDL",
+        "ליאו מולדובני": "MDL",
+        "moldavski leu": "MDL",
+        "moldován lej": "MDL",
+        "モルドバの通貨": "MDL",
+        "モルドバ・レイ": "MDL",
+        "moldovos lėja": "MDL",
+        "lej mołdawski": "MDL",
+        "leu da moldávia": "MDL",
+        "leul moldovenesc": "MDL",
+        "валюта молдавии": "MDL",
+        "лей": [
+            "RON",
+            "MDL"
+        ],
+        "молдавський лей": "MDL",
+        "ارياري": "MGA",
+        "Ar": "MGA",
+        "iraimbilanja": "MGA",
+        "madagascan ariary": "MGA",
+        "ariaro": "MGA",
+        "madagaskara ariaro": "MGA",
+        "franc malgache": "MGA",
+        "איראימבילאנג'ה": "MGA",
+        "mga": "MGA",
+        "アリアリ": "MGA",
+        "ariaris": "MGA",
+        "ariari": "MGA",
+        "ariari de madagascar": "MGA",
+        "ariari de madagáscar": "MGA",
+        "ariari malgaxe": "MGA",
+        "ariary de madagascar": "MGA",
+        "ariary de madagáscar": "MGA",
+        "ариари": "MGA",
+        "валюта мадагаскара": "MGA",
+        "малгашки ариари": "MGA",
+        "mgf": "MGA",
+        "madagaskar ariarysi": "MGA",
+        "malgaş ariarysi": "MGA",
+        "阿里亚里": "MGA",
+        "阿里亞里": "MGA",
+        "ден": "MKD",
+        "денар": "MKD",
+        "denar macedoni": "MKD",
+        "denar normacedoni": "MKD",
+        "dinar de macedònia": "MKD",
+        "dinar macedoni": "MKD",
+        "dinar normacedoni": "MKD",
+        "makedonský dinár": "MKD",
+        "makedonsk denar": "MKD",
+        "nordmazedonischer denar": "MKD",
+        "denari": "MKD",
+        "mkd": "MKD",
+        "δηνάριο πγδμ": "MKD",
+        "north macedonian denar": "MKD",
+        "makedonia denaro": "MKD",
+        "dinar macedonio": "MKD",
+        "makedoonia denaar": "MKD",
+        "makedonian denaari": "MKD",
+        "dinar macédonien": "MKD",
+        "denar macedone": "MKD",
+        "denaro macedone": "MKD",
+        "マケドニア・ディナール": "MKD",
+        "denaras": "MKD",
+        "noord macedonische denar": "MKD",
+        "denar da macedónia": "MKD",
+        "denar da macedônia": "MKD",
+        "denar macedónio": "MKD",
+        "denar macedônio": "MKD",
+        "dinar da macedónia": "MKD",
+        "dinar da macedônia": "MKD",
+        "dinar macedônio": "MKD",
+        "валюта республики македонии": "MKD",
+        "macedónsky dinár": "MKD",
+        "மாக்கடோனிய தெனார்": "MKD",
+        "மாக்கடோனியன் டெனார்": "MKD",
+        "македонський динар": "MKD",
+        "馬其頓代納爾": "MKD",
+        "馬其頓德納爾": "MKD",
+        "DEN": "MKD",
+        "K": [
+            "ZMW",
+            "PGK",
+            "MMK"
+        ],
+        "kyat birmà": "MMK",
+        "mmk": "MMK",
+        "k": "MMK",
+        "ks": "MMK",
+        "myanmar kyat": "MMK",
+        "کیات": "MMK",
+        "pyas": "MMK",
+        "бирманский кьят": "MMK",
+        "валюта мьянмы": "MMK",
+        "кейат": "MMK",
+        "къят": "MMK",
+        "мьянманский кьят": "MMK",
+        "мьянманский чат": "MMK",
+        "мијанмарски кјат": "MMK",
+        "мјанмарски киат": "MMK",
+        "buk": "MMK",
+        "myanmar kyatı": "MMK",
+        "kyat myanma": "MMK",
+        "缅元": "MMK",
+        "緬甸元": "MMK",
+        "توغروغ": "MNT",
+        "₮": "MNT",
+        "tugrug": "MNT",
+        "tögrök": "MNT",
+        "tögrög mongolia": "MNT",
+        "mongolischer tögrög": "MNT",
+        "möngö": "MNT",
+        "togrog": "MNT",
+        "tugrig": "MNT",
+        "mnt": "MNT",
+        "mongolian tughrik": "MNT",
+        "tughrik": "MNT",
+        "tögrög mongol": "MNT",
+        "توگروگ": "MNT",
+        "تاگریک": "MNT",
+        "توگریک": "MNT",
+        "төгрөг": "MNT",
+        "טוגריק": "MNT",
+        "מטבע מונגוליה": "MNT",
+        "mongolski tögrög": "MNT",
+        "トゥグリク": "MNT",
+        "ドグログ": "MNT",
+        "tiugrikas": "MNT",
+        "монгольский тугрик": "MNT",
+        "валюта монголии": "MNT",
+        "图格里克": "MNT",
+        "MOP$": "MOP",
+        "macao pataca": "MOP",
+        "mop": "MOP",
+        "mop$": "MOP",
+        "patako": "MOP",
+        "پاتاکای ماکانز": "MOP",
+        "patacas": "MOP",
+        "валюта макао": "MOP",
+        "макаонска патака": "MOP",
+        "pataca macau": "MOP",
+        "澳門元": "MOP",
+        "澳门元": "MOP",
+        "澳门币": "MOP",
+        "葡币": "MOP",
+        "葡幣": "MOP",
+        "أ.م.": "MRO",
+        "mro": "MRO",
+        "UM": "MRO",
+        "mur": "MUR",
+        "mauritisk rupee": "MUR",
+        "mauritius rupee": "MUR",
+        "ρουπία μαυρίκιου": "MUR",
+        "rupia mauricia": "MUR",
+        "rupia mauriciense": "MUR",
+        "רופי מאוריציני": "MUR",
+        "mauritiaanse rupee": "MUR",
+        "ropia de maurici": "MUR",
+        "روفيه": "MVR",
+        "MRF": "MVR",
+        "rupia de maldives": "MVR",
+        "mvr": "MVR",
+        "maldivisk rufiyaa": "MVR",
+        "laari": "MVR",
+        "malediven rupie": "MVR",
+        "rupia maldiva": "MVR",
+        "روفیهٔ مالدیو": "MVR",
+        "maldív szigeteki rúfia": "MVR",
+        "ルフィア": "MVR",
+        "ルフィヤー": "MVR",
+        "rufija": "MVR",
+        "rópia de las maldivas": "MVR",
+        "валюта мальдив": "MVR",
+        "мальдивская рупия": "MVR",
+        "руфия": "MVR",
+        "малдивска рупија": "MVR",
+        "maldiv rufiyaası": "MVR",
+        "ރ": "MVR",
+        "Rf": "MVR",
+        "كواشا": "MWK",
+        "MK": "MWK",
+        "malawská kvača": "MWK",
+        "tambala": "MWK",
+        "kwacha malaui": "MWK",
+        "kwacha malawite": "MWK",
+        "kwacha del malawi": "MWK",
+        "mwk": "MWK",
+        "malawiaanse kwacha": "MWK",
+        "kwacha do malaui": "MWK",
+        "kwacha do malauí": "MWK",
+        "kwacha do malavi": "MWK",
+        "kwacha do malawi": "MWK",
+        "kwacha do malávi": "MWK",
+        "kwacha malauiana": "MWK",
+        "kwacha malauiano": "MWK",
+        "kwacha malaviana": "MWK",
+        "kwacha malawiana": "MWK",
+        "валюта малави": "MWK",
+        "квача": [
+            "ZMW",
+            "MWK"
+        ],
+        "malavi kwachası": "MWK",
+        "البيزو المكسيكي": "MXN",
+        "mxn": "MXN",
+        "pes mexicà": "MXN",
+        "peso de mèxic": "MXN",
+        "mx$": "MXN",
+        "mexican un peso coinage": "MXN",
+        "mexican centavo": "MXN",
+        "mexican nuevo peso": "MXN",
+        "currency of mexico": "MXN",
+        "peso de mejico": "MXN",
+        "peso de mexico": "MXN",
+        "peso de méjico": "MXN",
+        "peso de méxico": "MXN",
+        "peso mejicano": "MXN",
+        "mehhiko peeso": "MXN",
+        "mexikar peso": "MXN",
+        "پزو مكزيك": "MXN",
+        "פזו מקסיקני": "MXN",
+        "meksički peso": "MXN",
+        "mexikói pezó": "MXN",
+        "メキシコの通貨": "MXN",
+        "墨ペソ": "MXN",
+        "мексиканский песо": "MXN",
+        "мексиканское новое песо": "MXN",
+        "песо мексиканское": "MXN",
+        "нови мексички пезос": "MXN",
+        "нови мексички песо": "MXN",
+        "mxp": "MXN",
+        "peso mexico": "MXN",
+        "unidad de inversion": "MXV",
+        "mexican unidad de inversion": "MXV",
+        "unidades de inversion": "MXV",
+        "メキシコ投資単位": "MXV",
+        "رينغيت": "MYR",
+        "RM": "MYR",
+        "myr": "MYR",
+        "rm": "MYR",
+        "ringgit malaysia": "MYR",
+        "dolar malasio": "MYR",
+        "dólar malasio": "MYR",
+        "رینگیت": "MYR",
+        "רינגיט מלזי": "MYR",
+        "ringgit malese": "MYR",
+        "малайзійський ринґіт": "MYR",
+        "马來西亚令吉": "MYR",
+        "林吉特": "MYR",
+        "零吉": "MYR",
+        "متكال": "MZN",
+        "MT": "MZN",
+        "mozambický metical": "MZN",
+        "metical mosambic": "MZN",
+        "mzm": "MZN",
+        "meticais": "MZN",
+        "metikalo": "MZN",
+        "metical mozambiqueno": "MZN",
+        "متیکال موزایکی": "MZN",
+        "metical mozambicain": "MZN",
+        "מטיקל מוזמביני": "MZN",
+        "mozambijski metikal": "MZN",
+        "mozambijski metical": "MZN",
+        "metical del mozambico": "MZN",
+        "モザンビーク・メティカル": "MZN",
+        "metikalas": "MZN",
+        "mozambiko metikalas": "MZN",
+        "mozambiko metikalis": "MZN",
+        "oude metical": "MZN",
+        "metical da nova família": "MZN",
+        "metical de moçambique": "MZN",
+        "metical moçambicano": "MZN",
+        "валюта мозамбика": "MZN",
+        "метикал": "MZN",
+        "N$": "NAD",
+        "намибски долар": "NAD",
+        "dòlar de namíbia": "NAD",
+        "dòlar namibi": "NAD",
+        "n$": "NAD",
+        "namibischer dollar": "NAD",
+        "nad": "NAD",
+        "dolar de namibia": "NAD",
+        "dolar namibio": "NAD",
+        "dólar de namibia": "NAD",
+        "מטבע נמיביה": "NAD",
+        "dollaro della namibia": "NAD",
+        "ナミビアドル": "NAD",
+        "dólar namibiano": "NAD",
+        "dólar namíbio": "NAD",
+        "намибийский доллар": "NAD",
+        "намібський долар": "NAD",
+        "نايرا": "NGN",
+        "₦": "NGN",
+        "نيرا": "NGN",
+        "نيرة": "NGN",
+        "نيره": "NGN",
+        "nigérijská naira": "NGN",
+        "najro": "NGN",
+        "niĝera najro": "NGN",
+        "naira nigérian": "NGN",
+        "ナイジェリア・ナイラ": "NGN",
+        "naira nigeriano": "NGN",
+        "нигерийская найра": "NGN",
+        "валюта нигерии": "NGN",
+        "нигерийский найр": "NGN",
+        "наира": "NGN",
+        "ngn": "NGN",
+        "奈拉": "NGN",
+        "尼日利亚奈拉": "NGN",
+        "كوردوبا نيكاراجوي": "NIO",
+        "córdoba nicaragüenc": "NIO",
+        "córdoba nicaragüenca": "NIO",
+        "nicaraguanischer córdoba": "NIO",
+        "mariana montserrat": "NIO",
+        "nicaraguan cordoba": "NIO",
+        "cordoba nicaraguense": "NIO",
+        "cordoba nicaragüense": "NIO",
+        "córdoba nicaragüense": "NIO",
+        "cordoba nicaraguayen": "NIO",
+        "córdoba nicaraguayen": "NIO",
+        "córdoba nicaraguéen": "NIO",
+        "nikaragvanska córdoba": "NIO",
+        "100ドル紙幣": "NIO",
+        "コルドバ・オロ": "NIO",
+        "nicaraguaanse cordoba": "NIO",
+        "córdoba ouro": "NIO",
+        "córdoba nicaraguano": "NIO",
+        "nio": "NIO",
+        "валюта никарагуа": "NIO",
+        "золотая кордоба": "NIO",
+        "кордоба": "NIO",
+        "кордобас": "NIO",
+        "новая никарагуанская кордоба": "NIO",
+        "никарагванска златна кордоба": "NIO",
+        "никарагванска кордоба оро": "NIO",
+        "nikaragua kordobası": "NIO",
+        "нікарагуанська кордова": "NIO",
+        "درام كراباخي": "NKD",
+        "درهم قرة باغ": "NKD",
+        "dram d'artsakh": "NKD",
+        "nagorno karabakh dram": "NKD",
+        "dram de nagorno karabaj": "NKD",
+        "dram del alto karabaj": "NKD",
+        "درام قرهباغ": "NKD",
+        "درام قره باغ": "NKD",
+        "درام قرهٔ باغ": "NKD",
+        "vuoristo karabahin dram": "NKD",
+        "dram du haut karabagh": "NKD",
+        "dram de nagorno karabakh": "NKD",
+        "hegyi karabahi dram": "NKD",
+        "ナゴルノ・カラバフ・ドラム": "NKD",
+        "валюта нагорно карабахской республики": "NKD",
+        "нагорно карабахский драм": "NKD",
+        "карабахський драм": "NKD",
+        "阿尔察赫德拉姆": "NKD",
+        "كرونه نروجية": "NOK",
+        "corona de noruega": "NOK",
+        "nok": "NOK",
+        "norsk krone": "NOK",
+        "krone in norwegen": "NOK",
+        "νορβηγική κορόνα": "NOK",
+        "norvegia krono": "NOK",
+        "couronne norvegienne": "NOK",
+        "כתר נורבגי": "NOK",
+        "קרונה נורבגית": "NOK",
+        "corona norvegian": "NOK",
+        "corone norvegesi": "NOK",
+        "ノルウェーの通貨": "NOK",
+        "ノルウェークローネ": "NOK",
+        "noorse kronen": "NOK",
+        "corona norvegiana": "NOK",
+        "coroa da noruega": "NOK",
+        "валюта норвегии": "NOK",
+        "валюта шпицбергена": "NOK",
+        "валюта ян майена": "NOK",
+        "norska kronor": "NOK",
+        "روبي نيبالي": "NPR",
+        "N₨": "NPR",
+        "rupia de nepal": "NPR",
+        "rupia del nepal": "NPR",
+        "npr": "NPR",
+        "nepalesisk rupee": "NPR",
+        "karod": "NPR",
+        "rupia nepali": "NPR",
+        "روپیهٔ نپال": "NPR",
+        "roupie du népal": "NPR",
+        "roupie nepalaise": "NPR",
+        "rupia do nepal": "NPR",
+        "валюта непала": "NPR",
+        "尼泊爾盧比": "NPR",
+        "нијујски долар": "NUD",
+        "الدولار النيوزيلندي": "NZD",
+        "NZ$": "NZD",
+        "دولار نيوزيلندي nzd": "NZD",
+        "dòlar de nova zelanda": "NZD",
+        "dòlars neozelandesos": "NZD",
+        "nzd": "NZD",
+        "new zealandske dollar": "NZD",
+        "newzealandsk dollar": "NZD",
+        "kiwi dollar": "NZD",
+        "nz$": "NZD",
+        "neuseeländischer dollar": "NZD",
+        "δολάριο της νέας ζηλανδίας": "NZD",
+        "nov zelanda dolaro": "NZD",
+        "dolar de nueva zelanda": "NZD",
+        "dolar neocelandes": "NZD",
+        "dolar neocelandés": "NZD",
+        "dolar neozelandes": "NZD",
+        "dolar neozelandés": "NZD",
+        "dolar neozélandes": "NZD",
+        "dolares neozelandeses": "NZD",
+        "dólar neocelandes": "NZD",
+        "dólar neozelandes": "NZD",
+        "dólares neozelandeses": "NZD",
+        "dólar de nueva zelanda": "NZD",
+        "zeelanda berriko dolar": "NZD",
+        "zeelandaberritar dolarra": "NZD",
+        "zeelandako dolarra": "NZD",
+        "dollar neo zelandais": "NZD",
+        "dollar néozélandais": "NZD",
+        "דולר ניו זילנד": "NZD",
+        "nzドル": "NZD",
+        "ニュージーランドドル": "NZD",
+        "dólar da nova zelândia": "NZD",
+        "dólar neo zelandês": "NZD",
+        "dolarul neozeelandez": "NZD",
+        "валюта ниуэ": "NZD",
+        "валюта новой зеландии": "NZD",
+        "валюта токелау": "NZD",
+        "紐元": "NZD",
+        "ريال عُماني": "OMR",
+        "ر.ع.": "OMR",
+        "rial d'oman": "OMR",
+        "ománský rial": "OMR",
+        "ománský riál": "OMR",
+        "baiza": "OMR",
+        "rial omani": "OMR",
+        "rial dell'oman": "OMR",
+        "オマーンの通貨": "OMR",
+        "オマーン・リヤル": "OMR",
+        "omanitische rial": "OMR",
+        "rial de omã": "OMR",
+        "rial de omão": "OMR",
+        "rial do omã": "OMR",
+        "rial do omão": "OMR",
+        "rial omaniano": "OMR",
+        "валюта омана": "OMR",
+        "оманский реал": "OMR",
+        "омански риал": "OMR",
+        "baisa": "OMR",
+        "omr": "OMR",
+        "ஓமானிய ரியால்": "OMR",
+        "بالبوا": "PAB",
+        "B/.": "PAB",
+        "панамски балбоа": "PAB",
+        "pab": "PAB",
+        "balboo": "PAB",
+        "panama balboao": "PAB",
+        "balboa panameno": "PAB",
+        "balboa panameño": "PAB",
+        "balboa panameen": "PAB",
+        "balboa panaméen": "PAB",
+        "מטבע פנמה": "PAB",
+        "balboja": "PAB",
+        "бальбао": "PAB",
+        "бальбоа": "PAB",
+        "балбоа": "PAB",
+        "панамска златна балбоа": "PAB",
+        "панамська бальбоа": "PAB",
+        "سول الجديد": "PEN",
+        "S/.": "PEN",
+        "nou sol": "PEN",
+        "sol d'or": "PEN",
+        "sol de oro": "PEN",
+        "peruánský sol": "PEN",
+        "nový sol": "PEN",
+        "nueovo sol": "PEN",
+        "ny sol": "PEN",
+        "neuer sol": "PEN",
+        "peruanischer nuevo sol": "PEN",
+        "νέο σολ περού": "PEN",
+        "nova suno": "PEN",
+        "nuevo sol peruano": "PEN",
+        "sol soleno": "PEN",
+        "pen": "PEN",
+        "s/": "PEN",
+        "s/.": "PEN",
+        "sol peruano": "PEN",
+        "سل جدید پرو": "PEN",
+        "perun nuevo sol": "PEN",
+        "nouveau sol": "PEN",
+        "perui új sol": "PEN",
+        "nuovo sol": "PEN",
+        "sol novo": "PEN",
+        "moeda peruana": "PEN",
+        "novo sol peruano": "PEN",
+        "валюта перу": "PEN",
+        "новый соль": "PEN",
+        "соль": "PEN",
+        "нови сол": "PEN",
+        "перуански нуево сол": "PEN",
+        "peru nueva solü": "PEN",
+        "новий соль": "PEN",
+        "новий перуанський соль": "PEN",
+        "κίνα": "PGK",
+        "pgk": "PGK",
+        "קינה": "PGK",
+        "パプアニューギニア・キナ": "PGK",
+        "papoea nieuw guinese kina": "PGK",
+        "kina papuásia": "PGK",
+        "toea": "PGK",
+        "валюта папуа — новой гвинеи": "PGK",
+        "новогвинејска кина": "PGK",
+        "валюта папуа — нової гвінеї": "PGK",
+        "بيسو": "PHP",
+        "₱": "PHP",
+        "php": "PHP",
+        "philippine piso": "PHP",
+        "piso": "PHP",
+        "peso de filipinas": "PHP",
+        "پزو": "PHP",
+        "פסו": "PHP",
+        "pezo": "PHP",
+        "pesas": "PHP",
+        "peso de las filipinas": "PHP",
+        "пезо": "PHP",
+        "பெசோ": "PHP",
+        "pesosu": "PHP",
+        "菲律宾比索": "PHP",
+        "rupia de pakistan": "PKR",
+        "rupia del pakistan": "PKR",
+        "pakistanske rupee": "PKR",
+        "pkr": "PKR",
+        "pakistansk rupee": "PKR",
+        "πακιστανική ρουπία": "PKR",
+        "rupia pakistani": "PKR",
+        "rupia de pakistán": "PKR",
+        "روپیهٔ پاکستان": "PKR",
+        "רופי פקיסטני ": "PKR",
+        "pakistaanse rupee": "PKR",
+        "валюта пакистана": "PKR",
+        "زلوتي": "PLN",
+        "zł": "PLN",
+        "полска злотаполска злота": "PLN",
+        "zloty": "PLN",
+        "zloty polonès": "PLN",
+        "złoty polonès": "PLN",
+        "pln": "PLN",
+        "polský zlotý": "PLN",
+        "polský złoty": "PLN",
+        "polsk zloty": "PLN",
+        "polsk złoty": "PLN",
+        "polnischer zloty": "PLN",
+        "polnischer złoty": "PLN",
+        "zlote": "PLN",
+        "zloti": "PLN",
+        "zlotych": "PLN",
+        "złote": "PLN",
+        "złotych": "PLN",
+        "polish zloty": "PLN",
+        "pola zloto": "PLN",
+        "sloti": "PLN",
+        "zloty polaco": "PLN",
+        "zlott": "PLN",
+        "زلوتی": "PLN",
+        "puolan złoty": "PLN",
+        "zloty polonais": "PLN",
+        "złoty polonais": "PLN",
+        "זלוטי פולני": "PLN",
+        "poljski zloti": "PLN",
+        "zloty polonese": "PLN",
+        "złoty polacco": "PLN",
+        "zloty polacco": "PLN",
+        "zl": "PLN",
+        "ズオチ": "PLN",
+        "ズロチ": "PLN",
+        "ポーランド・ズウォティ": "PLN",
+        "poolse zloty": "PLN",
+        "polski złoty": "PLN",
+        "zlóti": "PLN",
+        "zlóti polaco": "PLN",
+        "gros": "PLN",
+        "grosz": "PLN",
+        "валюта польши": "PLN",
+        "злотый": "PLN",
+        "злот": "PLN",
+        "போலந்திய ஸ்வாட்டெ": "PLN",
+        "போலந்து ஸ்வாட்டே": "PLN",
+        "போலிய ஸ்வாட்டே": "PLN",
+        "польський злотий": "PLN",
+        "兹罗提": "PLN",
+        "波蘭茲羅提": "PLN",
+        "dòlar de les illes pitcairn": "PND",
+        "دلار جزایر پیتکارین": "PND",
+        "доллар питкерна": "PND",
+        "доллар питкэрна": "PND",
+        "питкернский доллар": "PND",
+        "питкэрнский доллар": "PND",
+        "皮特凱恩群島元": "PND",
+        "prb": "PRB",
+        "pridnjestrovska rublja": "PRB",
+        "rublo della transnistria": "PRB",
+        "沿ドニエストル共和国の通貨": "PRB",
+        "trans nistrische roebel": "PRB",
+        "rubla transnistreană": "PRB",
+        "рублэ транснистрянэ": "PRB",
+        "валюта приднестровской молдавской республики": "PRB",
+        "приднестровские рубли": "PRB",
+        "рубль пмр": "PRB",
+        "рубль приднестровья": "PRB",
+        "суворики": "PRB",
+        "придњестарска рубља": "PRB",
+        "transnistrienrubel": "PRB",
+        "transnistrierubel": "PRB",
+        "transnistriska rubel": "PRB",
+        "德涅斯特河沿岸共和國盧布": "PRB",
+        "德涅斯特河沿岸卢布": "PRB",
+        "غواراني": "PYG",
+        "₲": "PYG",
+        "paraguajský guarani": "PYG",
+        "paraguajský guaraní": "PYG",
+        "paraguayský guarani": "PYG",
+        "pyg": "PYG",
+        "paraguayan guarani": "PYG",
+        "guaraní paraguayo": "PYG",
+        "guarani paraguayen": "PYG",
+        "guaraní paraguayen": "PYG",
+        "paragvajski guaraní": "PYG",
+        "guarani paraguaiano": "PYG",
+        "paragvajaus valiuta": "PYG",
+        "paraguayaanse guaraní": "PYG",
+        "guarani paraguaio": "PYG",
+        "валюта парагвая": "PYG",
+        "гварани": "PYG",
+        "гуарани": "PYG",
+        "гуварани": "PYG",
+        "paraguajské guaraní": "PYG",
+        "paraguayansk guarani": "PYG",
+        "paraguay guaranisi": "PYG",
+        "QR": "QAR",
+        "riyal catari": "QAR",
+        "rial kataru": "QAR",
+        "لو روماني": "RON",
+        "lei": "RON",
+        "لي روماني": "RON",
+        "румънска леа": "RON",
+        "румънски леи": "RON",
+        "rumunský leu": "RON",
+        "leu": "RON",
+        "rumænsk leu": "RON",
+        "rumänischer ban": "RON",
+        "rumänischer lei": "RON",
+        "λέι": "RON",
+        "ron": "RON",
+        "rumana leŭo": "RON",
+        "rol": "RON",
+        "novo leu": "RON",
+        "לאו": "RON",
+        "לאי": "RON",
+        "מטבע רומניה": "RON",
+        "rumunjski leu": "RON",
+        "leu romanian": "RON",
+        "leu rumeno": "RON",
+        "ルーマニア・レイ": "RON",
+        "leu da roménia": "RON",
+        "leu da romênia": "RON",
+        "leul românesc": "RON",
+        "валюта румынии": "RON",
+        "лей румынский": "RON",
+        "новый лей": "RON",
+        "новый румынский лей": "RON",
+        "старый румынский лей": "RON",
+        "romunski lej": "RON",
+        "rumänska lei": "RON",
+        "ருமேனிய லியு": "RON",
+        "ரொமேனிய லியூ": "RON",
+        "din": "RSD",
+        "dinar de sèrbia": "RSD",
+        "milandor": "RSD",
+        "rsd": "RSD",
+        "دینار صربی": "RSD",
+        "denar da sérvia": "RSD",
+        "denar sérvio": "RSD",
+        "dinar da sérvia": "RSD",
+        "dinar sârb": "RSD",
+        "валюта сербии": "RSD",
+        "сербские динары": "RSD",
+        "csd": "RSD",
+        "செர்பியன் தினார்": "RSD",
+        "дин": "RSD",
+        "الروبل": "RUB",
+        "₽": "RUB",
+        "الروبل الروسي": "RUB",
+        "روبل": "RUB",
+        "rub": "RUB",
+        "rubel": "RUB",
+        "руб": "RUB",
+        "rusa rublo": "RUB",
+        "vene rubla": "RUB",
+        "errusiar errublo": "RUB",
+        "kopeekka": "RUB",
+        "neuvostoliiton rupla": "RUB",
+        "rur": "RUB",
+        "venäjän federaation rupla": "RUB",
+        "ruska rublja": "RUB",
+        "rublo russe": "RUB",
+        "ソビエト連邦ルーブル": "RUB",
+        "ロシアの通貨": "RUB",
+        "ロシアルーブル": "RUB",
+        "kopeken": "RUB",
+        "rubla rusa": "RUB",
+        "rubla rusă": "RUB",
+        "rublă rusească": "RUB",
+        "рр": "RUB",
+        "валюта абхазии": "RUB",
+        "валюта днр": "RUB",
+        "валюта лнр": "RUB",
+        "валюта россии": "RUB",
+        "валюта южной осетии": "RUB",
+        "рубль россии": "RUB",
+        "рубль российский": "RUB",
+        "ruski rubelj": "RUB",
+        "kopek": "RUB",
+        "sovjetisk rubel": "RUB",
+        "ரஷ்ய ரூபிள்": "RUB",
+        "ruble": "RUB",
+        "ruble nga": "RUB",
+        "rúp": "RUB",
+        "俄國盧布": "RUB",
+        "俄羅斯盧布": "RUB",
+        "₣": [
+            "XPF",
+            "RWF"
+        ],
+        "FRw": "RWF",
+        "franc de ruanda": "RWF",
+        "frw": "RWF",
+        "rwanda franc": "RWF",
+        "rwandan frank": "RWF",
+        "rwf": "RWF",
+        "franco de ruanda": "RWF",
+        "franco ruandes": "RWF",
+        "franco do ruanda": "RWF",
+        "руандийский франк": "RWF",
+        "валюта руанды": "RWF",
+        "руандский франк": "RWF",
+        "الريال السعودي": "SAR",
+        "SR": "SAR",
+        "ريال": "SAR",
+        "saudi rial": "SAR",
+        "halalas": "SAR",
+        "sar": "SAR",
+        "sr": "SAR",
+        "riyal": "SAR",
+        "rijalo": "SAR",
+        "saŭda rialo": "SAR",
+        "riyal saudi": "SAR",
+        "rial saoudien": "SAR",
+        "ryal saoudien": "SAR",
+        "ריאל": "SAR",
+        "rial saudita": "SAR",
+        "サウジアラビアリヤル": "SAR",
+        "サウジアラビア・リヤール": "SAR",
+        "サウジ・リアル": "SAR",
+        "サウジ・リヤル": "SAR",
+        "サウディ・リヤル": "SAR",
+        "saoedische riyal": "SAR",
+        "saudi arabische riyal": "SAR",
+        "saudische riyal": "SAR",
+        "rial saudian": "SAR",
+        "rial da arábia saudita": "SAR",
+        "riyal da arábia saudita": "SAR",
+        "валюта саудовской аравии": "SAR",
+        "риал саудовской аравии": "SAR",
+        "риял": "SAR",
+        "саудовский риал": "SAR",
+        "саудијски риал": "SAR",
+        "suudi riyali": "SAR",
+        "ріал": "SAR",
+        "沙特阿拉伯里亚尔": "SAR",
+        "dòlar de les salomó": "SBD",
+        "dòlar de les illes salomó": "SBD",
+        "dolar šalamounových ostrovů": "SBD",
+        "šalamounský dolar": "SBD",
+        "šalomounský dolar": "SBD",
+        "δολάριο νήσων σολομώντος": "SBD",
+        "δολάριο των νήσων του σολομώντα": "SBD",
+        "solomon dollar": "SBD",
+        "dolar de las islas salomon": "SBD",
+        "dolar de las islas salomón": "SBD",
+        "sbd": "SBD",
+        "dolar salomonense": "SBD",
+        "dólar salomonense": "SBD",
+        "dollar des iles salomon": "SBD",
+        "dollaro delle isole salomone": "SBD",
+        "ソロモン諸島・ドル": "SBD",
+        "dolar de las illas salamon": "SBD",
+        "валюта соломоновых островов": "SBD",
+        "долар соломонских острва": "SBD",
+        "SI$": "SBD",
+        "SRe": "SCR",
+        "seychellisk rupee": "SCR",
+        "seychellerne rupee": "SCR",
+        "seychelles rupee": "SCR",
+        "ρουπία των σεϋχελλών": "SCR",
+        "sre": "SCR",
+        "rupia seychelense": "SCR",
+        "scr": "SCR",
+        "seychelle szigeteki rúpia": "SCR",
+        "セイシェル・ルピー": "SCR",
+        "seychelse roepia": "SCR",
+        "seychelse rupee": "SCR",
+        "валюта сейшел": "SCR",
+        "валюта сейшельских островов": "SCR",
+        "الجنيه السودانى": "SDG",
+        "ج.س": "SDG",
+        "الدينار السودانى": "SDG",
+        "دينار سوداني": "SDG",
+        "суданска лира": "SDG",
+        "lliura del sudan": "SDG",
+        "λίρα σουδάν": "SDG",
+        "sdg": "SDG",
+        "libra de sudán": "SDG",
+        "libra del sudán": "SDG",
+        "dinar soudanais": "SDG",
+        "לירה סודאנית": "SDG",
+        "soedanese pond": "SDG",
+        "валюта судана": "SDG",
+        "sdd": "SDG",
+        "sudanesisk pund": "SDG",
+        "sud£": "SDG",
+        "كرونه سويدية": "SEK",
+        "corona de suècia": "SEK",
+        "sek": "SEK",
+        "svensk krone": "SEK",
+        "svenske kroner": "SEK",
+        "kronor": "SEK",
+        "schwedenkrone": "SEK",
+        "svedia krono": "SEK",
+        "corona": "SEK",
+        "couronne suedoise": "SEK",
+        "coroa sueca svensk krona": "SEK",
+        "כתר שבדי": "SEK",
+        "スウェーデン・クローネ": "SEK",
+        "zweedse kronen": "SEK",
+        "coroa da suécia": "SEK",
+        "валюта аландских островов": "SEK",
+        "валюта швеции": "SEK",
+        "крона швеции": "SEK",
+        "svenska kronor": "SEK",
+        "svenska sedlar": "SEK",
+        "சுவீடன் குரோணர்": "SEK",
+        "S$": "SGD",
+        "s$": "SGD",
+        "sgd": "SGD",
+        "singaporeansk dollar": "SGD",
+        "singaporeanske dollars": "SGD",
+        "dolar de singapur": "SGD",
+        "dollar singapourien": "SGD",
+        "מטבע סינגפור": "SGD",
+        "シンガポールの通貨": "SGD",
+        "シンガポール・ドル": "SGD",
+        "星ドル": "SGD",
+        "dolar de singapor": "SGD",
+        "dólar de cingapura": "SGD",
+        "dólar singapurense": "SGD",
+        "валюта сингапура": "SGD",
+        "сингапуршки долар": "SGD",
+        "சிங்கப்பூர் டாலர்": "SGD",
+        "dollar singapore": "SGD",
+        "đôla singapore": "SGD",
+        "叻元": "SGD",
+        "坡元": "SGD",
+        "新元": "SGD",
+        "新加坡幣": "SGD",
+        "新幣": "SGD",
+        "جنيه سانت هيلينا": "SHP",
+        "lliura de saint helena": "SHP",
+        "sankt helena pundo": "SHP",
+        "sent helena pundo": "SHP",
+        "senthelena pundo": "SHP",
+        "livre de sainte helene": "SHP",
+        "sterlina di sant’elena": "SHP",
+        "libra santa helenense": "SHP",
+        "фунт острова святой елены": "SHP",
+        "聖赫倫那鎊": "SHP",
+        "Le": "SLL",
+        "λεόνε": "SLL",
+        "sll": "SLL",
+        "leone sierra léonais": "SLL",
+        "leone della sierra leone": "SLL",
+        "シエラレオネの通貨": "SLL",
+        "シエラレオネ・レオン": "SLL",
+        "レオネ": "SLL",
+        "leone serra leonino": "SLL",
+        "леоне сьерра леоне": "SLL",
+        "сијералеонске леоне": "SLL",
+        "Sh.So.": "SOS",
+        "xíling de somàlia": "SOS",
+        "σελίνι της σομαλίας": "SOS",
+        "σομαλιανό σελίνι": "SOS",
+        "currency of somalia": "SOS",
+        "sh.so.": "SOS",
+        "sos": "SOS",
+        "sosh": "SOS",
+        "chelin": [
+            "UGX",
+            "TZS",
+            "SOS"
+        ],
+        "chelin de somalia": "SOS",
+        "chelin somali": "SOS",
+        "chelín": [
+            "UGX",
+            "TZS",
+            "SOS"
+        ],
+        "chelín de somalia": "SOS",
+        "somalian shillinki": "SOS",
+        "somalian sillinki": "SOS",
+        "shilling somali": "SOS",
+        "szomáli shilling": "SOS",
+        "ソマリアシリング": "SOS",
+        "валюта сомали": "SOS",
+        "сомалски шилинг": "SOS",
+        "shilin": "SOS",
+        "索馬里先令": "SOS",
+        "索马里先令": "SOS",
+        "srd": "SRD",
+        "surinam dollar": "SRD",
+        "δολάριο του σουρινάμ": "SRD",
+        "dolar de surinam": "SRD",
+        "dolar surinames": "SRD",
+        "dolar surinamés": "SRD",
+        "dólar de surinam": "SRD",
+        "dólar surinames": "SRD",
+        "dollar du surinam": "SRD",
+        "dollar surinamien": "SRD",
+        "dollaro del suriname": "SRD",
+        "スリナムドル": "SRD",
+        "dólar surinamense": "SRD",
+        "dólar surinamês": "SRD",
+        "валюта суринама": "SRD",
+        "суринамски гилдер": "SRD",
+        "суринамски гулден": "SRD",
+        "苏利南元": "SRD",
+        "苏里南元": "SRD",
+        "蘇里南元": "SRD",
+        "Db": [
+            "STN",
+            "SSP"
+        ],
+        "lliura del sudan del sud": "SSP",
+        "südsudan pfund": "SSP",
+        "südsudan pound": "SSP",
+        "sud sudana pundo": "SSP",
+        "libra de sudan del sur": "SSP",
+        "libra de sudán del sur": "SSP",
+        "פאונד דרום סודאני": "SSP",
+        "sterlina sud sudanese": "SSP",
+        "zuid soedanese pond": "SSP",
+        "liura sodanesa": "SSP",
+        "funt południowego sudanu": "SSP",
+        "валюта южного судана": "SSP",
+        "фунт южного судана": "SSP",
+        "южно суданский фунт": "SSP",
+        "دوبرا": "STN",
+        "دوبرا ساو تومية وبرينسيبية": "STN",
+        "saotomea dobro": "STN",
+        "sao tomea dobro": "STN",
+        "sao tomeo kaj principea dobra": "STN",
+        "دبرای سائوتومه و پرینسیپ": "STN",
+        "dobra santoméen": "STN",
+        "דוברה": "STN",
+        "dobra san tomea i prinsipea": "STN",
+        "dobra svetog tome i principa": "STN",
+        "dobra svetog tome i prinsipa": "STN",
+        "dobra svetog tome i prinsipea": "STN",
+        "dobra svetoga tome i principa": "STN",
+        "dobra svetoga tome i prinsipa": "STN",
+        "dobra svetoga tome i prinsipea": "STN",
+        "santomska dobra": "STN",
+        "saotomska dobra": "STN",
+        "dobra di sao tomé e principe": "STN",
+        "サントメ・プリンシペ・ドブラ": "STN",
+        "stn": "STN",
+        "валюта сан томе и принсипи": "STN",
+        "добра": "STN",
+        "الليرة السورية": "SYP",
+        "syr£": "SYP",
+        "الليره السورية": "SYP",
+        "ليرات سورية": "SYP",
+        "ليره سوريه": "SYP",
+        "lira de síria": "SYP",
+        "lira síria": "SYP",
+        "lliura de síria": "SYP",
+        "syp": "SYP",
+        "syrisches pfund": "SYP",
+        "syrian liyra": "SYP",
+        "syr": "SYP",
+        "dolar sirio": "SYP",
+        "لیرهٔ سوریه": "SYP",
+        "پوند سوریه": "SYP",
+        "libra da síria": "SYP",
+        "валюта сирии": "SYP",
+        "sirijska lira": "SYP",
+        "sirijski funt": "SYP",
+        "sirska lira": "SYP",
+        "syrisk lira": "SYP",
+        "LS": "SYP",
+        "ليلانغيني": "SZL",
+        "E": "SZL",
+        "emalangeni": "SZL",
+        "eswatini lilangeni": "SZL",
+        "swaziland lilangeni": "SZL",
+        "lilangeni de suazilandia": "SZL",
+        "لیلانگنی سوازیلند": "SZL",
+        "lilangeni swazilandais": "SZL",
+        "svazijski lilangeni": "SZL",
+        "szl": "SZL",
+        "lilangeni dello swaziland": "SZL",
+        "エマランゲニ": "SZL",
+        "スワジ・リランジェニ": "SZL",
+        "リランジェニ": "SZL",
+        "lilangeni suázi": "SZL",
+        "свазилендский лилангени": "SZL",
+        "валюта свазиленда": "SZL",
+        "свазилендски лилангени": "SZL",
+        "лилиангени": "SZL",
+        "свазиландски лилангени": "SZL",
+        "ліланджені": "SZL",
+        "史瓦濟蘭里蘭吉尼": "SZL",
+        "البات": "THB",
+        "฿": "THB",
+        "بات": "THB",
+        "بات تايلندي": "THB",
+        "باخت": "THB",
+        "tical": "THB",
+        "fuang": "THB",
+        "fyän": "THB",
+        "salyn": "THB",
+        "salüng": "THB",
+        "tschang": "THB",
+        "tömling": "THB",
+        "xang": "THB",
+        "μπαχτ": "THB",
+        "thb": "THB",
+        "bahto": "THB",
+        "satango": "THB",
+        "taja bahto": "THB",
+        "tikalo": "THB",
+        "baht tailandes": "THB",
+        "bhat": "THB",
+        "tai baat": "THB",
+        "تای بات": "THB",
+        "thaimaan baht": "THB",
+        "bath": "THB",
+        "タイの通貨": "THB",
+        "タイ・バーツ": "THB",
+        "batas": "THB",
+        "satang": "THB",
+        "baht tailandês": "THB",
+        "валюта таиланда": "THB",
+        "сиамский бат": "THB",
+        "таиландский бат": "THB",
+        "тајландски бахт": "THB",
+        "tayland'ın para birimi": "THB",
+        "бат": "THB",
+        "baht thái": "THB",
+        "baht thái lan": "THB",
+        "bạt thái": "THB",
+        "bạt thái lan": "THB",
+        "泰币": "THB",
+        "泰铢": "THB",
+        "ساماني": "TJS",
+        "SM": "TJS",
+        "سامانی طاجيكي": "TJS",
+        "سمني": "TJS",
+        "سموني طاجيكي": "TJS",
+        "سمونی طاجيكي": "TJS",
+        "tjs": "TJS",
+        "tajik somoni": "TJS",
+        "currency of tajikistan": "TJS",
+        "somoni taxico": "TJS",
+        "סומוני טג'קיסטני": "TJS",
+        "somoni tagico": "TJS",
+        "タジキスタン・ソモニ": "TJS",
+        "tadžikijos somonis": "TJS",
+        "somoni tadżycki": "TJS",
+        "somoni tadjic": "TJS",
+        "таджикский сомони": "TJS",
+        "валюта таджикистана": "TJS",
+        "таџикистанска рубља": "TJS",
+        "сомоні": "TJS",
+        "塔吉克索莫尼": "TJS",
+        "عملات سنتافو تيمورية شرقية": "TLD",
+        "centavo de dólar de timor oriental": "TLD",
+        "centavos de dolar de timor oriental": "TLD",
+        "سکه کنتاووی تیمور خاوری": "TLD",
+        "סנטאבו מזרח טימורי": "TLD",
+        "moedas de centavo do timor leste": "TLD",
+        "восточно тиморские монеты": "TLD",
+        "T": "TMT",
+        "туркменски манат": "TMT",
+        "manat de turkmenistan": "TMT",
+        "manat del turkmenistan": "TMT",
+        "teňňe": "TMT",
+        "μανάτ τουρκμενίας": "TMT",
+        "manat turkmene": "TMT",
+        "manat de turkmenistán": "TMT",
+        "tmm": "TMT",
+        "トルクメン・マナト": "TMT",
+        "turkmėnistano manatas": "TMT",
+        "manat turcmèn": "TMT",
+        "manate do turcomenistão": "TMT",
+        "manatul turkmen": "TMT",
+        "tmt": "TMT",
+        "валюта туркмении": "TMT",
+        "новый манат": "TMT",
+        "новый туркменский манат": "TMT",
+        "туркменистанский манат": "TMT",
+        "туркменский новый манат": "TMT",
+        "тукменистански манат": "TMT",
+        "土庫曼馬納特": "TMT",
+        "الدينار التونسي": "TND",
+        "DT": "TND",
+        "دينار التونسي": "TND",
+        "dinar de tunísia": "TND",
+        "dinar tunisiaidd": "TND",
+        "millime": "TND",
+        "tunis dinar": "TND",
+        "tnd": "TND",
+        "dinar de tunez": "TND",
+        "dinar de túnez": "TND",
+        "دينار تونس": "TND",
+        "tuniški dinar": "TND",
+        "denar da tunísia": "TND",
+        "denar tunisiano": "TND",
+        "denar tunisino": "TND",
+        "dinar da tunísia": "TND",
+        "dinar tunisino": "TND",
+        "валюта туниса": "TND",
+        "тунижански динар": "TND",
+        "突尼斯第纳尔": "TND",
+        "بانجا تونجي": "TOP",
+        "بانجا": "TOP",
+        "T$": "TOP",
+        "pa’anga": "TOP",
+        "tonžská pa'anga": "TOP",
+        "tonžská paanga": "TOP",
+        "paanga": "TOP",
+        "t$": "TOP",
+        "tonga dollar": "TOP",
+        "tonga pa`anga": "TOP",
+        "tonga paʻanga": "TOP",
+        "tongan pa`anga": "TOP",
+        "dolar tongano": "TOP",
+        "dólar tongano": "TOP",
+        "pa'anga tongana": "TOP",
+        "پاآنگای تنگو": "TOP",
+        "פאנגה": "TOP",
+        "פנגה טונגית": "TOP",
+        "tongaška pa’anga": "TOP",
+        "tongai pa'anga": "TOP",
+        "tongai pa’anga": "TOP",
+        "tongan pa'anga": "TOP",
+        "pa'anga tongano": "TOP",
+        "pa'anga di tonga": "TOP",
+        "パ・アンガ": "TOP",
+        "トンガ・パ・アンガ": "TOP",
+        "tongos pa'anga": "TOP",
+        "paʻanga tonganesa": "TOP",
+        "тонганская паанга": "TOP",
+        "валюта тонга": "TOP",
+        "доллар тонги": "TOP",
+        "сенити": "TOP",
+        "тонганский доллар": "TOP",
+        "панга": "TOP",
+        "top": "TOP",
+        "潘加": "TOP",
+        "ليرة تركية جديدة": "TRY",
+        "₺": "TRY",
+        "lira de turquia": "TRY",
+        "lliura de turquia": "TRY",
+        "lliura turca": "TRY",
+        "nova lira de turquia": "TRY",
+        "nova lira turca": "TRY",
+        "nova lliura de turquia": "TRY",
+        "nova lliura turca": "TRY",
+        "nová turecká lira": "TRY",
+        "kurus": "TRY",
+        "kuruş": "TRY",
+        "neue türkische lira": "TRY",
+        "ytl": "TRY",
+        "yeni kuruş": "TRY",
+        "yeni türk lirası": "TRY",
+        "λίρα τουρκίας": "TRY",
+        "νέα τουρκική λίρα": "TRY",
+        "trl": "TRY",
+        "try": "TRY",
+        "nova turka liro": "TRY",
+        "nova turkia liro": "TRY",
+        "turkia liro": "TRY",
+        "nueva lira turca": "TRY",
+        "لیره جدید ترکیه": "TRY",
+        "livre turque": "TRY",
+        "livres turques": "TRY",
+        "nouvelle livre turque": "TRY",
+        "lira turc": "TRY",
+        "トルコ・リラ": "TRY",
+        "turkijos lira": "TRY",
+        "lira da turquia": "TRY",
+        "liras turcas": "TRY",
+        "nova libra turca": "TRY",
+        "lira turcească": "TRY",
+        "liră turcă": "TRY",
+        "валюта турецкой республики северного кипра": "TRY",
+        "валюта турции": "TRY",
+        "новая турецкая лира": "TRY",
+        "старая турецкая лира": "TRY",
+        "турецкий фунт": "TRY",
+        "nová turecká líra": "TRY",
+        "нова турска лира": "TRY",
+        "турска нова лира": "TRY",
+        "turkiska lira": "TRY",
+        "新土耳其里拉": "TRY",
+        "TT$": "TTD",
+        "тринидадски и тобагски долар": "TTD",
+        "dòlar de trinitat": "TTD",
+        "dòlar de trinitat tobago": "TTD",
+        "trinidadsko tobagský dolar": "TTD",
+        "tt$": "TTD",
+        "δολάριο τρινιντάντ και τομπάγκο": "TTD",
+        "trinidada tobaga dolaro": "TTD",
+        "dolar de trinidad y tobago": "TTD",
+        "dolar trinitense": "TTD",
+        "dólar de trinidad y tobago": "TTD",
+        "trinidad ja tobagon dollari": "TTD",
+        "dollar de trinidad et tobago": "TTD",
+        "dollar trinidadien": "TTD",
+        "trinidad en tobago dollar": "TTD",
+        "dolar trynidadzki": "TTD",
+        "dólar de trindade e tabago": "TTD",
+        "dólar de trindade e tobago": "TTD",
+        "dólar de trinidad e tabago": "TTD",
+        "dólar de trinidade e tabago": "TTD",
+        "dólar de trinidade e tobago": "TTD",
+        "dólar trinitino": "TTD",
+        "dólar trinitário": "TTD",
+        "валюта тринидада и тобаго": "TTD",
+        "тринидадский доллар": "TTD",
+        "trinidadsko tobažský dolár": "TTD",
+        "тринидад и тобаго долар": "TTD",
+        "долар тринідаду та тобаго": "TTD",
+        "千里達托貝哥元": "TTD",
+        "$T": "TVD",
+        "δολάριο του τουβαλού": "TVD",
+        "δολλάριο του τουβαλού": "TVD",
+        "$t": "TVD",
+        "tv$": "TVD",
+        "tvd": "TVD",
+        "tuvalu dollar": "TVD",
+        "dolar tuvaluano": "TVD",
+        "dolar de tuvalu": "TVD",
+        "dólar de tuvalu": "TVD",
+        "dollar de tuvalu": "TVD",
+        "tuvaluški dolar": "TVD",
+        "тувалуски долар": "TVD",
+        "圖瓦盧元": "TVD",
+        "TV$": "TVD",
+        "nt$": "TWD",
+        "NT$": "TWD",
+        "dòlar de taiwan": "TWD",
+        "dòlar taiwanès": "TWD",
+        "nou dòlar taiwanès": "TWD",
+        "nový tchajwanský dolar": "TWD",
+        "nový tchajwanský jüan": "TWD",
+        "twd": "TWD",
+        "tchajwanský jüan": "TWD",
+        "doler newydd taiwan": "TWD",
+        "taiwan dollar": "TWD",
+        "δολάριο ταϊβάν": "TWD",
+        "ntd": "TWD",
+        "tajvana dolaro": "TWD",
+        "dolar taiwanes": "TWD",
+        "dolar taiwanés": "TWD",
+        "dólar taiwanes": "TWD",
+        "dólar taiwanés": "TWD",
+        "nuevo dolar de taiwan": "TWD",
+        "nuevo dolar de taiwán": "TWD",
+        "nuevo dolar taiwanes": "TWD",
+        "nuevo dolar taiwanés": "TWD",
+        "nuevo dólar de taiwan": "TWD",
+        "nuevo dólar de taiwán": "TWD",
+        "nuevo dólar taiwanes": "TWD",
+        "dollar de taiwan": "TWD",
+        "dollar taiwanais": "TWD",
+        "dollar taïwanais": "TWD",
+        "nuovo dollaro taiwanese": "TWD",
+        "ニュー台湾ドル": "TWD",
+        "ntドル": "TWD",
+        "台湾の通貨": "TWD",
+        "台湾ドル": "TWD",
+        "台湾元": "TWD",
+        "新台幣": "TWD",
+        "nowy dolar tajwański": "TWD",
+        "dólar de taiuã": "TWD",
+        "dólar de taiwan": "TWD",
+        "dólar taiuanês": "TWD",
+        "dólar taiwanês": "TWD",
+        "novo dólar de taiuã": "TWD",
+        "novo dólar de taiwan": "TWD",
+        "novo dólar taiuanês": "TWD",
+        "валюта китайской республики": "TWD",
+        "тајвански долар": "TWD",
+        "tayvan doları": "TWD",
+        "đài tệ": "TWD",
+        "đô la đài loan mới": "TWD",
+        "台幣": "TWD",
+        "新台币": "TWD",
+        "臺幣": "TWD",
+        "TSh": "TZS",
+        "xíling de tanzània": "TZS",
+        "swllt tanzania": "TZS",
+        "tzs": "TZS",
+        "shilingi": "TZS",
+        "tsh": "TZS",
+        "tanzanian schilling": "TZS",
+        "tanzanian shilingi": "TZS",
+        "chelin de tanzania": "TZS",
+        "chelin tanzano": "TZS",
+        "chelín de tanzania": "TZS",
+        "szyling tanzanii": "TZS",
+        "xelim da tanzania": "TZS",
+        "xelim da tanzânia": "TZS",
+        "валюта танзании": "TZS",
+        "танзански шилинг": "TZS",
+        "tanzaniansk shilling": "TZS",
+        "tanzansk shilling": "TZS",
+        "坦先令": "TZS",
+        "₴": "UAH",
+        "hrývnia": "UAH",
+        "hřivna": "UAH",
+        "griwna": "UAH",
+        "hryvnja": "UAH",
+        "hrywen": "UAH",
+        "hrywni": "UAH",
+        "ukrainische hrywnja": "UAH",
+        "γρίβνα ουκρανίας": "UAH",
+        "γρίβνια": "UAH",
+        "χρίβνα": "UAH",
+        "hryvnya": "UAH",
+        "uah": "UAH",
+        "hrivno": "UAH",
+        "ukrainia hrivno": "UAH",
+        "grivnia": "UAH",
+        "grivnia ucraniana": "UAH",
+        "gryvnia": "UAH",
+        "hryvna": "UAH",
+        "grivna ucraniana": "UAH",
+        "грн": "UAH",
+        "krivna": "UAH",
+        "گریونا": "UAH",
+        "riuna": "UAH",
+        "ukrainan hryvnja": "UAH",
+        "hryvnia ukrainienne": "UAH",
+        "grivnja": "UAH",
+        "ukrajinska hrivnja": "UAH",
+        "hryvnja ukrainian": "UAH",
+        "hryvnia ucraina": "UAH",
+        "グリブナ": "UAH",
+        "グルィーヴナ": "UAH",
+        "フリブニャ": "UAH",
+        "フリヴナ": "UAH",
+        "フルィヴニャ": "UAH",
+        "フルィーヴニャ": "UAH",
+        "oekraïense hryvnja": "UAH",
+        "oekraiense hryvnja": "UAH",
+        "hrywna ukraińska": "UAH",
+        "grívnia ucraniana": "UAH",
+        "grivnă ucraineană": "UAH",
+        "hrn": "UAH",
+        "валюта украины": "UAH",
+        "валюта в украине": "UAH",
+        "валюта на украине": "UAH",
+        "гривна": "UAH",
+        "гривна украины": "UAH",
+        "украинская валюта": "UAH",
+        "украинская гривня": "UAH",
+        "украјинска хривња": "UAH",
+        "гривња": "UAH",
+        "karbovanet": "UAH",
+        "உக்ரைனிய ஹிரீவ்னியா": "UAH",
+        "உக்ரைனிய ஹிருன்யா": "UAH",
+        "українська гривня": "UAH",
+        "гривні": "UAH",
+        "грн.": "UAH",
+        "乌克兰格里夫尼亚": "UAH",
+        "乌克兰赫里夫尼亚": "UAH",
+        "烏克蘭荷林夫納": "UAH",
+        "Ush": "UGX",
+        "xíling d'uganda": "UGX",
+        "ugx": "UGX",
+        "σελίνι ουγκάντας": "UGX",
+        "ush": "UGX",
+        "uganda shilling": "UGX",
+        "chelin de uganda": "UGX",
+        "chelin ugandes": "UGX",
+        "chelín de uganda": "UGX",
+        "ウガンダシリング": "UGX",
+        "ugandese shilling": "UGX",
+        "валюта уганды": "UGX",
+        "US$": "USD",
+        "usd": "USD",
+        "us $": "USD",
+        "american dollar": "USD",
+        "u. s. dollar": "USD",
+        "u.s. dollar": "USD",
+        "us$": "USD",
+        "dolar estadounidense": "USD",
+        "dollar des états unis": "USD",
+        "dollar étatsunien": "USD",
+        "ドル": "USD",
+        "米ドル": "USD",
+        "dólar americano": "USD",
+        "dolari americani": "USD",
+        "$ сша": "USD",
+        "американский доллар": "USD",
+        "abd doları": "USD",
+        "u.s.$": "USD",
+        "американський долар": "USD",
+        "mĩ kim": "USD",
+        "mỹ kim": "USD",
+        "đô": "USD",
+        "đô la hoa kì": "USD",
+        "đô la hoa kỳ": "USD",
+        "đô la mĩ": "USD",
+        "đôla mĩ": "USD",
+        "đôla mỹ": "USD",
+        "đồng bạc mĩ": "USD",
+        "đồng bạc mỹ": "USD",
+        "美刀": "USD",
+        "美金": "USD",
+        "بيزو أوروغواني": "UYU",
+        "$U": "UYU",
+        "peso d'uruguai": "UYU",
+        "peso de l'uruguai": "UYU",
+        "$u": "UYU",
+        "uyu": "UYU",
+        "uruguay peso": "UYU",
+        "peso de uruguay": "UYU",
+        "پزوی اوروگوئه": "UYU",
+        "peso d'uruguay": "UYU",
+        "פסו של אורוגוואי": "UYU",
+        "urugvajski peso": "UYU",
+        "peso uruguaian": "UYU",
+        "peso do uruguai": "UYU",
+        "валюта уругвая": "UYU",
+        "уругвайский песо": "UYU",
+        "нови уругвајски пезос": "UYU",
+        "нови уругвајски песо": "UYU",
+        "уругвајски песо": "UYU",
+        "uruguyansk peso": "UYU",
+        "уругвайське песо": "UYU",
+        "سوم أوزبيكستاني": "UZS",
+        "So'm": "UZS",
+        "som d'uzbekistan": "UZS",
+        "som de l'uzbekistan": "UZS",
+        "uzbecký som": "UZS",
+        "so'm": "UZS",
+        "söm": "UZS",
+        "tiyin": "UZS",
+        "usbekistan som": "UZS",
+        "usbekistan sum": "UZS",
+        "ουζμπεκικό σομ": "UZS",
+        "uzbekistani som": "UZS",
+        "uzbeka sumo": "UZS",
+        "som uzbeco": "UZS",
+        "sum uzbeco": "UZS",
+        "sum uzbeko": "UZS",
+        "سم ازبکستان": "UZS",
+        "uzs": "UZS",
+        "som usbeco": "UZS",
+        "ウズベキスタン・スム": "UZS",
+        "ウズベキスタン・ソム": "UZS",
+        "uzbekijos somas": "UZS",
+        "uzbekistano sumas": "UZS",
+        "sum uzbecki": "UZS",
+        "som usbeque": "UZS",
+        "som uzbeque": "UZS",
+        "sum usbeque": "UZS",
+        "sum uzbeque": "UZS",
+        "валюта узбекистана": "UZS",
+        "узбекистанский сум": "UZS",
+        "сум": "UZS",
+        "узбекистански сум": "UZS",
+        "узбецький сом": "UZS",
+        "烏茲別克索姆": "UZS",
+        "苏姆": "UZS",
+        "Bs.S": "VES",
+        "ves": "VES",
+        "دونغ": "VND",
+        "₫": "VND",
+        "vnd": "VND",
+        "vnđ": "VND",
+        "ντογκ": "VND",
+        "đong": "VND",
+        "دونگ ویتنام": "VND",
+        "vietnamin dong": "VND",
+        "dong vietnamien": "VND",
+        "דונג וייטנאמי ": "VND",
+        "dong vietnamita": "VND",
+        "ベトナムドン": "VND",
+        "ベトナム・ドン": "VND",
+        "越南銅": "VND",
+        "dongas": "VND",
+        "dongue vietnamita": "VND",
+        "вьетнамский донг": "VND",
+        "xu": "VND",
+        "валюта вьетнама": "VND",
+        "việt nam đồng": "VND",
+        "tiền cụ hồ": "VND",
+        "đồng việt nam": "VND",
+        "đồng tiền": "VND",
+        "越盾": "VND",
+        "VT": "VUV",
+        "vanuatu vatus": "VUV",
+        "vatuo": "VUV",
+        "vuv": "VUV",
+        "vanuatuanski vatu": "VUV",
+        "vatu di vanuatu": "VUV",
+        "バヌアツの通貨": "VUV",
+        "vatu do vanuatu": "VUV",
+        "валюта вануату": "VUV",
+        "вануатский вату": "VUV",
+        "uvu": "VUV",
+        "вануатійський вату": "VUV",
+        "تالا ساموية": "WST",
+        "WS$": "WST",
+        "tala samoà": "WST",
+        "ws$": "WST",
+        "samoa dolaro": "WST",
+        "tālā samoano": "WST",
+        "טלה": "WST",
+        "wst": "WST",
+        "サモアの通貨": "WST",
+        "サモアドル": "WST",
+        "サモア・タラ": "WST",
+        "サモア・ターラ": "WST",
+        "サモア・ドル": "WST",
+        "валюта самоа": "WST",
+        "доллар самоа": "WST",
+        "самоанский доллар": "WST",
+        "тала": "WST",
+        "塔拉": "WST",
+        "فرنك س ف ا وسط أفريقيا": "XAF",
+        "xaf": "XAF",
+        "frank beac/cfa": "XAF",
+        "ffranc canol affrica": "XAF",
+        "centr afrika franko": "XAF",
+        "franco cfa de africa central": "XAF",
+        "فرانک آفریقای مرکزی": "XAF",
+        "فرانک سی اف ای آفریقای مرکزی": "XAF",
+        "فرانک سی اف ای آفریقای میانه": "XAF",
+        "فرانک سی اف ای افریقای میانه": "XAF",
+        "فرانک سی اف ای مرکز آفریقا": "XAF",
+        "فرانک سی اف ای میانه آفریقا": "XAF",
+        "keski afrikan cfa frangi": "XAF",
+        "franc cfa d'afrique centrale": "XAF",
+        "פרנק cfa מרכז אפריקני": "XAF",
+        "cfa": "XAF",
+        "franco cfa dell'africa centrale": "XAF",
+        "中部アフリカcfaフラン": "XAF",
+        "cfa franc": [
+            "XOF",
+            "XAF"
+        ],
+        "franc centrafrican cfa": "XAF",
+        "franc central african cfa": "XAF",
+        "валюта габона": "XAF",
+        "валюта камеруна": "XAF",
+        "валюта республики конго": "XAF",
+        "валюта центральноафриканской республики": "XAF",
+        "валюта чада": "XAF",
+        "валюта экваториальной гвинеи": "XAF",
+        "франк кфа веас": "XAF",
+        "центральноафриканский франк кфа": "XAF",
+        "central africa cfa franc": "XAF",
+        "மத்திய ஆப்பிரிக்க சி.எஃப்.ஏ பிராங்க்": "XAF",
+        "orta afrika cfa frankı": "XAF",
+        "cfa franc trung phi": "XAF",
+        "中非法郎": "XAF",
+        "ag": "XAG",
+        "العنصر 47": "XAG",
+        "العنصر رقم 47": "XAG",
+        "الفضة": "XAG",
+        "عنصر 47": "XAG",
+        "ασήμι": "XAG",
+        "element 47": "XAG",
+        "سیم": "XAG",
+        "ezüstany": "XAG",
+        "elemento 47": "XAG",
+        "العنصر 79": "XAU",
+        "au": "XAU",
+        "aurum": "XAU",
+        "χρυσάφι": "XAU",
+        "element 79": "XAU",
+        "elemento 79": "XAU",
+        "aurifera": "XAU",
+        "aurifero": "XAU",
+        "aurífera": "XAU",
+        "aurífero": "XAU",
+        "زر": "XAU",
+        "grundämne 79": "XAU",
+        "பொன்": "XAU",
+        "البيتكوين": "XBT",
+        "₿": "XBT",
+        "btc": "XBT",
+        "bitcoins": "XBT",
+        "microcoin": "XBT",
+        "millicoin": "XBT",
+        "mbtc": "XBT",
+        "satoshi": "XBT",
+        "μbtc": "XBT",
+        "xbt": "XBT",
+        "بیت کوین": "XBT",
+        "cryptografisch geld": "XBT",
+        "биткоин": "XBT",
+        "比特幣": "XBT",
+        "位元幣": "XBT",
+        "EC$": "XCD",
+        "eastern caribbean currency union": "XCD",
+        "východokaribská měnová unie": "XCD",
+        "xcd": "XCD",
+        "ec$": "XCD",
+        "ostkaribische währungsunion": "XCD",
+        "δολλάριο ανατολικής καραϊβικής": "XCD",
+        "orient kariba dolaro": "XCD",
+        "orientkariba dolaro": "XCD",
+        "dolar caribe este": "XCD",
+        "dolar del caribe este": "XCD",
+        "dolar del caribe oriental": "XCD",
+        "dólar caribe este": "XCD",
+        "dólar del caribe este": "XCD",
+        "dollar de la caraibe orientale": "XCD",
+        "dollar de la caraïbe orientale": "XCD",
+        "dólar caribe leste": "XCD",
+        "דולר מזרח קאריבי": "XCD",
+        "מטבע אנטיגואה וברבודה": "XCD",
+        "מטבע גרנדה": "XCD",
+        "מטבע דומיניקה": "XCD",
+        "מטבע סנט וינסנט והגרנדינים": "XCD",
+        "מטבע סנט לושה": "XCD",
+        "מטבע סנט קיטס ונוויס": "XCD",
+        "東カリブドル": "XCD",
+        "oost caraibische dollar": "XCD",
+        "oost caraïbische dollar": "XCD",
+        "dolar de las caribas orientalas": "XCD",
+        "dólar das caraíbas": "XCD",
+        "dólar das caraíbas orientais": "XCD",
+        "восточно карибский доллар": "XCD",
+        "валюта ангильи": "XCD",
+        "валюта антигуа и барбуды": "XCD",
+        "கிழக்குக் கரிபியன் டாலர்": "XCD",
+        "східно карибський долар": "XCD",
+        "đô la đông caribbe": "XCD",
+        "спт": "XDR",
+        "deg": "XDR",
+        "xdr": "XDR",
+        "special drawing right, sdr": "XDR",
+        "special drawing rights, sdr": "XDR",
+        "erityinen nosto oikeus": "XDR",
+        "erityiset nosto oikeudet": "XDR",
+        "sdrs": "XDR",
+        "droits de tirage speciaux": "XDR",
+        "papierowe złoto": "XDR",
+        "specjalne prawo ciągnienia": "XDR",
+        "сдр": "XDR",
+        "спз": "XDR",
+        "zpč": "XDR",
+        "special drawings right": "XDR",
+        "европейска валутна единица": "XEU",
+        "₠": "XEU",
+        "unitat de compte europea": "XEU",
+        "xeu": "XEU",
+        "ελμ": "XEU",
+        "eŭropa monunuo": "XEU",
+        "e.c.u.": "XEU",
+        "unité de compte européen": "XEU",
+        "unité de compte européenne": "XEU",
+        "unité monétaire européenne": "XEU",
+        "unidade monetaria europea": "XEU",
+        "יחידת מטבע אירופי": "XEU",
+        "ヨーロッパ通貨単位": "XEU",
+        "écu": "XEU",
+        "unitate monetară europeană": "XEU",
+        "европейская валютная единица": "XEU",
+        "歐洲通貨單位": "XEU",
+        "stellar lumens": "XLM",
+        "xlm": "XLM",
+        "xmr": "XMR",
+        "mo": "XMR",
+        "bitmonero": "XMR",
+        "墨內羅": "XMR",
+        "فرنك س ف ا غرب أفريقيا": "XOF",
+        "F": "XOF",
+        "xof": "XOF",
+        "φράγκο cfa bceao": "XOF",
+        "okcident afrika franko": "XOF",
+        "franco cfa de africa occidental": "XOF",
+        "فرانک سی اف ای آفریقای باختری": "XOF",
+        "فرانک آفریقای غربی": "XOF",
+        "فرانک سی اف ای آفریقای غربی": "XOF",
+        "فرانک سی اف ای افریقای باختری": "XOF",
+        "فرانک سی اف ای باختر آفریقا": "XOF",
+        "فرانک سی اف ای غرب آفریقا": "XOF",
+        "פרנק cfa מערב אפריקני": "XOF",
+        "franco cfa uemoa": "XOF",
+        "franco cfa dell'africa occidentale": "XOF",
+        "franco cfa dell'africa dell'ovest": "XOF",
+        "frank cfa": "XOF",
+        "frank zachodnioafrykański": "XOF",
+        "franc cfa vest african": "XOF",
+        "валюта бенина": "XOF",
+        "валюта буркина фасо": "XOF",
+        "валюта гвинеи бисау": "XOF",
+        "валюта кот д’ивуара": "XOF",
+        "валюта мали": "XOF",
+        "валюта нигера": "XOF",
+        "валюта сенегала": "XOF",
+        "валюта того": "XOF",
+        "западно африканский франк кфа": "XOF",
+        "западноафриканский франк кфа": "XOF",
+        "франк африканского финансового сообщества": "XOF",
+        "франк кфа всеао": "XOF",
+        "frank bceao/cfa": "XOF",
+        "மேற்கு ஆபிரிக்க சி.எஃப்.ஏ பிராங்க்": "XOF",
+        "batı afrika cfa frankı": "XOF",
+        "cfa franc tây phi": "XOF",
+        "西非法郎": "XOF",
+        "pd": "XPD",
+        "46pd": "XPD",
+        "element 46": "XPD",
+        "itélany": "XPD",
+        "elemento 46": "XPD",
+        "పల్లాడియం": "XPD",
+        "paladi": "XPD",
+        "xpf": "XPF",
+        "pazifik franc": "XPF",
+        "cfp franko": "XPF",
+        "فرانک cfp": "XPF",
+        "fcfp": "XPF",
+        "francs pacifique": "XPF",
+        "פרנק צרפתי": "XPF",
+        "franak cfp": "XPF",
+        "francuski pacifički franak": "XPF",
+        "franco pacifico": "XPF",
+        "institut d'émission d'outre mer": "XPF",
+        "franc pacific": "XPF",
+        "французский тихоокеанский франк": "XPF",
+        "валюта уоллис и футуна": "XPF",
+        "обменный тихоокеанский франк": "XPF",
+        "франк кпф": "XPF",
+        "франк кфп": "XPF",
+        "французское тихоокеанское банковское соглашение": "XPF",
+        "француски тихоокеански франак": "XPF",
+        "pt": "XPT",
+        "element 78": "XPT",
+        "éreny": "XPT",
+        "プラチナ": "XPT",
+        "プラティナ": "XPT",
+        "鉑": "XPT",
+        "elemento 78": "XPT",
+        "bạch kim": "XPT",
+        "sistema único de compensación regional": "XSU",
+        "Sucre": "XSU",
+        "sistema unico de compensacion regional": "XSU",
+        "スクレ": "XSU",
+        "единая система региональных взаиморасчетов": "XSU",
+        "единая система региональных взаиморасчётов": "XSU",
+        "rial nord yéménite": "YER",
+        "észak jemeni riál": "YER",
+        "северо йеменский риал": "YER",
+        "северойеменский риал": "YER",
+        "الريال اليمني": "YER",
+        "﷼'": "YER",
+        "rial de iemen": "YER",
+        "rial del iemen": "YER",
+        "nordjemenitischer rial": "YER",
+        "yer": "YER",
+        "rial yemeni": "YER",
+        "rial yéménite": "YER",
+        "dinar du yémen du sud": "YER",
+        "rial yemenite": "YER",
+        "rial do iemen": "YER",
+        "rial yemenita": "YER",
+        "イエメンの通貨": "YER",
+        "イエメン・リヤル": "YER",
+        "イエメン・リヤール": "YER",
+        "rial de iemèn": "YER",
+        "rial do iémen": "YER",
+        "rial do iémene": "YER",
+        "rial do iêmen": "YER",
+        "rial iémenita": "YER",
+        "валюта йемена": "YER",
+        "јеменски риал": "YER",
+        "yemenitisk rial": "YER",
+        "叶门里亚尔": "YER",
+        "R": "ZAR",
+        "rand de sud àfrica": "ZAR",
+        "rand sud africà": "ZAR",
+        "rando": "ZAR",
+        "sud afrika rando": "ZAR",
+        "zar": "ZAR",
+        "randi": "ZAR",
+        "rand sud africain": "ZAR",
+        "ראנד": "ZAR",
+        "南アフリカランド": "ZAR",
+        "南アフリカ・ランド": "ZAR",
+        "par randas": "ZAR",
+        "pietų afrikos randas": "ZAR",
+        "rand południowoafrykański": "ZAR",
+        "rand sul africano": "ZAR",
+        "rand sulafricano": "ZAR",
+        "rands": "ZAR",
+        "валюта юар": "ZAR",
+        "ранд юар": "ZAR",
+        "рэнд": "ZAR",
+        "рэнд юар": "ZAR",
+        "южно африканский рэнд": "ZAR",
+        "южно африканский ранд": "ZAR",
+        "южноафриканский ранд": "ZAR",
+        "sydafrikansk rand": "ZAR",
+        "південно африканський ранд": "ZAR",
+        "南非蘭特": "ZAR",
+        "蘭特": "ZAR",
+        "zec": "ZEC",
+        "كواشا زامبية": "ZMW",
+        "kwacha de zàmbia": "ZMW",
+        "ngwee": "ZMW",
+        "sambia kwacha": "ZMW",
+        "κουάτσα ζάμπιας": "ZMW",
+        "zmw": "ZMW",
+        "kwacha zambese": "ZMW",
+        "zmk": "ZMW",
+        "kwacha zambian": "ZMW",
+        "kwacha": "ZMW",
+        "kwacha da zâmbia": "ZMW",
+        "kwacha zambiana": "ZMW",
+        "валюта замбии": "ZMW",
+        "квача замбии": "ZMW",
+        "ZK": "ZMW",
+        "pesos": [
+            "MXN"
+        ]
+    },
     "iso4217": {
-	"XBT":{
-	    "fr": "Bitcoin", 
-            "en": "Bitcoin", 
-            "nl": "Bitcoin", 
-            "de": "Bitcoin", 
-            "it": "Bitcoin", 
-            "hu": "Bitcoin", 
-            "es": "Bitcoin"
-	},	
-        "DZD": {
-            "fr": "Dinar alg\u00e9rien", 
-            "en": "Algerian dinar", 
-            "nl": "Algerijnse dinar", 
-            "de": "Algerischer Dinar", 
-            "it": "Dinaro algerino", 
-            "hu": "alg\u00e9riai din\u00e1r", 
-            "es": "Dinar argelino"
-        }, 
-        "NAD": {
-            "fr": "Dollar namibien", 
-            "en": "Namibian dollar", 
-            "nl": "Namibische dollar", 
-            "de": "Namibia-Dollar", 
-            "it": "Dollaro namibiano", 
-            "hu": "Nam\u00edbiai doll\u00e1r", 
-            "es": "D\u00f3lar namibio"
-        }, 
-        "GHS": {
-            "fr": "Cedi", 
-            "en": "Ghana cedi", 
-            "nl": "Ghanese cedi", 
-            "de": "Cedi", 
-            "it": "Cedi ghanese", 
-            "hu": "Gh\u00e1nai cedi", 
-            "es": "Cedi"
-        }, 
-        "BZD": {
-            "fr": "Dollar b\u00e9lizien", 
-            "en": "Belize dollar", 
-            "nl": "Belizaanse dollar", 
-            "de": "Belize-Dollar", 
-            "it": "Dollaro del Belize", 
-            "hu": "Belize-i doll\u00e1r", 
-            "es": "D\u00f3lar belice\u00f1o"
-        }, 
-        "BGN": {
-            "fr": "Lev bulgare", 
-            "en": "Bulgarian lev", 
-            "nl": "Bulgaarse lev", 
-            "de": "Lew", 
-            "it": "Lev bulgaro", 
-            "hu": "bolg\u00e1r leva", 
-            "es": "Lev"
-        }, 
-        "PAB": {
-            "fr": "Balboa", 
-            "en": "Panamanian balboa", 
-            "nl": "Panamese balboa", 
-            "de": "Panamaischer Balboa", 
-            "it": "Balboa panamense", 
-            "hu": "Panamai balboa", 
-            "es": "Balboa"
-        }, 
-        "BOB": {
-            "fr": "boliviano", 
-            "en": "boliviano", 
-            "nl": "Boliviaanse boliviano", 
-            "de": "Boliviano", 
-            "it": "boliviano", 
-            "hu": "bol\u00edviai boliviano", 
-            "es": "boliviano"
-        }, 
-        "DKK": {
-            "fr": "Couronne danoise", 
-            "en": "Danish krone", 
-            "nl": "Deense kroon", 
-            "de": "D\u00e4nische Krone", 
-            "it": "Corona danese", 
-            "hu": "d\u00e1n korona", 
-            "es": "Corona danesa"
-        }, 
-        "BWP": {
-            "fr": "Pula", 
-            "en": "Botswana pula", 
-            "nl": "Botswaanse pula", 
-            "de": "Botswanischer Pula", 
-            "it": "Pula del Botswana", 
-            "hu": "Botswanai pula", 
-            "es": "Pula"
-        }, 
-        "LBP": {
-            "fr": "livre libanaise", 
-            "en": "Lebanese pound", 
-            "nl": "Libanees pond", 
-            "de": "Libanesisches Pfund", 
-            "it": "Lira libanese", 
-            "hu": "libanoni font", 
-            "es": "Libra libanesa"
-        }, 
-        "TZS": {
-            "fr": "shilling tanzanien", 
-            "en": "Tanzanian shilling", 
-            "nl": "Tanzaniaanse shilling", 
-            "de": "Tansania-Schilling", 
-            "it": "Scellino tanzaniano", 
-            "hu": "Tanz\u00e1niai shilling", 
-            "es": "chel\u00edn"
-        }, 
-        "VND": {
-            "fr": "Dong", 
-            "en": "Vietnamese dong", 
-            "nl": "Vietnamese dong", 
-            "de": "Vietnamesischer \u0110\u1ed3ng", 
-            "it": "\u0110\u1ed3ng vietnamita", 
-            "hu": "vietnami \u0111\u1ed3ng", 
-            "es": "\u0111\u1ed3ng vietnamita"
-        }, 
-        "AOA": {
-            "fr": "Kwanza", 
-            "en": "Angolan kwanza", 
-            "nl": "Angolese kwanza", 
-            "de": "Kwanza", 
-            "it": "Kwanza angolano", 
-            "hu": "angolai kwanza", 
-            "es": "Kwanza angole\u00f1o"
-        }, 
-        "KHR": {
-            "fr": "Riel", 
-            "en": "riel", 
-            "nl": "Cambodjaanse riel", 
-            "de": "Kambodschanischer Riel", 
-            "it": "Riel cambogiano", 
-            "hu": "kambodzsai riel", 
-            "es": "Riel camboyano"
-        }, 
-        "MYR": {
-            "fr": "Ringgit", 
-            "en": "Malaysian ringgit", 
-            "nl": "Maleisische ringgit", 
-            "de": "Ringgit", 
-            "it": "Ringgit malese", 
-            "hu": "mal\u00e1j ringgit", 
-            "es": "Ringgit"
-        }, 
-        "KYD": {
-            "fr": "Dollar des \u00eeles Ca\u00efmans", 
-            "en": "Cayman Islands dollar", 
-            "nl": "Kaaimaneilandse dollar", 
-            "de": "Kaiman-Dollar", 
-            "it": "Dollaro delle Cayman", 
-            "hu": "Kajm\u00e1n-szigeteki doll\u00e1r", 
-            "es": "D\u00f3lar de las Islas Caim\u00e1n"
-        }, 
-        "LYD": {
-            "fr": "Dinar libyen", 
-            "en": "Libyan dinar", 
-            "nl": "Libische dinar", 
-            "de": "Libyscher Dinar", 
-            "it": "Dinaro libico", 
-            "hu": "L\u00edbiai din\u00e1r", 
-            "es": "Dinar libio"
-        }, 
-        "UAH": {
-            "fr": "Hryvnia", 
-            "en": "hryvnia", 
-            "nl": "Oekra\u00efense hryvnja", 
-            "de": "Hrywnja", 
-            "it": "Grivnia ucraina", 
-            "hu": "ukr\u00e1n hrivnya", 
-            "es": "Grivna"
-        }, 
-        "JOD": {
-            "fr": "Dinar jordanien", 
-            "en": "Jordanian dinar", 
-            "nl": "Jordaanse dinar", 
-            "de": "Jordanischer Dinar", 
-            "it": "Dinaro giordano", 
-            "hu": "jord\u00e1n din\u00e1r", 
-            "es": "Dinar jordano"
-        }, 
-        "SUR": {
-            "fr": "Rouble sovi\u00e9tique", 
-            "en": "Soviet ruble", 
-            "de": "Sowjetischer Rubel", 
-            "it": "Rublo sovietico", 
-            "hu": "Szovjet rubel", 
-            "es": "Rublo sovi\u00e9tico"
-        }, 
-        "AWG": {
-            "fr": "Florin arubais", 
-            "en": "Aruban florin", 
-            "nl": "Arubaanse florin", 
-            "de": "Aruba-Florin", 
-            "it": "Fiorino arubano", 
-            "hu": "Arubai florin", 
-            "es": "Flor\u00edn arube\u00f1o"
-        }, 
-        "SAR": {
-            "fr": "Riyal saoudien", 
-            "en": "Saudi riyal", 
-            "nl": "Saoedi-Arabische riyal", 
-            "de": "Saudi-Rial", 
-            "it": "Riyal saudita", 
-            "hu": "sza\u00fadi ri\u00e1l", 
-            "es": "Riyal saud\u00ed"
-        }, 
-        "EUR": {
-            "fr": "euro", 
-            "en": "euro", 
-            "nl": "euro", 
-            "de": "Euro", 
-            "it": "euro", 
-            "hu": "eur\u00f3", 
-            "es": "euro"
-        }, 
-        "HKD": {
-            "fr": "Dollar de Hong Kong", 
-            "en": "Hong Kong dollar", 
-            "nl": "Hongkongse dollar", 
-            "de": "Hongkong-Dollar", 
-            "it": "dollaro hongkonghese", 
-            "hu": "hongkongi doll\u00e1r", 
-            "es": "D\u00f3lar de Hong Kong"
-        }, 
-        "SRG": {
-            "en": "Surinamese guilder", 
-            "nl": "Surinaamse gulden", 
-            "it": "Fiorino surinamese", 
-            "es": "Flor\u00edn surinam\u00e9s"
-        }, 
-        "CHF": {
-            "fr": "Franc suisse", 
-            "en": "Swiss franc", 
-            "nl": "Zwitserse frank", 
-            "de": "Schweizer Franken", 
-            "it": "franco svizzero", 
-            "hu": "sv\u00e1jci frank", 
-            "es": "franco suizo"
-        }, 
-        "GIP": {
-            "fr": "Livre de Gibraltar", 
-            "en": "Gibraltar pound", 
-            "nl": "Gibraltarees pond", 
-            "de": "Gibraltar-Pfund", 
-            "it": "Sterlina di Gibilterra", 
-            "hu": "Gibralt\u00e1ri font", 
-            "es": "Libra gibraltare\u00f1a"
-        }, 
-        "ALL": {
-            "fr": "Lek", 
-            "en": "lek", 
-            "nl": "Albanese lek", 
-            "de": "Albanischer Lek", 
-            "it": "Lek albanese", 
-            "hu": "alb\u00e1n lek", 
-            "es": "Lek alban\u00e9s"
-        }, 
-        "MRO": {
-            "fr": "Ouguiya", 
-            "en": "Mauritanian ouguiya", 
-            "nl": "Mauritaanse ouguiya", 
-            "de": "Ouguiya", 
-            "it": "Ouguiya mauritana", 
-            "hu": "Maurit\u00e1niai ouguiya", 
-            "es": "Uquiya"
-        }, 
-        "HRK": {
-            "fr": "Kuna croate", 
-            "en": "Croatian kuna", 
-            "nl": "Kroatische kuna", 
-            "de": "Kroatische Kuna", 
-            "it": "Kuna croata", 
-            "hu": "horv\u00e1t kuna", 
-            "es": "Kuna croata"
-        }, 
-        "DJF": {
-            "fr": "franc Djibouti", 
-            "en": "Djiboutian franc", 
-            "nl": "Djiboutiaanse frank", 
-            "de": "Dschibuti-Franc", 
-            "it": "Franco gibutiano", 
-            "hu": "Dzsibuti frank", 
-            "es": "franco"
-        }, 
-        "THB": {
-            "fr": "Baht", 
-            "en": "Thai baht", 
-            "nl": "Thaise baht", 
-            "de": "Baht", 
-            "it": "Baht thailandese", 
-            "hu": "thai b\u00e1t", 
-            "es": "Baht tailand\u00e9s"
-        }, 
-        "XAF": {
-            "fr": "Franc CFA", 
-            "en": "Central African CFA franc", 
-            "de": "CFA-Franc BEAC", 
-            "es": "Franco CFA de \u00c1frica Central"
-        }, 
-        "BND": {
-            "fr": "Dollar de Brunei", 
-            "en": "Brunei dollar", 
-            "nl": "Bruneise dollar", 
-            "de": "Brunei-Dollar", 
-            "it": "Dollaro del Brunei", 
-            "hu": "brunei doll\u00e1r", 
-            "es": "D\u00f3lar de Brun\u00e9i"
-        }, 
-        "VUV": {
-            "fr": "Vatu", 
-            "en": "Vanuatu vatu", 
-            "nl": "Vanuatuaanse vatu", 
-            "de": "Vatu", 
-            "it": "Vatu di Vanuatu", 
-            "hu": "Vanuatui vatu", 
-            "es": "Vatu"
-        }, 
-        "UYU": {
-            "fr": "Peso uruguayen", 
-            "en": "Uruguayan peso", 
-            "nl": "Uruguayaanse peso", 
-            "de": "Uruguayischer Peso", 
-            "it": "Peso uruguaiano", 
-            "hu": "Uruguayi peso", 
-            "es": "peso"
-        }, 
-        "NIO": {
-            "fr": "C\u00f3rdoba", 
-            "en": "Nicaraguan c\u00f3rdoba", 
-            "nl": "Nicaraguaanse c\u00f3rdoba", 
-            "de": "C\u00f3rdoba Oro", 
-            "it": "C\u00f3rdoba nicaraguense", 
-            "hu": "Nicaraguai c\u00f3rdoba", 
-            "es": "C\u00f3rdoba"
-        }, 
-        "LAK": {
-            "fr": "Kip laotien", 
-            "en": "Lao kip", 
-            "nl": "Laotiaanse kip", 
-            "de": "Kip", 
-            "it": "Kip laotiano", 
-            "hu": "laoszi kip", 
-            "es": "Kip laosiano"
-        }, 
-        "MZE": {
-            "de": "Mosambikanischer Escudo", 
-            "en": "Mozambican escudo", 
-            "es": "Escudo mozambique\u00f1o"
-        }, 
-        "SYP": {
-            "fr": "Livre syrienne", 
-            "en": "Syrian pound", 
-            "nl": "Syrisch pond", 
-            "de": "Syrische Lira", 
-            "it": "Lira siriana", 
-            "hu": "Sz\u00edr font", 
-            "es": "Libra siria"
-        }, 
-        "MAD": {
-            "fr": "Dirham marocain", 
-            "en": "Moroccan dirham", 
-            "nl": "Marokkaanse dirham", 
-            "de": "Marokkanischer Dirham", 
-            "it": "Dirham marocchino", 
-            "hu": "Marokk\u00f3i dirham", 
-            "es": "D\u00edrham marroqu\u00ed"
-        }, 
-        "MZN": {
-            "fr": "Metical", 
-            "en": "Mozambican metical", 
-            "nl": "Mozambikaanse metical", 
-            "de": "Metical", 
-            "it": "Metical mozambicano", 
-            "hu": "Mozambiki metical", 
-            "es": "Metical mozambique\u00f1o"
-        }, 
-        "SCR": {
-            "fr": "roupie seychelloise", 
-            "en": "Seychellois rupee", 
-            "nl": "Seychelse roepie", 
-            "de": "Seychellen-Rupie", 
-            "it": "Rupia delle Seychelles", 
-            "hu": "Seychelle-i r\u00fapia", 
-            "es": "rupia"
-        }, 
-        "ZAR": {
-            "fr": "rand", 
-            "en": "South African rand", 
-            "nl": "Zuid-Afrikaanse rand", 
-            "de": "S\u00fcdafrikanischer Rand", 
-            "it": "Rand sudafricano", 
-            "hu": "D\u00e9l-afrikai rand", 
-            "es": "Rand sudafricano"
-        }, 
-        "NPR": {
-            "fr": "Roupie n\u00e9palaise", 
-            "en": "Nepalese rupee", 
-            "nl": "Nepalese roepie", 
-            "de": "Nepalesische Rupie", 
-            "it": "Rupia nepalese", 
-            "hu": "nep\u00e1li r\u00fapia", 
-            "es": "Rupia nepal\u00ed"
-        }, 
-        "XSU": {
-            "fr": "Sucre", 
-            "en": "SUCRE", 
-            "nl": "SUCRE", 
-            "es": "SUCRE", 
-            "de": "SUCRE"
-        }, 
-        "NGN": {
-            "fr": "Naira", 
-            "en": "Nigerian naira", 
-            "nl": "Nigeriaanse naira", 
-            "de": "Naira", 
-            "it": "Naira nigeriana", 
-            "hu": "Nig\u00e9riai naira", 
-            "es": "Naira"
-        }, 
-        "CRC": {
-            "fr": "col\u00f3n", 
-            "en": "Costa Rican col\u00f3n", 
-            "nl": "Costa Ricaanse colon", 
-            "de": "Costa-Rica-Col\u00f3n", 
-            "it": "Col\u00f3n costaricano", 
-            "hu": "Costa Rica-i col\u00f3n", 
-            "es": "Col\u00f3n"
-        }, 
+        "ABA": {
+            "ar": "أبصار أبخازي",
+            "cs": "Abcházský apsar",
+            "de": "Abchasischer Apsar",
+            "en": "Abkhazian apsar",
+            "es": "apsar",
+            "fa": "آپسار",
+            "fi": "Abhasian apsar",
+            "fr": "Apsar",
+            "gl": "apsar abkhazo",
+            "hr": "Abhaški apsar",
+            "it": "Apsar abcaso",
+            "lt": "Abchazijos apsaras",
+            "pl": "Apsar",
+            "pt": "Apsar abcásio",
+            "ru": "Абхазский апсар",
+            "sv": "Apsar",
+            "tr": "Abhazya apsarı",
+            "uk": "Абхазький апсар",
+            "zh": "阿布哈兹阿沙",
+            "ja": "アプサラ",
+            "sr": "абхаски апсар"
+        },
         "AED": {
-            "fr": "Dirham des \u00c9mirats arabes unis", 
-            "en": "United Arab Emirates dirham", 
-            "nl": "VAE-Dirham", 
-            "de": "VAE-Dirham", 
-            "it": "Dirham degli Emirati Arabi Uniti", 
-            "hu": "emir\u00e1tusi dirham", 
-            "es": "D\u00edrham de los Emiratos \u00c1rabes Unidos"
-        }, 
-        "GBP": {
-            "fr": "livre sterling", 
-            "en": "pound sterling", 
-            "nl": "pond sterling", 
-            "de": "Pfund Sterling", 
-            "it": "sterlina britannica", 
-            "hu": "font sterling", 
-            "es": "libra esterlina"
-        }, 
-        "LKR": {
-            "fr": "roupie srilankaise", 
-            "en": "Sri Lankan rupee", 
-            "nl": "Sri Lankaanse roepie", 
-            "de": "Sri-Lanka-Rupie", 
-            "it": "Rupia singalese", 
-            "hu": "Sr\u00ed Lanka-i r\u00fapia", 
-            "es": "rupia"
-        }, 
-        "PKR": {
-            "fr": "Roupie pakistanaise", 
-            "en": "Pakistani rupee", 
-            "nl": "Pakistaanse roepie", 
-            "de": "Pakistanische Rupie", 
-            "it": "Rupia pakistana", 
-            "hu": "pakiszt\u00e1ni r\u00fapia", 
-            "es": "Rupia pakistan\u00ed"
-        }, 
-        "HUF": {
-            "fr": "Forint", 
-            "en": "Hungarian forint", 
-            "nl": "Hongaarse forint", 
-            "de": "Forint", 
-            "it": "Fiorino ungherese", 
-            "hu": "magyar forint", 
-            "es": "Forinto h\u00fangaro"
-        }, 
-        "SZL": {
-            "fr": "Lilangeni", 
-            "en": "Swazi lilangeni", 
-            "nl": "Swazische lilangeni", 
-            "de": "Lilangeni", 
-            "it": "Lilangeni dello Swaziland", 
-            "hu": "Szv\u00e1zif\u00f6ldi lilangeni", 
-            "es": "lilangeni"
-        }, 
-        "LSL": {
-            "fr": "Loti", 
-            "en": "Lesotho loti", 
-            "nl": "Lesothaanse loti", 
-            "de": "Lesothischer Loti", 
-            "it": "Loti lesothiano", 
-            "hu": "Lesoth\u00f3i loti", 
-            "es": "Loti"
-        }, 
-        "MNT": {
-            "fr": "Tugrik", 
-            "en": "Mongolian t\u00f6gr\u00f6g", 
-            "nl": "Mongoolse tugrik", 
-            "de": "T\u00f6gr\u00f6g", 
-            "it": "Tugrik mongolo", 
-            "hu": "mongol tugrik", 
-            "es": "Tugrik mongol"
-        }, 
-        "AMD": {
-            "fr": "Dram", 
-            "en": "Armenian dram", 
-            "nl": "Armeense dram", 
-            "de": "Armenischer Dram", 
-            "it": "Dram armeno", 
-            "hu": "\u00f6rm\u00e9ny dram", 
-            "es": "Dram armenio"
-        }, 
-        "UGX": {
-            "fr": "shilling ougandais", 
-            "en": "Ugandan shilling", 
-            "nl": "Oegandese shilling", 
-            "de": "Uganda-Schilling", 
-            "it": "Scellino ugandese", 
-            "hu": "Ugandai shilling", 
-            "es": "chel\u00edn"
-        }, 
-        "QAR": {
-            "fr": "Riyal qatarien", 
-            "en": "Qatari riyal", 
-            "nl": "Qatarese rial", 
-            "de": "Katar-Riyal", 
-            "it": "Riyal del Qatar", 
-            "hu": "katari ri\u00e1l", 
-            "es": "Riyal catar\u00ed"
-        }, 
-        "XDR": {
-            "fr": "Droits de tirage sp\u00e9ciaux", 
-            "en": "Special drawing rights", 
-            "nl": "Speciale trekkingsrechten", 
-            "de": "Sonderziehungsrecht", 
-            "it": "Diritti speciali di prelievo", 
-            "hu": "SDR", 
-            "es": "Derechos Especiales de Giro"
-        }, 
-        "ITL": {
-            "fr": "Lire italienne", 
-            "en": "Italian lira", 
-            "nl": "Italiaanse lire", 
-            "de": "Italienische Lira", 
-            "it": "lira italiana", 
-            "hu": "Olasz l\u00edra", 
-            "es": "Lira italiana"
-        }, 
-        "JMD": {
-            "fr": "Dollar jama\u00efcain", 
-            "en": "Jamaican dollar", 
-            "nl": "Jamaicaanse dollar", 
-            "de": "Jamaika-Dollar", 
-            "it": "Dollaro giamaicano", 
-            "hu": "Jamaicai doll\u00e1r", 
-            "es": "D\u00f3lar jamaiquino"
-        }, 
-        "GEL": {
-            "fr": "lari", 
-            "en": "Georgian lari", 
-            "nl": "Georgische lari", 
-            "de": "Georgischer Lari", 
-            "it": "Lari georgiano", 
-            "hu": "gr\u00faz lari", 
-            "es": "lari"
-        }, 
-        "SHP": {
-            "fr": "Livre de Sainte-H\u00e9l\u00e8ne", 
-            "en": "Saint Helena pound", 
-            "nl": "Sint-Heleens pond", 
-            "de": "St.-Helena-Pfund", 
-            "it": "Sterlina di Sant'Elena", 
-            "hu": "Szent Ilona-i font", 
-            "es": "Libra de Santa Elena"
-        }, 
+            "ar": "درهم إماراتي",
+            "ca": "dírham dels Emirats Àrabs Units",
+            "cs": "dirham Spojených arabských emirátů",
+            "de": "VAE-Dirham",
+            "el": "Ντιρχάμ Ηνωμένων Αραβικών Εμιράτων",
+            "en": "United Arab Emirates dirham",
+            "eo": "UAE-dirhamo",
+            "es": "dírham de los Emiratos Árabes Unidos",
+            "fa": "درهم امارات",
+            "fi": "Yhdistyneiden arabiemiirikuntien dirhami",
+            "fr": "Dirham des Émirats arabes unis",
+            "gl": "Dirham dos Emiratos Árabes Unidos",
+            "he": "דירהם איחוד האמירויות הערביות",
+            "hr": "Dirham UAE",
+            "hu": "emirátusi dirham",
+            "it": "Dirham degli Emirati Arabi Uniti",
+            "ja": "UAEディルハム",
+            "lt": "Jungtinių Arabų Emyratų dirhamas",
+            "nl": "VAE-Dirham",
+            "pl": "Dirham",
+            "pt": "Dirham dos Emirados Árabes Unidos",
+            "ro": "Dirham EAU",
+            "ru": "дирхам ОАЭ",
+            "sr": "УАЕ дирхам",
+            "sv": "Emiratisk dirham",
+            "ta": "ஐக்கிய அரபு அமீரக திர்கம்",
+            "tr": "Birleşik Arap Emirlikleri dirhemi",
+            "uk": "дирхам ОАЕ",
+            "zh": "阿联酋迪尔汗",
+            "da": "emirata arabiske dirham"
+        },
         "AFN": {
-            "fr": "Afghani", 
-            "en": "Afghan afghani", 
-            "nl": "Afghaanse afghani", 
-            "de": "Afghani", 
-            "it": "Afghani afgano", 
-            "hu": "afg\u00e1n afg\u00e1ni", 
-            "es": "Afgani afgano"
-        }, 
-        "MMK": {
-            "fr": "Kyat", 
-            "en": "kyat", 
-            "nl": "Myanmarese kyat", 
-            "de": "Kyat", 
-            "it": "Kyat birmano", 
-            "hu": "mianmari kjap", 
-            "es": "Kyat birmano"
-        }, 
-        "CSK": {
-            "fr": "couronne tch\u00e9coslovaque", 
-            "en": "Czechoslovak koruna", 
-            "nl": "Tsjecho-Slowaakse kroon", 
-            "de": "Tschechoslowakische Krone", 
-            "it": "Corona cecoslovacca", 
-            "hu": "csehszlov\u00e1k korona", 
-            "es": "Corona checoslovaca"
-        }, 
-        "KPW": {
-            "fr": "Won nord-cor\u00e9en", 
-            "en": "North Korean won", 
-            "nl": "Noord-Koreaanse won", 
-            "de": "Nordkoreanischer Won", 
-            "it": "Won nordcoreano", 
-            "hu": "\u00e9szak-koreai von", 
-            "es": "W\u014fn norcoreano"
-        }, 
-        "TRY": {
-            "fr": "Livre turque", 
-            "en": "Turkish lira", 
-            "nl": "Nieuwe Turkse lira", 
-            "de": "T\u00fcrkische Lira", 
-            "it": "Nuova lira turca", 
-            "hu": "t\u00f6r\u00f6k \u00faj l\u00edra", 
-            "es": "Lira turca"
-        }, 
-        "BDT": {
-            "fr": "Taka", 
-            "en": "taka", 
-            "nl": "Bengalese taka", 
-            "de": "Taka", 
-            "it": "Taka bengalese", 
-            "hu": "bangladesi taka", 
-            "es": "Taka banglades\u00ed"
-        }, 
-        "GRD": {
-            "fr": "Drachme moderne grecque", 
-            "en": "Greek drachma", 
-            "nl": "Drachme", 
-            "de": "Griechische Drachme", 
-            "it": "Dracma greca", 
-            "es": "Dracma griega moderna"
-        }, 
-        "YER": {
-            "fr": "rial y\u00e9m\u00e9nite", 
-            "en": "Yemeni rial", 
-            "nl": "Jemenitische rial", 
-            "de": "Jemen-Rial", 
-            "it": "riyal yemenita", 
-            "hu": "Jemeni ri\u00e1l", 
-            "es": "rial yemen\u00ed"
-        }, 
-        "DDM": {
-            "fr": "Mark est-allemand", 
-            "en": "East German mark", 
-            "nl": "Oost-Duitse mark", 
-            "de": "Mark", 
-            "it": "Marco della Repubblica Democratica Tedesca", 
-            "es": "Marco de la Rep\u00fablica Democr\u00e1tica Alemana"
-        }, 
-        "HTG": {
-            "fr": "Gourde", 
-            "en": "Haitian gourde", 
-            "nl": "Ha\u00eftiaanse gourde", 
-            "de": "Gourde", 
-            "it": "Gourde haitiano", 
-            "hu": "haiti gourde", 
-            "es": "Gourde"
-        }, 
-        "XOF": {
-            "fr": "Franc CFA", 
-            "en": "West African CFA franc", 
-            "de": "CFA-Franc BCEAO", 
-            "es": "Franco CFA de \u00c1frica Occidental"
-        }, 
-        "MGA": {
-            "fr": "ariary", 
-            "en": "Malagasy ariary", 
-            "nl": "Malagassische ariary", 
-            "de": "Ariary", 
-            "it": "Ariary malgascio", 
-            "hu": "Madagaszk\u00e1ri ariary", 
-            "es": "ariary"
-        }, 
-        "PHP": {
-            "fr": "peso philippin", 
-            "en": "Philippine peso", 
-            "nl": "Filipijnse peso", 
-            "de": "Philippinischer Peso", 
-            "it": "peso filippino", 
-            "hu": "F\u00fcl\u00f6p-szigeteki peso", 
-            "es": "peso"
-        }, 
-        "LRD": {
-            "fr": "Dollar lib\u00e9rien", 
-            "en": "Liberian dollar", 
-            "nl": "Liberiaanse dollar", 
-            "de": "Liberianischer Dollar", 
-            "it": "Dollaro liberiano", 
-            "hu": "Lib\u00e9riai doll\u00e1r", 
-            "es": "D\u00f3lar liberiano"
-        }, 
-        "RWF": {
-            "fr": "franc rwandais", 
-            "en": "Rwandan franc", 
-            "nl": "Rwandese frank", 
-            "de": "Ruanda-Franc", 
-            "it": "Franco ruandese", 
-            "hu": "Ruandai frank", 
-            "es": "franco"
-        }, 
-        "NOK": {
-            "fr": "Couronne norv\u00e9gienne", 
-            "en": "Norwegian krone", 
-            "nl": "Noorse kroon", 
-            "de": "Norwegische Krone", 
-            "it": "Corona norvegese", 
-            "hu": "norv\u00e9g korona", 
-            "es": "Corona noruega"
-        }, 
-        "MOP": {
-            "fr": "Pataca", 
-            "en": "Macanese pataca", 
-            "nl": "Macause pataca", 
-            "de": "Macao-Pataca", 
-            "it": "Pataca di Macao", 
-            "hu": "Maka\u00f3i pataca", 
-            "es": "Pataca"
-        }, 
-        "SSP": {
-            "fr": "Livre sud-soudanaise", 
-            "en": "South Sudanese pound", 
-            "nl": "Zuid-Soedanees pond", 
-            "de": "S\u00fcdsudanesisches Pfund", 
-            "it": "Sterlina sudsudanese", 
-            "hu": "D\u00e9l-szud\u00e1ni font", 
-            "es": "Libra sursudanesa"
-        }, 
-        "INR": {
-            "fr": "Roupie indienne", 
-            "en": "Indian rupee", 
-            "nl": "Indiase roepie", 
-            "de": "Indische Rupie", 
-            "it": "rupia indiana", 
-            "hu": "Indiai r\u00fapia", 
-            "es": "Rupia india"
-        }, 
-        "MXN": {
-            "fr": "peso mexicain", 
-            "en": "Mexican peso", 
-            "nl": "Mexicaanse peso", 
-            "de": "Mexikanischer Peso", 
-            "it": "Peso messicano", 
-            "hu": "mexik\u00f3i peso", 
-            "es": "peso"
-        }, 
-        "CZK": {
-            "fr": "Couronne tch\u00e8que", 
-            "en": "Czech koruna", 
-            "nl": "Tsjechische kroon", 
-            "de": "Tschechische Krone", 
-            "it": "Corona ceca", 
-            "hu": "cseh korona", 
-            "es": "Corona checa"
-        }, 
-        "TJS": {
-            "fr": "Somoni", 
-            "en": "Tajikistani somoni", 
-            "nl": "Tadzjiekse somoni", 
-            "de": "Somoni", 
-            "it": "Somoni tagico", 
-            "hu": "t\u00e1dzsik szomoni", 
-            "es": "Somoni tayiko"
-        }, 
-        "TJR": {
-            "en": "Tajikistani ruble", 
-            "es": "Rublo tayiko"
-        }, 
-        "BTN": {
-            "fr": "ngultrum", 
-            "en": "Bhutanese ngultrum", 
-            "nl": "Bhutaanse ngultrum", 
-            "de": "Ngultrum", 
-            "it": "Ngultrum del Bhutan", 
-            "hu": "bhut\u00e1ni ngultrum", 
-            "es": "Ngultrum butan\u00e9s"
-        }, 
-        "KMF": {
-            "fr": "Franc comorien", 
-            "en": "Comorian franc", 
-            "nl": "Comorese frank", 
-            "de": "Komoren-Franc", 
-            "it": "Franco delle Comore", 
-            "hu": "Comore-i frank", 
-            "es": "Franco comorano"
-        }, 
-        "TMT": {
-            "fr": "Manat turkm\u00e8ne", 
-            "en": "Turkmenistan manat", 
-            "nl": "Turkmeense manat", 
-            "de": "Turkmenistan-Manat", 
-            "it": "Manat turkmeno", 
-            "hu": "T\u00fcrkm\u00e9n manat", 
-            "es": "Manat turkmeno"
-        }, 
-        "MUR": {
-            "fr": "Roupie mauricienne", 
-            "en": "Mauritian rupee", 
-            "nl": "Mauritiaanse roepie", 
-            "de": "Mauritius-Rupie", 
-            "it": "Rupia mauriziana", 
-            "hu": "Mauritiusi r\u00fapia", 
-            "es": "Rupia de Mauricio"
-        }, 
-        "IDR": {
-            "fr": "Roupie indon\u00e9sienne", 
-            "en": "Indonesian Rupiah", 
-            "nl": "Indonesische roepia", 
-            "de": "Indonesische Rupiah", 
-            "it": "Rupia indonesiana", 
-            "hu": "indon\u00e9z r\u00fapia", 
-            "es": "Rupia indonesia"
-        }, 
-        "HNL": {
-            "fr": "Lempira", 
-            "en": "Honduran lempira", 
-            "nl": "Hondurese lempira", 
-            "de": "Lempira", 
-            "it": "Lempira honduregna", 
-            "hu": "hondurasi lempira", 
-            "es": "lempira"
-        }, 
-        "ETB": {
-            "fr": "Birr", 
-            "en": "Ethiopian birr", 
-            "nl": "Ethiopische birr", 
-            "de": "\u00c4thiopischer Birr", 
-            "it": "Birr etiope", 
-            "hu": "eti\u00f3p birr", 
-            "es": "Birr et\u00edope"
-        }, 
-        "FJD": {
-            "fr": "dollar de Fidji", 
-            "en": "Fijian dollar", 
-            "nl": "Fiji-dollar", 
-            "de": "Fidschi-Dollar", 
-            "it": "Dollaro delle Figi", 
-            "hu": "Fidzsi doll\u00e1r", 
-            "es": "d\u00f3lar"
-        }, 
-        "ISK": {
-            "fr": "Couronne islandaise", 
-            "en": "Icelandic kr\u00f3na", 
-            "nl": "IJslandse kroon", 
-            "de": "Isl\u00e4ndische Krone", 
-            "it": "Corona islandese", 
-            "hu": "izlandi korona", 
-            "es": "corona islandesa"
-        }, 
-        "PEN": {
-            "fr": "nouveau sol", 
-            "en": "Peruvian nuevo sol", 
-            "nl": "Peruviaanse sol", 
-            "de": "Nuevo Sol", 
-            "it": "nuevo sol peruviano", 
-            "hu": "perui \u00faj sol", 
-            "es": "nuevo sol"
-        }, 
-        "MKD": {
-            "fr": "Dinar mac\u00e9donien", 
-            "en": "Macedonian denar", 
-            "nl": "Macedonische denar", 
-            "de": "Mazedonischer Denar", 
-            "it": "Denaro macedone", 
-            "hu": "maced\u00f3n d\u00e9n\u00e1r", 
-            "es": "Denar macedonio"
-        }, 
-        "ILS": {
-            "fr": "Shekel", 
-            "en": "Israeli new shekel", 
-            "nl": "Isra\u00eblische sjekel", 
-            "de": "Schekel", 
-            "it": "nuovo siclo israeliano", 
-            "hu": "izraeli \u00faj s\u00e9kel", 
-            "es": "Nuevo sh\u00e9quel"
-        }, 
-        "DOP": {
-            "fr": "Peso dominicain", 
-            "en": "Dominican peso", 
-            "nl": "Dominicaanse peso", 
-            "de": "Dominikanischer Peso", 
-            "it": "Peso dominicano", 
-            "hu": "Dominikai peso", 
-            "es": "peso"
-        }, 
-        "AZN": {
-            "fr": "Manat azerba\u00efdjanais", 
-            "en": "Azerbaijani manat", 
-            "nl": "Azerbeidzjaanse manat", 
-            "de": "Aserbaidschan-Manat", 
-            "it": "Manat azero", 
-            "hu": "Azeri manat", 
-            "es": "Manat azerbaiyano"
-        }, 
-        "MDL": {
-            "fr": "Leu moldave", 
-            "en": "Moldovan leu", 
-            "nl": "Moldavische leu", 
-            "de": "Moldauischer Leu", 
-            "it": "Leu moldavo", 
-            "hu": "moldov\u00e1n lej", 
-            "es": "Leu moldavo"
-        }, 
-        "BSD": {
-            "fr": "Dollar baham\u00e9en", 
-            "en": "Bahamian dollar", 
-            "nl": "Bahamaanse dollar", 
-            "de": "Bahama-Dollar", 
-            "it": "Dollaro delle Bahamas", 
-            "hu": "bahamai doll\u00e1r", 
-            "es": "D\u00f3lar bahame\u00f1o"
-        }, 
-        "SEK": {
-            "fr": "Couronne su\u00e9doise", 
-            "en": "Swedish krona", 
-            "nl": "Zweedse kroon", 
-            "de": "Schwedische Krone", 
-            "it": "Corona svedese", 
-            "hu": "Sv\u00e9d korona", 
-            "es": "Corona sueca"
-        }, 
-        "MVR": {
-            "fr": "Rufiyaa", 
-            "en": "Maldivian rufiyaa", 
-            "nl": "Maldivische rufiyaa", 
-            "de": "Rufiyaa", 
-            "it": "Rufiyaa delle Maldive", 
-            "hu": "Mald\u00edv-szigeteki r\u00fafia", 
-            "es": "Rupia de Maldivas"
-        }, 
-        "FRF": {
-            "fr": "Franc fran\u00e7ais", 
-            "en": "French franc", 
-            "nl": "Franse frank", 
-            "de": "Franz\u00f6sischer Franc", 
-            "it": "Franco francese", 
-            "hu": "Francia frank", 
-            "es": "Franco franc\u00e9s"
-        }, 
-        "SRD": {
-            "fr": "Dollar de Surinam", 
-            "en": "Surinamese dollar", 
-            "nl": "Surinaamse dollar", 
-            "de": "Suriname-Dollar", 
-            "it": "Dollaro surinamese", 
-            "hu": "suriname-i doll\u00e1r", 
-            "es": "D\u00f3lar surinam\u00e9s"
-        }, 
-        "CUP": {
-            "fr": "peso cubain", 
-            "en": "Cuban peso", 
-            "nl": "Cubaanse peso", 
-            "de": "Kubanischer Peso", 
-            "it": "peso cubano", 
-            "hu": "kubai peso", 
-            "es": "peso"
-        }, 
-        "BBD": {
-            "fr": "dollar barbadien", 
-            "en": "Barbadian dollar", 
-            "nl": "Barbadiaanse dollar", 
-            "de": "Barbados-Dollar", 
-            "it": "Dollaro di Barbados", 
-            "hu": "barbadosi doll\u00e1r", 
-            "es": "D\u00f3lar de Barbados"
-        }, 
-        "KRW": {
-            "fr": "Won sud-cor\u00e9en", 
-            "en": "South Korean won", 
-            "nl": "Zuid-Koreaanse won", 
-            "de": "S\u00fcdkoreanischer Won", 
-            "it": "Won sudcoreano", 
-            "hu": "D\u00e9l-koreai von", 
-            "es": "W\u014fn surcoreano"
-        }, 
-        "GMD": {
-            "fr": "Dalasi", 
-            "en": "Gambian dalasi", 
-            "nl": "Gambiaanse dalasi", 
-            "de": "Dalasi", 
-            "it": "Dalasi gambese", 
-            "hu": "Gambiai dalasi", 
-            "es": "Dalasi"
-        }, 
-        "VEF": {
-            "fr": "Bol\u00edvar v\u00e9n\u00e9zu\u00e9lien", 
-            "en": "Venezuelan bol\u00edvar", 
-            "nl": "Venezolaanse bol\u00edvar", 
-            "de": "Venezolanischer Bol\u00edvar", 
-            "it": "Bol\u00edvar venezuelano", 
-            "hu": "venezuelai bol\u00edvar", 
-            "es": "Bol\u00edvar"
-        }, 
-        "GTQ": {
-            "fr": "Quetzal", 
-            "en": "Guatemalan quetzal", 
-            "nl": "Guatemalteekse quetzal", 
-            "de": "Guatemaltekischer Quetzal", 
-            "it": "Quetzal guatemalteco", 
-            "hu": "Guatemalai quetzal", 
-            "es": "Quetzal"
-        }, 
+            "ar": "أفغاني",
+            "bg": "Афганистански афган",
+            "ca": "afgani",
+            "cs": "afghánský afghání",
+            "da": "Afghani",
+            "de": "Afghani",
+            "el": "Αφγάνι",
+            "en": "Afghan afghani",
+            "eo": "afgana afganio",
+            "es": "afgani afgano",
+            "et": "Afganistani afgaani",
+            "fa": "افغانی",
+            "fi": "Afganistanin afgaani",
+            "fr": "afghani",
+            "gl": "afgani",
+            "he": "אפגני",
+            "hr": "Afganistanski afgani",
+            "hu": "afgán afgáni",
+            "it": "afghani afgano",
+            "ja": "アフガニ",
+            "lt": "Afganis",
+            "nl": "Afghaanse afghani",
+            "oc": "Afgani",
+            "pl": "Afgani",
+            "pt": "afegane",
+            "ru": "афгани",
+            "sl": "Afganistanski afgani",
+            "sr": "авганистански авгани",
+            "sv": "Afghani",
+            "tr": "Afgani",
+            "uk": "Афгані",
+            "zh": "阿富汗尼",
+            "ro": "afgan afgan",
+            "ta": "ஆப்கான் ஆப்கானி"
+        },
+        "ALL": {
+            "ar": "ليك ألباني",
+            "bg": "Албански лек",
+            "ca": "lek",
+            "cs": "Albánský lek",
+            "cy": "Lek",
+            "da": "Lek",
+            "de": "Albanischer Lek",
+            "el": "Λεκ",
+            "en": "Albanian lek",
+            "eo": "albana leko",
+            "es": "lek albanés",
+            "et": "Albaania lekk",
+            "fa": "لک آلبانی",
+            "fi": "Albanian lek",
+            "fr": "lek",
+            "gl": "Lek albanés",
+            "he": "לק",
+            "hr": "Albanski lek",
+            "hu": "albán lek",
+            "it": "lek albanese",
+            "ja": "レク",
+            "lt": "Albanijos lekas",
+            "nl": "Albanese lek",
+            "pl": "lek",
+            "pt": "lek",
+            "ro": "Lek",
+            "ru": "албанский лек",
+            "sk": "Albánsky lek",
+            "sl": "Albanski lek",
+            "sr": "албански лек",
+            "sv": "Lek",
+            "ta": "அல்பேனிய லெக்",
+            "tr": "Arnavut leki",
+            "uk": "Албанський лек",
+            "zh": "阿爾巴尼亞列克",
+            "ia": "lek albanese",
+            "oc": "Lek"
+        },
+        "AMD": {
+            "ar": "درام أرميني",
+            "bg": "Арменски драм",
+            "ca": "dram",
+            "cs": "Arménský dram",
+            "da": "Armenske dram",
+            "de": "Dram",
+            "el": "Ντραμ",
+            "en": "Armenian dram",
+            "eo": "armena dramo",
+            "es": "dram armenio",
+            "et": "Armeenia dramm",
+            "fa": "درام",
+            "fi": "Armenian dram",
+            "fr": "dram",
+            "gl": "Dram armenio",
+            "he": "דראם ארמני",
+            "hr": "Armenski dram",
+            "hu": "örmény dram",
+            "ia": "Dram (moneta)",
+            "it": "dram armeno",
+            "ja": "ドラム",
+            "lt": "Dramas",
+            "nl": "Armeense dram",
+            "pl": "Dram",
+            "pt": "dram arménio",
+            "ro": "Dram",
+            "ru": "армянский драм",
+            "sk": "Arménsky dram",
+            "sl": "Armenski dram",
+            "sr": "јерменски драм",
+            "sv": "Dram",
+            "ta": "ஆர்மேனிய டிராம்",
+            "tr": "Ermeni dramı",
+            "uk": "Вірменський драм",
+            "zh": "亚美尼亚德拉姆",
+            "cy": "Dram Armenia",
+            "oc": "dram"
+        },
         "ANG": {
-            "fr": "Florin des Antilles n\u00e9erlandaises", 
-            "en": "Netherlands Antillean guilder", 
-            "nl": "Antilliaanse gulden", 
-            "de": "Antillen-Gulden", 
-            "it": "Fiorino delle Antille Olandesi", 
-            "hu": "Holland antill\u00e1kbeli forint", 
-            "es": "Flor\u00edn antillano neerland\u00e9s"
-        }, 
-        "CUC": {
-            "fr": "Peso cubain convertible", 
-            "en": "Cuban convertible peso", 
-            "nl": "Convertibele peso", 
-            "de": "Peso convertible", 
-            "it": "Peso cubano convertibile", 
-            "hu": "Kubai konvertibilis peso", 
-            "es": "peso convertible"
-        }, 
-        "CLP": {
-            "fr": "Peso chilien", 
-            "en": "Chilean peso", 
-            "nl": "Chileense peso", 
-            "de": "Chilenischer Peso", 
-            "it": "Peso cileno", 
-            "hu": "chilei peso", 
-            "es": "peso"
-        }, 
-        "ZMW": {
-            "fr": "Kwacha zambien", 
-            "en": "Zambian kwacha", 
-            "nl": "Zambiaanse kwacha", 
-            "de": "Sambischer Kwacha", 
-            "it": "Kwacha zambiano", 
-            "hu": "Zambiai kwacha", 
-            "es": "Kwacha zambiano"
-        }, 
-        "LTL": {
-            "fr": "Litas", 
-            "en": "Lithuanian litas", 
-            "nl": "Litouwse litas", 
-            "de": "Litas", 
-            "it": "Litas lituano", 
-            "hu": "litv\u00e1n litas", 
-            "es": "Litas lituana"
-        }, 
-        "CDF": {
-            "fr": "Franc congolais", 
-            "en": "Congolese franc", 
-            "nl": "Congolese frank", 
-            "de": "Kongo-Franc", 
-            "it": "Franco congolese", 
-            "hu": "Kong\u00f3i frank", 
-            "es": "franco"
-        }, 
-        "XCD": {
-            "fr": "dollar des Cara\u00efbes orientales", 
-            "en": "East Caribbean dollar", 
-            "nl": "Oost-Caribische dollar", 
-            "de": "ostkaribischer Dollar", 
-            "it": "dollaro dei Caraibi Orientali", 
-            "hu": "kelet-karibi doll\u00e1r", 
-            "es": "d\u00f3lar del Caribe Oriental"
-        }, 
-        "KZT": {
-            "fr": "Tenge kazakh", 
-            "en": "Kazakhstani tenge", 
-            "nl": "Kazachse tenge", 
-            "de": "Tenge", 
-            "it": "Tenge kazako", 
-            "hu": "kazah tenge", 
-            "es": "Tenge kazajo"
-        }, 
-        "XPF": {
-            "fr": "Franc Pacifique", 
-            "en": "CFP Franc", 
-            "nl": "CFP-frank", 
-            "de": "CFP-Franc", 
-            "it": "Franco CFP", 
-            "hu": "Csendes-\u00f3ce\u00e1ni valutak\u00f6z\u00f6ss\u00e9gi frank", 
-            "es": "Franco CFP"
-        }, 
-        "RUB": {
-            "fr": "Rouble russe", 
-            "en": "Russian ruble", 
-            "nl": "Russische roebel", 
-            "de": "Russischer Rubel", 
-            "it": "Rublo russo", 
-            "hu": "orosz rubel", 
-            "es": "Rublo ruso"
-        }, 
-        "XFU": {
-            "fr": "Franc UIC", 
-            "en": "UIC franc"
-        }, 
-        "TTD": {
-            "fr": "Dollar de Trinit\u00e9-et-Tobago", 
-            "en": "Trinidad and Tobago dollar", 
-            "nl": "Trinidad en Tobagodollar", 
-            "de": "Trinidad-und-Tobago-Dollar", 
-            "it": "Dollaro di Trinidad e Tobago", 
-            "hu": "Trinidad \u00e9s Tobag\u00f3-i doll\u00e1r", 
-            "es": "D\u00f3lar trinitense"
-        }, 
-        "RON": {
-            "fr": "Leu roumain", 
-            "en": "Romanian leu", 
-            "nl": "Roemeense leu", 
-            "de": "Rum\u00e4nischer Leu", 
-            "it": "Leu romeno", 
-            "hu": "rom\u00e1n lej", 
-            "es": "Leu rumano"
-        }, 
-        "OMR": {
-            "fr": "Rial omanais", 
-            "en": "Omani rial", 
-            "nl": "Omaanse rial", 
-            "de": "Omanischer Rial", 
-            "it": "Riyal dell'Oman", 
-            "hu": "Om\u00e1ni ri\u00e1l", 
-            "es": "Rial oman\u00ed"
-        }, 
-        "BRL": {
-            "fr": "r\u00e9al br\u00e9silien", 
-            "en": "Brazilian real", 
-            "nl": "Braziliaanse real", 
-            "de": "Brasilianischer Real", 
-            "it": "Real brasiliano", 
-            "hu": "brazil real", 
-            "es": "Real brasile\u00f1o"
-        }, 
-        "SBD": {
-            "fr": "dollar des \u00eeles Salomon", 
-            "en": "Solomon Islands dollar", 
-            "nl": "Salomon-dollar", 
-            "de": "Salomonen-Dollar", 
-            "it": "Dollaro delle Salomone", 
-            "hu": "Salamon-szigeteki doll\u00e1r", 
-            "es": "d\u00f3lar de las Islas Salom\u00f3n"
-        }, 
-        "PYG": {
-            "fr": "Guaran\u00ed", 
-            "en": "Paraguayan guaran\u00ed", 
-            "nl": "Paraguayaanse guaran\u00ed", 
-            "de": "Paraguayischer Guaran\u00ed", 
-            "it": "Guaran\u00ed paraguaiano", 
-            "hu": "Paraguayi guaran\u00ed", 
-            "es": "Guaran\u00ed"
-        }, 
-        "KES": {
-            "fr": "Shilling k\u00e9nyan", 
-            "en": "Kenyan shilling", 
-            "nl": "Keniaanse shilling", 
-            "de": "Kenia-Schilling", 
-            "it": "Scellino keniota", 
-            "hu": "Kenyai shilling", 
-            "es": "Chel\u00edn keniano"
-        }, 
-        "USD": {
-            "fr": "dollar am\u00e9ricain", 
-            "en": "United States dollar", 
-            "nl": "Amerikaanse dollar", 
-            "de": "US-Dollar", 
-            "it": "dollaro statunitense", 
-            "hu": "amerikai doll\u00e1r", 
-            "es": "d\u00f3lar"
-        }, 
-        "TWD": {
-            "fr": "Nouveau dollar de Ta\u00efwan", 
-            "en": "New Taiwan dollar", 
-            "nl": "Taiwanese dollar", 
-            "de": "Neuer Taiwan-Dollar", 
-            "it": "Dollaro taiwanese", 
-            "hu": "Tajvani \u00faj doll\u00e1r", 
-            "es": "Nuevo d\u00f3lar taiwan\u00e9s"
-        }, 
-        "TOP": {
-            "fr": "pa\u2019anga", 
-            "en": "Tongan pa\u02bbanga", 
-            "nl": "Tongaanse pa'anga", 
-            "de": "Pa\u02bbanga", 
-            "it": "Pa'anga tongano", 
-            "hu": "Tongai pa\u02bbanga", 
-            "es": "pa\u02bbanga"
-        }, 
-        "COP": {
-            "fr": "Peso colombien", 
-            "en": "peso", 
-            "nl": "Colombiaanse peso", 
-            "de": "Kolumbianischer Peso", 
-            "it": "Peso colombiano", 
-            "hu": "Kolumbiai peso", 
-            "es": "peso"
-        }, 
-        "GNF": {
-            "fr": "Franc guin\u00e9en", 
-            "en": "Guinean franc", 
-            "nl": "Guineese frank", 
-            "de": "Franc Guin\u00e9en", 
-            "it": "Franco guineano", 
-            "hu": "Guineai frank", 
-            "es": "Franco guineano"
-        }, 
-        "WST": {
-            "fr": "Tala", 
-            "en": "Samoan t\u0101l\u0101", 
-            "nl": "Samoaanse tala", 
-            "de": "Samoanischer Tala", 
-            "it": "Tala samoano", 
-            "hu": "Szamoai tala", 
-            "es": "tala"
-        }, 
-        "IQD": {
-            "fr": "Dinar irakien", 
-            "en": "Iraqi dinar", 
-            "nl": "Iraakse dinar", 
-            "de": "Irakischer Dinar", 
-            "it": "Dinaro iracheno", 
-            "hu": "iraki din\u00e1r", 
-            "es": "Dinar iraqu\u00ed"
-        }, 
-        "ERN": {
-            "fr": "Nakfa \u00e9rythr\u00e9en", 
-            "en": "Eritrean nakfa", 
-            "nl": "Eritrese nakfa", 
-            "de": "Eritreischer Nakfa", 
-            "it": "Nacfa eritreo", 
-            "hu": "Eritreai nakfa", 
-            "es": "Nakfa"
-        }, 
-        "CVE": {
-            "fr": "Escudo cap-verdien", 
-            "en": "Cape Verdean escudo", 
-            "nl": "Kaapverdische escudo", 
-            "de": "Kap-Verde-Escudo", 
-            "it": "Escudo capoverdiano", 
-            "hu": "Z\u00f6ld-foki k\u00f6zt\u00e1rsas\u00e1gi escudo", 
-            "es": "escudo"
-        }, 
-        "AUD": {
-            "fr": "dollar australien", 
-            "en": "Australian dollar", 
-            "nl": "Australische dollar", 
-            "de": "Australischer Dollar", 
-            "it": "Dollaro australiano", 
-            "hu": "Ausztr\u00e1l doll\u00e1r", 
-            "es": "D\u00f3lar australiano"
-        }, 
-        "BAM": {
-            "fr": "Mark convertible de Bosnie-Herz\u00e9govine", 
-            "en": "Bosnia and Herzegovina convertible mark", 
-            "nl": "Bosnische inwisselbare mark", 
-            "de": "Konvertible Mark", 
-            "it": "Marco bosniaco", 
-            "hu": "bosny\u00e1k konvertibilis m\u00e1rka", 
-            "es": "Marco bosnioherzegovino"
-        }, 
-        "KWD": {
-            "fr": "Dinar kowe\u00eftien", 
-            "en": "Kuwaiti dinar", 
-            "nl": "Koeweitse dinar", 
-            "de": "Kuwait-Dinar", 
-            "it": "Dinaro kuwaitiano", 
-            "hu": "kuvaiti din\u00e1r", 
-            "es": "Dinar kuwait\u00ed"
-        }, 
-        "BIF": {
-            "fr": "Franc burundais", 
-            "en": "Burundian franc", 
-            "nl": "Burundese frank", 
-            "de": "Burundi-Franc", 
-            "it": "Franco del Burundi", 
-            "hu": "Burundi frank", 
-            "es": "Franco de Burundi"
-        }, 
-        "PGK": {
-            "fr": "Kina", 
-            "en": "Papua New Guinean kina", 
-            "nl": "Papoea-Nieuw-Guinese kina", 
-            "de": "Kina", 
-            "it": "Kina papuana", 
-            "hu": "P\u00e1pua \u00faj-guineai kina", 
-            "es": "Kina"
-        }, 
-        "SOS": {
-            "fr": "shilling somalien", 
-            "en": "Somali shilling", 
-            "nl": "Somalische shilling", 
-            "de": "Somalia-Schilling", 
-            "it": "Scellino somalo", 
-            "hu": "Szom\u00e1liai shilling", 
-            "es": "chel\u00edn"
-        }, 
-        "CAD": {
-            "fr": "Dollar canadien", 
-            "en": "Canadian dollar", 
-            "nl": "Canadese dollar", 
-            "de": "Kanadischer Dollar", 
-            "it": "Dollaro canadese", 
-            "hu": "kanadai doll\u00e1r", 
-            "es": "D\u00f3lar canadiense"
-        }, 
-        "SGD": {
-            "fr": "Dollar de Singapour", 
-            "en": "Singapore dollar", 
-            "nl": "Singaporese dollar", 
-            "de": "Singapur-Dollar", 
-            "it": "Dollaro di Singapore", 
-            "hu": "szingap\u00fari doll\u00e1r", 
-            "es": "D\u00f3lar de Singapur"
-        }, 
-        "UZS": {
-            "fr": "Sum", 
-            "en": "Uzbekistani som", 
-            "nl": "Oezbeekse sum", 
-            "de": "So\u02bbm", 
-            "it": "Som uzbeco", 
-            "hu": "\u00dczb\u00e9g szom", 
-            "es": "som"
-        }, 
-        "STD": {
-            "fr": "Dobra", 
-            "en": "S\u00e3o Tom\u00e9 and Pr\u00edncipe dobra", 
-            "nl": "Santomese dobra", 
-            "de": "S\u00e3o-tom\u00e9ischer Dobra", 
-            "it": "Dobra di S\u00e3o Tom\u00e9 e Pr\u00edncipe", 
-            "hu": "S\u00e3o Tom\u00e9 \u00e9s Pr\u00edncipe-i dobra", 
-            "es": "Dobra santotomense"
-        }, 
-        "XFO": {
-            "fr": "Franc-or", 
-            "en": "Gold franc", 
-            "de": "Goldfranken"
-        }, 
-        "IRR": {
-            "fr": "Rial iranien", 
-            "en": "Iranian rial", 
-            "nl": "Iraanse rial", 
-            "de": "Iranischer Rial", 
-            "it": "Riyal iraniano", 
-            "hu": "ir\u00e1ni ri\u00e1l", 
-            "es": "Rial iran\u00ed"
-        }, 
-        "CNY": {
-            "fr": "Yuan", 
-            "en": "renminbi", 
-            "nl": "Chinese renminbi", 
-            "de": "Renminbi", 
-            "it": "Renminbi cinese", 
-            "hu": "Renminbi", 
-            "es": "Yuan chino"
-        }, 
-        "SLL": {
-            "fr": "leone", 
-            "en": "Sierra Leonean leone", 
-            "nl": "Sierra Leoonse leone", 
-            "de": "Sierra-leonischer Leone", 
-            "it": "Leone sierraleonese", 
-            "hu": "Sierra Leone-i leone", 
-            "es": "leone"
-        }, 
-        "TND": {
-            "fr": "Dinar tunisien", 
-            "en": "Tunisian dinar", 
-            "nl": "Tunesische dinar", 
-            "de": "Tunesischer Dinar", 
-            "it": "Dinaro tunisino", 
-            "hu": "Tun\u00e9ziai din\u00e1r", 
-            "es": "dinar"
-        }, 
-        "GYD": {
-            "fr": "Dollar guyanien", 
-            "en": "Guyanese dollar", 
-            "nl": "Guyaanse dollar", 
-            "de": "Guyana-Dollar", 
-            "it": "Dollaro della Guyana", 
-            "hu": "Guyanai doll\u00e1r", 
-            "es": "D\u00f3lar guyan\u00e9s"
-        }, 
-        "MTL": {
-            "fr": "Lire maltaise", 
-            "en": "Maltese lira", 
-            "nl": "Maltese lire", 
-            "de": "Maltesische Lira", 
-            "it": "Lira maltese", 
-            "hu": "M\u00e1ltai l\u00edra", 
-            "es": "Lira maltesa"
-        }, 
-        "NZD": {
-            "fr": "dollar n\u00e9o-z\u00e9landais", 
-            "en": "New Zealand dollar", 
-            "nl": "Nieuw-Zeelandse dollar", 
-            "de": "Neuseeland-Dollar", 
-            "it": "Dollaro neozelandese", 
-            "hu": "\u00faj-z\u00e9landi doll\u00e1r", 
-            "es": "D\u00f3lar neozeland\u00e9s"
-        }, 
-        "FKP": {
-            "fr": "Livre des \u00celes Malouines", 
-            "en": "Falkland Islands pound", 
-            "nl": "Falklandeilands pond", 
-            "de": "Falkland-Pfund", 
-            "it": "Sterlina delle Falkland", 
-            "hu": "Falkland-szigeteki font", 
-            "es": "Libra malvinense"
-        }, 
-        "LVL": {
-            "fr": "Lats", 
-            "en": "lats", 
-            "nl": "Letse lats", 
-            "de": "Lats", 
-            "it": "Lats lettone", 
-            "hu": "lett lat", 
-            "es": "Lats let\u00f3n"
-        }, 
-        "ARP": {
-            "fr": "peso argentino", 
-            "en": "peso argentino", 
-            "nl": "peso argentino", 
-            "it": "peso argentino", 
-            "es": "peso argentino"
-        }, 
-        "KGS": {
-            "fr": "Som", 
-            "en": "Kyrgyzstani som", 
-            "nl": "Kirgizische som", 
-            "de": "Som", 
-            "it": "som kirghizo", 
-            "hu": "kirgiz szom", 
-            "es": "Som kirgu\u00eds"
-        }, 
+            "ar": "غيلدر الأنتيل الهولندية",
+            "ca": "florí de les Antilles Neerlandeses",
+            "cs": "Gulden Nizozemských Antil",
+            "de": "Antillen-Gulden",
+            "en": "Netherlands Antillean guilder",
+            "eo": "nederlandantila guldeno",
+            "es": "florín antillano neerlandés",
+            "eu": "Holandarren Antilletako florin",
+            "fa": "گیلدر آنتیل هلند",
+            "fi": "Alankomaiden Antillien guldeni",
+            "fr": "Florin des Antilles néerlandaises",
+            "gl": "Florín das Antillas Neerlandesas",
+            "hr": "Nizozemskoantilski gulden",
+            "hu": "Holland antillákbeli forint",
+            "it": "Fiorino delle Antille Olandesi",
+            "ja": "アンティル・ギルダー",
+            "lt": "Nyderlandų Antilų guldenas",
+            "nl": "Antilliaanse gulden",
+            "oc": "Florin de las Antilhas Neerlandesas",
+            "pl": "gulden Antyli Holenderskich",
+            "pt": "Florim das Antilhas Neerlandesas",
+            "ru": "нидерландский антильский гульден",
+            "sv": "Antillergulden",
+            "tr": "Hollanda Antilleri guldeni",
+            "uk": "Нідерландський антильський гульден",
+            "zh": "荷屬安的列斯盾",
+            "he": "גילדן אנטילי"
+        },
+        "AOA": {
+            "ar": "كوانزا أنغولي",
+            "bg": "Анголска кванза",
+            "ca": "kwanza",
+            "cs": "angolská kwanza",
+            "cy": "Kwanza",
+            "de": "Kwanza",
+            "el": "Κουάνζα",
+            "en": "kwanza",
+            "eo": "angola kvanzo",
+            "es": "Kwanza angoleño",
+            "fa": "کوانزای آنگولا",
+            "fi": "Angolan kwanza",
+            "fr": "Kwanza",
+            "gl": "Kwanza",
+            "he": "קוואנזה",
+            "hr": "Angolska kvanza",
+            "hu": "angolai kwanza",
+            "it": "Kwanza angolano",
+            "ja": "クワンザ",
+            "lt": "Kvanza",
+            "nl": "Angolese kwanza",
+            "pl": "Kwanza",
+            "pt": "Kwanza",
+            "ru": "ангольская кванза",
+            "sr": "анголска кванза",
+            "sv": "Kwanza",
+            "tr": "Kwanza",
+            "uk": "Ангольська кванза",
+            "vi": "Kwanza Angola",
+            "zh": "安哥拉寬扎",
+            "oc": "Kwanza",
+            "ta": "அங்கோலா குவான்சா"
+        },
+        "ARG": {
+            "es": "Peso Oro Sellado"
+        },
         "ARS": {
-            "fr": "peso argentin", 
-            "en": "peso", 
-            "nl": "Argentijnse peso", 
-            "de": "Argentinischer Peso", 
-            "it": "peso argentino", 
-            "hu": "argentin peso", 
-            "es": "peso"
-        }, 
-        "BMD": {
-            "fr": "Dollar bermudien", 
-            "en": "Bermudian dollar", 
-            "nl": "Bermuda-dollar", 
-            "de": "Bermuda-Dollar", 
-            "it": "Dollaro della Bermuda", 
-            "hu": "bermudai doll\u00e1r", 
-            "es": "D\u00f3lar bermude\u00f1o"
-        }, 
-        "RSD": {
-            "fr": "Dinar serbe", 
-            "en": "Serbian dinar", 
-            "nl": "Servische dinar", 
-            "de": "Serbischer Dinar", 
-            "it": "Dinaro serbo", 
-            "hu": "szerb din\u00e1r", 
-            "es": "Dinar serbio"
-        }, 
+            "ar": "بيزو أرجنتيني",
+            "bg": "Аржентинско песо",
+            "ca": "peso argentí",
+            "cs": "Argentinské peso",
+            "de": "argentinischer Peso",
+            "el": "Πέσο Αργεντινής",
+            "en": "Argentine peso",
+            "eo": "argentina peso",
+            "es": "peso argentino",
+            "et": "Argentina peeso",
+            "eu": "Argentinar peso",
+            "fa": "پزوی آرژانتین",
+            "fi": "Argentiinan peso",
+            "fr": "peso argentin",
+            "gl": "Peso arxentino",
+            "he": "פסו ארגנטינאי",
+            "hr": "Argentinski pezo",
+            "hu": "argentin peso",
+            "it": "peso argentino",
+            "ja": "アルゼンチン・ペソ",
+            "lt": "Argentinos pesas",
+            "nl": "Argentijnse peso",
+            "oc": "Peso",
+            "pl": "Peso argentyńskie",
+            "pt": "peso argentino",
+            "ro": "Peso argentinian",
+            "ru": "аргентинское песо",
+            "sr": "аргентински пезос",
+            "sv": "Argentinsk peso",
+            "ta": "ஆர்ஜென்டின பீசோ",
+            "tr": "Arjantin pesosu",
+            "uk": "аргентинський песо",
+            "vi": "Peso Argentina",
+            "zh": "阿根廷比索"
+        },
+        "AUD": {
+            "ar": "دولار أسترالي",
+            "bg": "Австралийски долар",
+            "ca": "dòlar australià",
+            "cs": "Australský dolar",
+            "da": "Australske dollar",
+            "de": "Australischer Dollar",
+            "el": "Δολάριο Αυστραλίας",
+            "en": "Australian dollar",
+            "eo": "Aŭstralia dolaro",
+            "es": "dólar australiano",
+            "et": "Austraalia dollar",
+            "eu": "Australiar dolar",
+            "fa": "دلار استرالیا",
+            "fi": "Australian dollari",
+            "fr": "dollar australien",
+            "gl": "Dólar australiano",
+            "he": "דולר אוסטרלי",
+            "hr": "Australski dolar",
+            "hu": "ausztrál dollár",
+            "it": "dollaro australiano",
+            "ja": "オーストラリア・ドル",
+            "lt": "Australijos doleris",
+            "nl": "Australische dollar",
+            "oc": "Dolar australian",
+            "pl": "Dolar australijski",
+            "pt": "Dólar australiano",
+            "ro": "dolar australian",
+            "ru": "австралийский доллар",
+            "sk": "Austrálsky dolár",
+            "sr": "аустралијски долар",
+            "sv": "Australisk dollar",
+            "ta": "அவுத்திரேலிய வெள்ளி",
+            "tr": "Avustralya doları",
+            "uk": "австралійський долар",
+            "vi": "Đô la Úc",
+            "zh": "澳大利亚元"
+        },
+        "AWG": {
+            "ar": "فلورن أروبي",
+            "ca": "florí d'Aruba",
+            "cs": "Arubský florin",
+            "de": "Aruba-Florin",
+            "el": "Φλορίνι της Αρούμπα",
+            "en": "Aruban florin",
+            "eo": "aruba guldeno",
+            "es": "florín arubeño",
+            "et": "Aruba floriin",
+            "eu": "Florin arubar",
+            "fa": "آروبا فلورین",
+            "fi": "Aruban floriini",
+            "fr": "Florin arubais",
+            "gl": "Florín arubeño",
+            "he": "פלורין ארובי",
+            "hr": "Arupski gulden",
+            "hu": "Arubai florin",
+            "it": "Fiorino arubano",
+            "ja": "アルバ・フロリン",
+            "lt": "Arubos florinas",
+            "nl": "Arubaanse florin",
+            "pl": "Florin arubański",
+            "pt": "Florim arubano",
+            "ro": "Florin arubez",
+            "ru": "арубанский флорин",
+            "sv": "Arubansk florin",
+            "tr": "Aruba florini",
+            "uk": "Арубський флорін",
+            "zh": "阿魯巴弗羅林",
+            "sr": "арупски флорин",
+            "ta": "அரூபா ஃபுளோரின்"
+        },
+        "AYP": {
+            "en": "Alderney pound",
+            "fi": "Alderneyn punta",
+            "hr": "Aldernejska funta",
+            "hu": "Alderney-i font",
+            "it": "sterlina di Alderney",
+            "pl": "Funt Alderney",
+            "ru": "фунт Олдерни",
+            "eo": "alderneja pundo",
+            "es": "libra de Alderney",
+            "ja": "オルダニー・ポンド",
+            "nl": "Alderney pound"
+        },
+        "AZN": {
+            "ar": "مانات أذربيجاني",
+            "bg": "Азербайджански манат",
+            "ca": "manat azerbaidjanès",
+            "cs": "Ázerbájdžánský manat",
+            "da": "Aserbajdsjanske manat",
+            "de": "Aserbaidschan-Manat",
+            "el": "Μανάτ του Αζερμπαϊτζάν",
+            "en": "Azerbaijani manat",
+            "eo": "azerbajĝana manato",
+            "es": "manat azerbaiyano",
+            "et": "Aserbaidžaani manat",
+            "eu": "Manat azerbaijandar",
+            "fa": "منات جمهوری آذربایجان",
+            "fi": "Azerbaidžanin manat",
+            "fr": "Manat azerbaïdjanais",
+            "gl": "Manat acerbaixano",
+            "he": "מאנאט אזרבייג'ני",
+            "hr": "Azerbajdžanski manat",
+            "hu": "azeri manat",
+            "ia": "manat azeri",
+            "it": "Manat azero",
+            "ja": "アゼルバイジャン・マナト",
+            "lt": "Azerbaidžano manatas",
+            "nl": "Azerbeidzjaanse manat",
+            "pl": "Manat azerski",
+            "pt": "Manat azeri",
+            "ro": "Manat azer",
+            "ru": "азербайджанский манат",
+            "sk": "Azerbajdžanský manat",
+            "sl": "azerbajdžanski manat",
+            "sr": "азербејџански манат",
+            "sv": "Azerbajdzjansk manat",
+            "ta": "அசர்பைச்சானிய மனாத்து",
+            "tr": "Azerbaycan manatı",
+            "uk": "Азербайджанський манат",
+            "vi": "Manat Azerbaijan",
+            "zh": "阿塞拜疆马纳特",
+            "cy": "Manat Aserbaijan",
+            "oc": "Manat"
+        },
+        "BAM": {
+            "ar": "مارك بوسني",
+            "bg": "Конвертибилна марка",
+            "ca": "marc convertible",
+            "cs": "Konvertibilní marka",
+            "da": "Konvertibilna mark",
+            "de": "konvertible Mark",
+            "el": "Μετατρέψιμο μάρκο Βοσνίας και Ερζεγοβίνης",
+            "en": "convertible mark",
+            "eo": "konvertebla marko",
+            "es": "marco bosnioherzegovino",
+            "fa": "مارک تبدیلپذیر بوسنی و هرزگوین",
+            "fi": "Bosnian ja Hertsegovinan vaihdettava markka",
+            "fr": "mark convertible de Bosnie-Herzégovine",
+            "gl": "Marco convertible",
+            "he": "מארק סחיר",
+            "hr": "Bosna i Hercegovina Konvertibilna marka",
+            "hu": "bosnyák konvertibilis márka",
+            "it": "marco bosniaco",
+            "ja": "兌換マルク",
+            "lt": "Konvertuojamoji markė",
+            "nl": "Bosnische inwisselbare mark",
+            "pl": "Marka zamienna",
+            "pt": "marco conversível",
+            "ro": "Marcă bosniacă convertibilă",
+            "ru": "конвертируемая марка",
+            "sk": "Konvertibilná marka",
+            "sl": "Konvertibilna marka Bosne in Hercegovine",
+            "sr": "конвертибилна марка",
+            "sv": "Konvertibilna marka",
+            "ta": "கன்வர்ட்டிபிள் மார்க்கு",
+            "tr": "Bosna-Hersek değiştirilebilir markı",
+            "uk": "Конвертована марка",
+            "zh": "波斯尼亚和黑塞哥维那可兑换马克",
+            "cy": "mark cyfnewidiol (Bosnia)",
+            "ia": "mark convertibile de Bosnia-Herzegovina",
+            "oc": "Marka de Bòsnia e Ercegovina"
+        },
+        "BBD": {
+            "ar": "دولار بربادوسي",
+            "bg": "Барбадоски долар",
+            "ca": "dòlar de Barbados",
+            "cs": "Barbadoský dolar",
+            "de": "Barbados-Dollar",
+            "el": "Δολάριο Μπαρμπάντος",
+            "en": "Barbadian dollar",
+            "eo": "barbada dolaro",
+            "es": "dólar de Barbados",
+            "eu": "Dolar barbadostar",
+            "fa": "دلار باربادوس",
+            "fi": "Barbadoksen dollari",
+            "fr": "dollar barbadien",
+            "gl": "Dólar de Barbados",
+            "hr": "Barbadoski dolar",
+            "hu": "barbadosi dollár",
+            "it": "dollaro di Barbados",
+            "ja": "バルバドス・ドル",
+            "lt": "Barbadoso doleris",
+            "nl": "Barbadiaanse dollar",
+            "pl": "Dolar barbadoski",
+            "pt": "dólar barbadense",
+            "ru": "барбадосский доллар",
+            "sk": "Barbadoský dolár",
+            "sr": "барбадоски долар",
+            "sv": "Barbadisk dollar",
+            "tr": "Barbados doları",
+            "uk": "Барбадоський долар",
+            "vi": "Đô la Barbados",
+            "zh": "巴貝多元",
+            "ta": "பார்படோஸ் டாலர்"
+        },
+        "BDT": {
+            "ar": "تاكا بنغلاديشي",
+            "bg": "Бангладешка така",
+            "ca": "taka",
+            "cs": "Bangladéšská taka",
+            "de": "Taka",
+            "el": "Μπανγκλαντεσιανή τάκα",
+            "en": "Bangladeshi taka",
+            "eo": "bangladeŝa tako",
+            "es": "taka bangladesí",
+            "fa": "تاکا بنگلادش",
+            "fi": "Bangladeshin taka",
+            "fr": "taka",
+            "hr": "Bangladeška taka",
+            "hu": "bangladesi taka",
+            "it": "taka bengalese",
+            "ja": "タカ",
+            "lt": "Bangladešo taka",
+            "nl": "Bengalese taka",
+            "oc": "Taka",
+            "pl": "Taka",
+            "pt": "taka",
+            "ru": "бангладешская така",
+            "sk": "Taka",
+            "sr": "бангладешка така",
+            "sv": "Taka",
+            "ta": "வங்காளதேச இட்டாக்கா",
+            "tr": "Taka",
+            "uk": "Бангладеська така",
+            "vi": "Taka",
+            "zh": "孟加拉塔卡",
+            "he": "טאקה"
+        },
+        "BGN": {
+            "ar": "ليف بلغاري",
+            "bg": "български лев",
+            "ca": "lev",
+            "cs": "bulharský lev",
+            "da": "Lev",
+            "de": "Lew",
+            "el": "Λεβ",
+            "en": "Bulgarian lev",
+            "eo": "bulgara levo",
+            "es": "lev búlgaro",
+            "et": "Leev",
+            "eu": "Bulgariar lev",
+            "fa": "لو بلغارستان",
+            "fi": "Bulgarian leva",
+            "fr": "lev bulgare",
+            "gl": "Lev búlgaro",
+            "he": "לב",
+            "hr": "Bugarski lev",
+            "hu": "bolgár leva",
+            "it": "lev bulgaro",
+            "ja": "レフ",
+            "lt": "Bulgarijos levas",
+            "nl": "Bulgaarse lev",
+            "oc": "Lev",
+            "pl": "Lew",
+            "pt": "lev búlgaro",
+            "ro": "Leva",
+            "ru": "болгарский лев",
+            "sk": "Bulharský lev",
+            "sl": "Bolgarski lev",
+            "sr": "бугарски лев",
+            "sv": "Lev",
+            "ta": "பல்கேரிய லெவ்",
+            "tr": "Lev",
+            "uk": "болгарський лев",
+            "vi": "Lev Bulgaria",
+            "zh": "保加利亞列弗",
+            "ia": "lev bulgare"
+        },
         "BHD": {
-            "fr": "Dinar bahre\u00efnien", 
-            "en": "Bahraini dinar", 
-            "nl": "Bahreinse dinar", 
-            "de": "Bahrain-Dinar", 
-            "it": "Dinaro del Bahrain", 
-            "hu": "bahreini din\u00e1r", 
-            "es": "Dinar barein\u00ed"
-        }, 
+            "ar": "دينار بحريني",
+            "bg": "Бахрейнски динар",
+            "ca": "dinar de Bahrain",
+            "cs": "Bahrajnský dinár",
+            "de": "Bahrain-Dinar",
+            "el": "Δηνάριο Μπαχρέιν",
+            "en": "Bahraini dinar",
+            "eo": "barejna dinaro",
+            "es": "dinar bareiní",
+            "fa": "دینار بحرین",
+            "fi": "Bahrainin dinaari",
+            "fr": "dinar bahreïnien",
+            "he": "דינר בחרייני",
+            "hr": "Bahreinski dinar",
+            "hu": "bahreini dinár",
+            "it": "dinaro del Bahrain",
+            "ja": "バーレーン・ディナール",
+            "lt": "Bahreino dinaras",
+            "nl": "Bahreinse dinar",
+            "pl": "Dinar Bahrajnu",
+            "pt": "dinar bareinita",
+            "ru": "бахрейнский динар",
+            "sr": "бахреински динар",
+            "sv": "Bahrainsk dinar",
+            "tr": "Bahreyn dinarı",
+            "uk": "Бахрейнський динар",
+            "zh": "巴林第納爾",
+            "oc": "Dinar de Bahrayn",
+            "ta": "பஹ்ரேன் தினார்"
+        },
+        "BIF": {
+            "ar": "فرنك بوروندي",
+            "bg": "Бурундийски франк",
+            "ca": "franc de Burundi",
+            "cs": "Burundský frank",
+            "de": "Burundi-Franc",
+            "el": "Φράγκο Μπουρούντι",
+            "en": "Burundian franc",
+            "eo": "burunda franko",
+            "es": "franco burundés",
+            "fa": "فرانک بوروندی",
+            "fi": "Burundin frangi",
+            "fr": "Franc burundais",
+            "hr": "Burundski franak",
+            "hu": "Burundi frank",
+            "it": "Franco del Burundi",
+            "ja": "ブルンジ・フラン",
+            "lt": "Burundžio frankas",
+            "nl": "Burundese frank",
+            "pl": "frank burundyjski",
+            "pt": "Franco do Burúndi",
+            "ru": "бурундийский франк",
+            "sr": "бурундски франак",
+            "sv": "Burundisk franc",
+            "ta": "புரூண்டி பிராங்க்",
+            "tr": "Burundi frangı",
+            "uk": "Бурундійський франк",
+            "zh": "蒲隆地法郎",
+            "he": "פרנק בורונדי",
+            "ro": "franc burundez"
+        },
+        "BMD": {
+            "ar": "دولار برمودي",
+            "ca": "dòlar de les Bermudes",
+            "cs": "Bermudský dolar",
+            "de": "Bermuda-Dollar",
+            "el": "Δολάριο Βερμούδων",
+            "en": "Bermudian dollar",
+            "eo": "bermuda dolaro",
+            "es": "Dólar bermudeño",
+            "eu": "Dolar bermudar",
+            "fa": "دلار برمودا",
+            "fi": "Bermudan dollari",
+            "fr": "Dollar bermudien",
+            "hr": "Bermudski dolar",
+            "hu": "bermudai dollár",
+            "it": "Dollaro di Bermuda",
+            "ja": "バミューダ・ドル",
+            "lt": "Bermudos doleris",
+            "nl": "Bermuda-dollar",
+            "pl": "Dolar bermudzki",
+            "pt": "Dólar bermudense",
+            "ru": "бермудский доллар",
+            "sr": "бермудски долар",
+            "sv": "Bermudisk dollar",
+            "tr": "Bermuda doları",
+            "uk": "Бермудський долар",
+            "vi": "Đô la Bermuda",
+            "zh": "百慕達元",
+            "he": "דולר ברמודה ",
+            "ta": "பெர்முடா டாலர்"
+        },
+        "BND": {
+            "ar": "دولار بروني",
+            "bg": "Брунейски долар",
+            "ca": "dòlar de Brunei",
+            "cs": "Brunejský dolar",
+            "de": "Brunei-Dollar",
+            "en": "Brunei dollar",
+            "eo": "bruneja dolaro",
+            "es": "dólar de Brunéi",
+            "eu": "Dolar bruneitar",
+            "fa": "دلار برونئی",
+            "fi": "Brunein dollari",
+            "fr": "dollar de Brunei",
+            "gl": "Dólar de Brunei",
+            "he": "דולר ברוניי",
+            "hr": "Brunejski dolar",
+            "hu": "brunei dollár",
+            "it": "dollaro del Brunei",
+            "ja": "ブルネイ・ドル",
+            "lt": "Brunėjaus doleris",
+            "nl": "Bruneise dollar",
+            "pl": "Dolar Brunei",
+            "pt": "Dólar de Brunei",
+            "ru": "брунейский доллар",
+            "sr": "брунејски долар",
+            "sv": "Bruneisk dollar",
+            "ta": "புருனே டாலர்",
+            "tr": "Brunei doları",
+            "uk": "Брунейський долар",
+            "vi": "Đô la Brunei",
+            "zh": "汶萊元",
+            "el": "δολάριο Μπρουνέι"
+        },
+        "BOB": {
+            "ar": "بوليفاريو بوليفي",
+            "ca": "boliviano",
+            "cs": "Bolivijský boliviano",
+            "da": "Boliviano",
+            "de": "Boliviano",
+            "el": "Μπολιβιάνο",
+            "en": "boliviano",
+            "eo": "bolivia bolivjano",
+            "es": "boliviano",
+            "eu": "Bigarren boliviano",
+            "fa": "بولیویانو بولیوی",
+            "fi": "Bolivian boliviano",
+            "fr": "boliviano",
+            "gl": "Boliviano",
+            "he": "בוליביאנו",
+            "hr": "Bolivijski bolivijano",
+            "hu": "bolíviai boliviano",
+            "it": "boliviano",
+            "ja": "ボリビアーノ",
+            "lt": "Bolivianas",
+            "nl": "Boliviaanse boliviano",
+            "oc": "Boliviano",
+            "pl": "boliviano",
+            "pt": "Boliviano",
+            "ru": "боливиано",
+            "sr": "боливијски боливијано",
+            "sv": "Boliviano",
+            "tr": "Boliviano",
+            "uk": "Болівіано",
+            "zh": "玻利維亞諾",
+            "ta": "பொலிவியானோ"
+        },
+        "BOV": {
+            "es": "Boliviano con mantenimiento de valor respecto al dólar estadounidense"
+        },
+        "BRL": {
+            "ar": "ريال برازيلي",
+            "bg": "Бразилски реал",
+            "ca": "real",
+            "cs": "Brazilský real",
+            "da": "Brasiliansk real",
+            "de": "brasilianischer Real",
+            "el": "Ρεάλ Βραζιλίας",
+            "en": "Brazilian real",
+            "eo": "brazila realo",
+            "es": "real brasileño",
+            "eu": "Brasildar real",
+            "fa": "رئال",
+            "fi": "Brasilian real",
+            "fr": "réal brésilien",
+            "gl": "Real brasileiro",
+            "he": "ריאל ברזילאי",
+            "hr": "Brazilski real",
+            "hu": "brazil real",
+            "it": "real brasiliano",
+            "ja": "レアル",
+            "lt": "Brazilijos realas",
+            "nl": "Braziliaanse real",
+            "pl": "Real brazylijski",
+            "pt": "real",
+            "ro": "Real",
+            "ru": "бразильский реал",
+            "sr": "бразилски реал",
+            "sv": "Real",
+            "ta": "பிரசிலியன் ரியால்",
+            "tr": "Brezilya reali",
+            "uk": "бразильський реал",
+            "vi": "Real Brasil",
+            "zh": "巴西雷亞爾",
+            "oc": "Real"
+        },
+        "BSD": {
+            "ar": "دولار بهامي",
+            "bg": "Бахамски долар",
+            "ca": "dòlar de les Bahames",
+            "cs": "Bahamský dolar",
+            "de": "Bahama-Dollar",
+            "en": "Bahamian dollar",
+            "eo": "bahama dolaro",
+            "es": "dólar bahameño",
+            "eu": "Dolar bahamar",
+            "fa": "دلار باهاما",
+            "fi": "Bahaman dollari",
+            "fr": "dollar bahaméen",
+            "gl": "Dólar bahamés",
+            "hr": "Bahamski dolar",
+            "hu": "bahamai dollár",
+            "it": "dollaro delle Bahamas",
+            "ja": "バハマ・ドル",
+            "lt": "Bahamų doleris",
+            "nl": "Bahamaanse dollar",
+            "pl": "Dolar bahamski",
+            "pt": "dólar baamiano",
+            "ru": "багамский доллар",
+            "sk": "Bahamský dolár",
+            "sr": "бахамски долар",
+            "sv": "Bahamansk dollar",
+            "tr": "Bahama doları",
+            "uk": "Багамський долар",
+            "vi": "Đô la Bahamas",
+            "zh": "巴哈馬元",
+            "oc": "Dolar de las Bahamas",
+            "ta": "பஹ்மானிய டாலர்"
+        },
+        "BTN": {
+            "ar": "نغولترم بوتاني",
+            "bg": "Бутански нгултрум",
+            "ca": "Ngultrum",
+            "cs": "Bhútánský ngultrum",
+            "da": "Ngultrum",
+            "de": "Ngultrum",
+            "el": "Νγκούλτρουμ",
+            "en": "ngultrum",
+            "eo": "butana ngultrumo",
+            "es": "ngultrum butanés",
+            "et": "Bhutani ngultrum",
+            "eu": "Ngultrum",
+            "fa": "نگولتروم بوتان",
+            "fi": "Bhutanin ngultrum",
+            "fr": "ngultrum",
+            "gl": "Ngultrum",
+            "hr": "Butanski ngultrum",
+            "hu": "bhutáni ngultrum",
+            "it": "Ngultrum del Bhutan",
+            "ja": "ニュルタム",
+            "lt": "Ngultrumas",
+            "nl": "Bhutaanse ngultrum",
+            "pl": "Ngultrum",
+            "pt": "ngultrum",
+            "ro": "Ngultrum",
+            "ru": "нгултрум",
+            "sk": "Ngultrum",
+            "sr": "бутански нгултрум",
+            "sv": "Ngultrum",
+            "ta": "பூட்டானின் இங்குல்ட்ரம்",
+            "tr": "Ngultrum",
+            "uk": "Нгултрум",
+            "vi": "Ngultrum Bhutan",
+            "zh": "不丹努尔特鲁姆",
+            "he": "נגולטורם",
+            "oc": "Ngultrum"
+        },
+        "BWP": {
+            "ar": "بوتسوانا بولا",
+            "bg": "Ботсванска пула",
+            "ca": "pula",
+            "cs": "Botswanská pula",
+            "da": "Pula",
+            "de": "botswanischer Pula",
+            "el": "Πούλα",
+            "en": "Botswana pula",
+            "eo": "bocvana pulao",
+            "es": "pula",
+            "et": "Botswana pula",
+            "eu": "Pula",
+            "fa": "پولای بوتسوانا",
+            "fi": "Pula",
+            "fr": "pula",
+            "gl": "Pula",
+            "he": "פולה",
+            "hr": "Bocvanska pula",
+            "hu": "Botswanai pula",
+            "it": "pula del Botswana",
+            "ja": "プラ",
+            "lt": "Botsvanos pula",
+            "nl": "Botswaanse pula",
+            "pl": "Pula",
+            "pt": "pula",
+            "ro": "Pula botswaniană",
+            "ru": "Ботсванская пула",
+            "sr": "боцванска пула",
+            "sv": "Pula",
+            "tr": "Botsvana pulası",
+            "uk": "Ботсванська пула",
+            "zh": "波札那普拉",
+            "oc": "Pula",
+            "ta": "போட்ஸ்வானா பூலா"
+        },
+        "BYN": {
+            "ar": "روبل بلاروسي",
+            "bg": "Беларуска рубла",
+            "ca": "ruble bielorús",
+            "cs": "Běloruský rubl",
+            "da": "Hviderussiske rubler",
+            "de": "weißrussischer Rubel",
+            "el": "Λευκορωσικό ρούβλι",
+            "en": "Belarusian ruble",
+            "eo": "Belorusia rublo",
+            "es": "rublo bielorruso",
+            "et": "Valgevene rubla",
+            "fa": "روبل بلاروس",
+            "fi": "Valko-Venäjän rupla",
+            "fr": "rouble biélorusse",
+            "gl": "Rublo belaruso",
+            "he": "רובל בלארוסי",
+            "hr": "Bjeloruska rublja",
+            "hu": "belarusz rubel",
+            "it": "rublo bielorusso",
+            "ja": "ベラルーシ・ルーブル",
+            "lt": "Baltarusijos rublis",
+            "nl": "Wit-Russische roebel",
+            "pl": "rubel białoruski",
+            "pt": "rublo bielorrusso",
+            "ro": "Rublă belarusă",
+            "ru": "белорусский рубль",
+            "sk": "Bieloruský rubeľ",
+            "sl": "beloruski rubelj",
+            "sr": "белоруска рубља",
+            "sv": "Belarusisk rubel",
+            "ta": "பெலருசிய ரூபிள்",
+            "tr": "Beyaz Rusya rublesi",
+            "uk": "білоруський рубль",
+            "vi": "Rúp Belarus",
+            "zh": "白俄羅斯盧布",
+            "ia": "rublo bielorusse",
+            "oc": "Robla bielorussa"
+        },
+        "BZD": {
+            "ar": "دولار بليزي",
+            "bg": "Белизийски долар",
+            "ca": "dòlar de Belize",
+            "cs": "Belizský dolar",
+            "de": "Belize-Dollar",
+            "el": "Δολάριο Μπελίζε",
+            "en": "Belize dollar",
+            "eo": "beliza dolaro",
+            "es": "Dólar beliceño",
+            "eu": "Dolar belizetar",
+            "fa": "دلار بلیز",
+            "fi": "Belizen dollari",
+            "fr": "dollar bélizien",
+            "gl": "Dólar de Belize",
+            "he": "דולר בליזאי",
+            "hr": "Belizejski dolar",
+            "hu": "Belize-i dollár",
+            "it": "Dollaro del Belize",
+            "ja": "ベリーズ・ドル",
+            "lt": "Belizo doleris",
+            "nl": "Belizaanse dollar",
+            "pl": "Dolar Belize",
+            "pt": "Dólar de Belize",
+            "ru": "белизский доллар",
+            "sr": "белизејски долар",
+            "sv": "Belizisk dollar",
+            "tr": "Belize doları",
+            "uk": "Белізський долар",
+            "vi": "Đô la Belize",
+            "zh": "貝里斯元",
+            "cy": "Doler (Belîs)",
+            "ta": "பெலலீசு டாலர்"
+        },
+        "CAD": {
+            "ar": "دولار كندي",
+            "bg": "Канадски долар",
+            "ca": "dòlar canadenc",
+            "cs": "Kanadský dolar",
+            "da": "Canadiske dollar",
+            "de": "kanadischer Dollar",
+            "el": "Καναδικό δολάριο",
+            "en": "Canadian dollar",
+            "eo": "kanada dolaro",
+            "es": "dólar canadiense",
+            "et": "Kanada dollar",
+            "eu": "Kanadar dolar",
+            "fa": "دلار کانادا",
+            "fi": "Kanadan dollari",
+            "fr": "dollar canadien",
+            "gl": "Dólar canadense",
+            "he": "דולר קנדי",
+            "hr": "Kanadski dolar",
+            "hu": "kanadai dollár",
+            "ia": "Dollar canadian",
+            "it": "dollaro canadese",
+            "ja": "カナダドル",
+            "lt": "Kanados doleris",
+            "nl": "Canadese dollar",
+            "pl": "Dolar kanadyjski",
+            "pt": "dólar canadense",
+            "ro": "dolar canadian",
+            "ru": "канадский доллар",
+            "sk": "Kanadský dolár",
+            "sl": "Kanadski dolar",
+            "sr": "канадски долар",
+            "sv": "kanadensisk dollar",
+            "ta": "கனடா டொலர்",
+            "tr": "Kanada doları",
+            "uk": "канадський долар",
+            "vi": "Đô la Canada",
+            "zh": "加拿大元",
+            "cy": "doler",
+            "oc": "Dolar canadian"
+        },
+        "CDF": {
+            "ar": "فرنك كونغولي",
+            "bg": "Конгоански франк",
+            "ca": "franc congolès",
+            "cs": "Konžský frank",
+            "de": "Kongo-Franc",
+            "en": "Congolese franc",
+            "eo": "konga franko",
+            "es": "franco congoleño",
+            "fa": "فرانک کنگو",
+            "fi": "Kongon frangi",
+            "fr": "franc congolais",
+            "gl": "Franco congolés",
+            "he": "פרנק קונגולזי",
+            "hr": "Kongoanski franak",
+            "hu": "Kongói frank",
+            "it": "franco congolese",
+            "ja": "コンゴ・フラン",
+            "lt": "Kongo frankas",
+            "nl": "Congolese frank",
+            "pl": "frank kongijski",
+            "pt": "franco congolês",
+            "ru": "конголезский франк",
+            "sk": "Konžský frank",
+            "sr": "конгоански франак",
+            "sv": "Kongolesisk franc",
+            "tr": "Kongo frangı",
+            "uk": "Конголезький франк",
+            "vi": "Franc Congo",
+            "zh": "剛果法郎",
+            "cy": "ffranc y Congo",
+            "oc": "Franc congolés"
+        },
+        "CHF": {
+            "ar": "فرنك سويسري",
+            "bg": "Швейцарски франк",
+            "ca": "franc suís",
+            "cs": "švýcarský frank",
+            "da": "Schweizisk franc",
+            "de": "Schweizer Franken",
+            "el": "Ελβετικό φράγκο",
+            "en": "Swiss franc",
+            "eo": "svisa franko",
+            "es": "franco suizo",
+            "et": "Šveitsi frank",
+            "eu": "Suitzar libera",
+            "fa": "فرانک سوئیس",
+            "fi": "Sveitsin frangi",
+            "fr": "Franc suisse",
+            "gl": "Franco suízo",
+            "he": "פרנק שווייצרי",
+            "hr": "Švicarski franak",
+            "hu": "svájci frank",
+            "it": "franco svizzero",
+            "ja": "スイス・フラン",
+            "lt": "Šveicarijos frankas",
+            "nl": "Zwitserse frank",
+            "oc": "Franc soís",
+            "pl": "frank szwajcarski",
+            "pt": "Franco suíço",
+            "ro": "Franc elvețian",
+            "ru": "швейцарский франк",
+            "sk": "Švajčiarsky frank",
+            "sl": "Švicarski frank",
+            "sr": "швајцарски франак",
+            "sv": "schweizisk franc",
+            "ta": "சுவிசு பிராங்க்",
+            "te": "స్విస్ ఫ్రాంక్",
+            "tr": "İsviçre frangı",
+            "uk": "швейцарський франк",
+            "vi": "Franc Thụy Sĩ",
+            "zh": "瑞士法郎",
+            "cy": "franc Swisaidd",
+            "ia": "franc switze"
+        },
+        "CKD": {
+            "ar": "دولار جزر كوك",
+            "ca": "dòlar de les illes Cook",
+            "cs": "Dolar Cookových ostrovů",
+            "de": "Cookinsel-Dollar",
+            "el": "Δολάριο Νήσων Κουκ",
+            "en": "Cook Islands dollar",
+            "eo": "Kukinsula dolaro",
+            "es": "dólar de las Islas Cook",
+            "fa": "دلار جزایر کوک",
+            "fi": "Cookinsaarten dollari",
+            "fr": "Dollar des îles Cook",
+            "gl": "Dólar das Illas Cook",
+            "hr": "Kukovootočki dolar",
+            "hu": "Cook-szigeteki dollár",
+            "it": "Dollaro delle Cook",
+            "lt": "Kuko Salų doleris",
+            "nl": "Cookeilandendollar",
+            "pl": "Dolar Wysp Cooka",
+            "pt": "Dólar das Ilhas Cook",
+            "ro": "Dolar din Insulele Cook",
+            "ru": "доллар Островов Кука",
+            "sv": "Cook Islands dollar",
+            "uk": "Долар Островів Кука",
+            "vi": "Đô la Quần đảo Cook",
+            "zh": "庫克群島元",
+            "ja": "クック諸島ドル"
+        },
+        "CLF": {
+            "de": "Unidad de Fomento",
+            "en": "Unidad de Fomento",
+            "es": "Unidad de Fomento",
+            "fr": "Unidad de Fomento",
+            "pl": "Unidad de Fomento",
+            "zh": "UF值",
+            "ja": "ウニダ・デ・フォメント"
+        },
+        "CLP": {
+            "ar": "بيزو تشيلي",
+            "bg": "Чилийско песо",
+            "ca": "peso xilè",
+            "cs": "Chilské peso",
+            "cy": "Peso Chile",
+            "de": "chilenischer Peso",
+            "el": "Πέσο Χιλής",
+            "en": "Chilean peso",
+            "eo": "ĉilia peso",
+            "es": "peso chileno",
+            "et": "Tšiili peeso",
+            "eu": "Peso txiletar",
+            "fa": "پسو شیلی",
+            "fi": "Chilen peso",
+            "fr": "peso chilien",
+            "gl": "Peso chileno",
+            "he": "פסו צ'יליאני",
+            "hr": "Čileanski pezo",
+            "hu": "chilei peso",
+            "it": "peso cileno",
+            "ja": "チリ・ペソ",
+            "lt": "Čilės pesas",
+            "nl": "Chileense peso",
+            "oc": "Peso de Chile",
+            "pl": "Peso chilijskie",
+            "pt": "peso chileno",
+            "ru": "чилийское песо",
+            "sl": "Čilenski peso",
+            "sr": "чилеански пезос",
+            "sv": "Chilensk peso",
+            "tr": "Şili pesosu",
+            "uk": "Чилійський песо",
+            "vi": "Peso Chile",
+            "zh": "智利比索"
+        },
+        "CNY": {
+            "ar": "رنمينبي",
+            "bg": "Китайски юан",
+            "bo": "མི་དམངས་ཤོག་དངུལ",
+            "ca": "renminbi",
+            "cs": "Čínský jüan",
+            "cy": "Renminbi",
+            "da": "Renminbi",
+            "de": "Renminbi",
+            "el": "Ρενμίνμπι",
+            "en": "renminbi",
+            "eo": "Renminbio",
+            "es": "yuan chino",
+            "et": "Renminbi",
+            "eu": "Renminbi",
+            "fa": "رنمینبی",
+            "fi": "Renminbi",
+            "fr": "Renminbi",
+            "gl": "Renminbi",
+            "he": "רנמינבי",
+            "hr": "Renminbi",
+            "hu": "renminbi",
+            "it": "renminbi cinese",
+            "ja": "人民幣",
+            "lt": "Juanis",
+            "nl": "Chinese renminbi",
+            "oc": "Renminbi",
+            "pl": "Renminbi",
+            "pt": "yuan",
+            "ro": "Yuan renminbi",
+            "ru": "китайский юань",
+            "sk": "Čínsky jüan",
+            "sl": "Renminbi",
+            "sr": "ренминби",
+            "sv": "Renminbi",
+            "ta": "ரென்மின்பி",
+            "tr": "Renminbi",
+            "uk": "юань",
+            "vi": "nhân dân tệ",
+            "zh": "人民币"
+        },
+        "COP": {
+            "ar": "بيزو كولومبي",
+            "bg": "Колумбийско песо",
+            "ca": "peso colombià",
+            "cs": "Kolumbijské peso",
+            "da": "Colombiansk peso",
+            "de": "kolumbianischer Peso",
+            "el": "Πέσο Κολομβίας",
+            "en": "Colombian peso",
+            "eo": "kolombia peso",
+            "es": "peso colombiano",
+            "et": "Colombia peeso",
+            "eu": "Peso kolonbiar",
+            "fa": "پزوی کلمبیا",
+            "fi": "Kolumbian peso",
+            "fr": "peso colombien",
+            "gl": "Peso colombiano",
+            "he": "פסו קולומביאני",
+            "hr": "Kolumbijski pezo",
+            "hu": "Kolumbiai peso",
+            "it": "peso colombiano",
+            "ja": "コロンビア・ペソ",
+            "lt": "Kolumbijos pesas",
+            "nl": "Colombiaanse peso",
+            "pl": "Peso kolumbijskie",
+            "pt": "peso colombiano",
+            "ru": "колумбийское песо",
+            "sr": "колумбијски пезос",
+            "sv": "Colombiansk peso",
+            "tr": "Kolombiya pesosu",
+            "uk": "Колумбійський песо",
+            "vi": "Peso Colombia",
+            "zh": "哥伦比亚比索",
+            "oc": "Peso colombian"
+        },
+        "CRC": {
+            "ar": "كولون كوستاريكي",
+            "bg": "Костарикански колон",
+            "ca": "colon costa-riqueny",
+            "cs": "Kostarický colón",
+            "de": "Costa-Rica-Colón",
+            "en": "Costa Rican colón",
+            "eo": "kostarika kolumbo",
+            "es": "colón costarricense",
+            "eu": "Colón costarricar",
+            "fa": "کولون کاستاریکا",
+            "fi": "Costa Rican colón",
+            "fr": "colón",
+            "gl": "colón costarriqueño",
+            "hr": "Kostarikanski kolon",
+            "hu": "Costa Rica-i colón",
+            "it": "Colón costaricano",
+            "ja": "コスタリカ・コロン",
+            "lt": "Kosta Rikos kolonas",
+            "nl": "Costa Ricaanse colon",
+            "pl": "Colon kostarykański",
+            "pt": "Colón costa-riquenho",
+            "ru": "костариканский колон",
+            "sr": "костарикански колон",
+            "sv": "Costaricansk colón",
+            "tr": "Kosta Rika colónu",
+            "uk": "Костариканський колон",
+            "zh": "哥斯大黎加科朗"
+        },
+        "CUP": {
+            "ar": "بيزو كوبي",
+            "bg": "Кубинско песо",
+            "ca": "peso cubà",
+            "cs": "Kubánské peso",
+            "da": "Cubanske pesos",
+            "de": "kubanischer Peso",
+            "el": "Πέσο Κούβας",
+            "en": "Cuban peso",
+            "eo": "kuba peso",
+            "es": "peso cubano",
+            "fa": "پزوی کوبا",
+            "fi": "Kuuban peso",
+            "fr": "peso cubain",
+            "hr": "Kubanski pezo",
+            "hu": "kubai peso",
+            "it": "peso cubano",
+            "ja": "キューバ・ペソ",
+            "lt": "Kubos pesas",
+            "nl": "Cubaanse peso",
+            "pl": "Peso kubańskie",
+            "pt": "peso cubano",
+            "ro": "Peso cubanez",
+            "ru": "кубинское песо",
+            "sr": "кубански пезос",
+            "sv": "Kubansk peso",
+            "tr": "Küba pesosu",
+            "uk": "Кубинський песо",
+            "vi": "Peso Cuba",
+            "zh": "古巴比索",
+            "cy": "peso (Ciwba)",
+            "he": "פסו קובני"
+        },
+        "CVE": {
+            "ar": "إيسكودو جزر الرأس الأخضر",
+            "bg": "Ескудо на Кабо Верде",
+            "ca": "escut de Cap Verd",
+            "cs": "Kapverdské escudo",
+            "da": "Kapverdisk escudo",
+            "de": "Kap-Verde-Escudo",
+            "el": "Εσκούδο του Πράσινου Ακρωτηρίου",
+            "en": "Cape Verdean escudo",
+            "eo": "kaboverda eskudo",
+            "es": "escudo caboverdiano",
+            "fa": "اسکودوی کیپ ورد",
+            "fi": "Kap Verden escudo",
+            "fr": "escudo cap-verdien",
+            "hr": "Zelenortski eskudo",
+            "hu": "Zöld-foki köztársasági escudo",
+            "it": "escudo capoverdiano",
+            "ja": "カーボベルデ・エスクード",
+            "lt": "Žaliojo Kyšulio eskudas",
+            "nl": "Kaapverdische escudo",
+            "pl": "escudo Zielonego Przylądka",
+            "pt": "escudo cabo-verdiano",
+            "ru": "Эскудо Кабо-Верде",
+            "sr": "зеленортски ескудо",
+            "sv": "Kapverdisk escudo",
+            "tr": "Yeşil Burun Adaları eskudosu",
+            "uk": "Ескудо Кабо-Верде",
+            "vi": "Escudo Cabo Verde",
+            "zh": "維德角埃斯庫多",
+            "he": "אשקודו כף ורדי",
+            "oc": "Escut de Cap Verd"
+        },
+        "CZK": {
+            "ar": "كرونة تشيكية",
+            "bg": "крони",
+            "ca": "corona txeca",
+            "cs": "koruna česká",
+            "da": "Tjekkiske koruna",
+            "de": "tschechische Krone",
+            "el": "Κορόνα Τσεχίας",
+            "en": "Czech koruna",
+            "eo": "ĉeĥa krono",
+            "es": "corona checa",
+            "et": "Tšehhi kroon",
+            "eu": "Txekiar koroa",
+            "fa": "کرونا چک",
+            "fi": "Tšekin koruna",
+            "fr": "couronne tchèque",
+            "gl": "Coroa checa",
+            "he": "קורונה צ'כית",
+            "hr": "Češka kruna",
+            "hu": "cseh korona",
+            "it": "corona ceca",
+            "ja": "チェコ・コルナ",
+            "lt": "Čekijos krona",
+            "nl": "Tsjechische kroon",
+            "oc": "corona chèca",
+            "pl": "Korona czeska",
+            "pt": "coroa checa",
+            "ro": "Coroană cehă",
+            "ru": "чешская крона",
+            "sk": "Česká koruna",
+            "sl": "Češka krona",
+            "sr": "чешка круна",
+            "sv": "tjeckisk krona",
+            "ta": "செக் கொருனா",
+            "tr": "Çek korunası",
+            "uk": "чеська крона",
+            "vi": "Koruna Séc",
+            "zh": "捷克克朗",
+            "cy": "Czech koruna",
+            "ia": "corona tchec"
+        },
+        "DJF": {
+            "ar": "فرنك جيبوتي",
+            "bg": "Джибутски франк",
+            "ca": "franc de Djibouti",
+            "cs": "Džibutský frank",
+            "da": "Djiboutiske franc",
+            "de": "Dschibuti-Franc",
+            "el": "Φράγκο του Τζιμπουτί",
+            "en": "Djiboutian franc",
+            "eo": "ĝibutia franko",
+            "es": "franco yibutiano",
+            "fa": "فرانک جیبوتی",
+            "fi": "Djiboutin frangi",
+            "fr": "franc Djibouti",
+            "hr": "Džibutski franak",
+            "hu": "Dzsibuti frank",
+            "it": "franco gibutiano",
+            "ja": "ジブチ・フラン",
+            "lt": "Džibučio frankas",
+            "nl": "Djiboutiaanse frank",
+            "pl": "frank Dżibuti",
+            "pt": "franco do Jibuti",
+            "ru": "Франк Джибути",
+            "sr": "џибутски франак",
+            "sv": "Djiboutisk franc",
+            "tr": "Cibuti frangı",
+            "uk": "Франк Джибуті",
+            "zh": "吉布地法郎",
+            "he": "פרנק ג'יבוטי"
+        },
+        "DKK": {
+            "ar": "كرونة دنماركية",
+            "bg": "Датска крона",
+            "ca": "corona danesa",
+            "cs": "Dánská koruna",
+            "da": "danske kroner",
+            "de": "dänische Krone",
+            "el": "Κορόνα Δανίας",
+            "en": "Danish krone",
+            "eo": "dana krono",
+            "es": "corona danesa",
+            "et": "Taani kroon",
+            "eu": "Daniar koroa",
+            "fa": "کرون دانمارک",
+            "fi": "Tanskan kruunu",
+            "fr": "couronne danoise",
+            "gl": "Coroa dinamarquesa",
+            "he": "כתר דני",
+            "hr": "Danska kruna",
+            "hu": "dán korona",
+            "it": "corona danese",
+            "ja": "デンマーク・クローネ",
+            "lt": "Danijos krona",
+            "nl": "Deense kroon",
+            "oc": "Corona danesa",
+            "pl": "korona duńska",
+            "pt": "coroa dinamarquesa",
+            "ro": "Coroană daneză",
+            "ru": "датская крона",
+            "sk": "Dánska koruna",
+            "sr": "данска круна",
+            "sv": "dansk krona",
+            "ta": "டானிய குரோன்",
+            "tr": "Danimarka kronu",
+            "uk": "данська крона",
+            "vi": "Krone Đan Mạch",
+            "zh": "丹麥克朗",
+            "cy": "Krone Danaidd",
+            "ia": "corona danese"
+        },
+        "DOP": {
+            "ar": "بيزو دومنيكاني",
+            "bg": "Доминиканско песо",
+            "ca": "peso dominicà",
+            "cs": "Dominikánské peso",
+            "de": "dominikanischer Peso",
+            "el": "Πέσο Δομινικανής Δημοκρατίας",
+            "en": "Dominican peso",
+            "eo": "dominga peso",
+            "es": "peso dominicano",
+            "eu": "Peso dominikar",
+            "fa": "پزو دومینیکن",
+            "fi": "Dominikaanisen tasavallan peso",
+            "fr": "peso dominicain",
+            "hr": "Dominikanski pezo",
+            "hu": "Dominikai peso",
+            "it": "peso dominicano",
+            "ja": "ドミニカ・ペソ",
+            "lt": "Dominikos pesas",
+            "nl": "Dominicaanse peso",
+            "pl": "Peso dominikańskie",
+            "pt": "peso dominicano",
+            "ru": "доминиканское песо",
+            "sr": "доминикански пезос",
+            "sv": "Dominikansk peso",
+            "tr": "Dominik pesosu",
+            "uk": "Домініканський песо",
+            "zh": "多明尼加比索",
+            "ro": "peso dominican"
+        },
+        "DZD": {
+            "ar": "دينار جزائري",
+            "bg": "Алжирски динар",
+            "ca": "dinar algerià",
+            "cs": "Alžírský dinár",
+            "cy": "Dinar Algeriaidd",
+            "de": "algerischer Dinar",
+            "el": "Δηνάριο Αλγερίας",
+            "en": "Algerian dinar",
+            "eo": "alĝeria dinaro",
+            "es": "dinar argelino",
+            "eu": "Aljeriar dinar",
+            "fa": "دینار الجزایر",
+            "fi": "Algerian dinaari",
+            "fr": "dinar algérien",
+            "gl": "Dinar alxeriano",
+            "he": "דינר אלג'ירי",
+            "hr": "Alžirski dinar",
+            "hu": "algériai dinár",
+            "it": "dinaro algerino",
+            "ja": "アルジェリア・ディナール",
+            "lt": "Alžyro dinaras",
+            "nl": "Algerijnse dinar",
+            "pl": "dinar algierski",
+            "pt": "dinar argelino",
+            "ro": "Dinar algerian",
+            "ru": "алжирский динар",
+            "sr": "алжирски динар",
+            "sv": "Algerisk dinar",
+            "tr": "Cezayir dinarı",
+            "uk": "Алжирський динар",
+            "vi": "Dinar Algérie",
+            "zh": "阿爾及利亞第納爾",
+            "ta": "அல்ஜீரிய தினார்"
+        },
+        "EGP": {
+            "ar": "جنيه مصري",
+            "bg": "Египетска лира",
+            "ca": "lliura egípcia",
+            "cs": "Egyptská libra",
+            "de": "ägyptisches Pfund",
+            "el": "Λίρα Αιγύπτου",
+            "en": "Egyptian pound",
+            "eo": "egipta pundo",
+            "es": "libra egipcia",
+            "et": "Egiptuse nael",
+            "eu": "Egiptoar libera",
+            "fa": "پوند مصر",
+            "fi": "Egyptin punta",
+            "fr": "livre égyptienne",
+            "gl": "Libra exipcia",
+            "he": "לירה מצרית",
+            "hr": "Egipatska funta",
+            "hu": "egyiptomi font",
+            "it": "sterlina egiziana",
+            "ja": "エジプト・ポンド",
+            "lt": "Egipto svaras",
+            "nl": "Egyptisch pond",
+            "pl": "Funt egipski",
+            "pt": "libra egípcia",
+            "ro": "Liră egipteană",
+            "ru": "египетский фунт",
+            "sr": "египатска фунта",
+            "sv": "Egyptiskt pund",
+            "tr": "Mısır lirası",
+            "uk": "Єгипетський фунт",
+            "vi": "Bảng Ai Cập",
+            "zh": "埃及鎊",
+            "oc": "Liura egipciana",
+            "sk": "Egyptská libra"
+        },
+        "ERN": {
+            "ar": "ناكفا",
+            "ca": "nakfa",
+            "cs": "Eritrejská nakfa",
+            "da": "Nakfa",
+            "de": "eritreischer Nakfa",
+            "el": "Νάκφα",
+            "en": "nakfa",
+            "eo": "eritrea nakfo",
+            "es": "nakfa",
+            "fa": "ناکفای اریتره",
+            "fi": "Eritrean nakfa",
+            "fr": "nakfa érythréen",
+            "gl": "Nakfa",
+            "he": "נאקפה",
+            "hr": "Eritrejska nakfa",
+            "hu": "Eritreai nakfa",
+            "it": "nacfa eritreo",
+            "ja": "ナクファ",
+            "lt": "Nakfa",
+            "nl": "Eritrese nakfa",
+            "pl": "Nakfa",
+            "pt": "nakfa",
+            "ru": "эритрейская накфа",
+            "sr": "еритрејска накфа",
+            "sv": "Nakfa",
+            "tr": "Eritre nakfası",
+            "uk": "Еритрейська накфа",
+            "zh": "厄立特里亚纳克法"
+        },
+        "ETB": {
+            "ar": "بير إثيوبي",
+            "bg": "Етиопски бир",
+            "ca": "birr",
+            "cs": "Etiopský birr",
+            "da": "Etiopiske birr",
+            "de": "Äthiopischer Birr",
+            "el": "Μπιρ",
+            "en": "birr",
+            "eo": "etiopa birro",
+            "es": "Birr etíope",
+            "fa": "بیر اتیوپی",
+            "fi": "Etiopian birr",
+            "fr": "Birr",
+            "hr": "Etiopski bir",
+            "hu": "etióp birr",
+            "it": "birr etiope",
+            "ja": "ブル",
+            "lt": "Etiopijos biras",
+            "nl": "Ethiopische birr",
+            "pl": "Birr",
+            "pt": "Birr etíope",
+            "ru": "эфиопский быр",
+            "sr": "етиопски бир",
+            "sv": "Birr (valuta)",
+            "tr": "Birr",
+            "uk": "Ефіопський бир",
+            "zh": "衣索比亞比爾",
+            "he": "ביר אתיופי"
+        },
+        "ETH": {
+            "ar": "إيثريوم",
+            "bg": "Етериум",
+            "ca": "Ethereum",
+            "cs": "Ethereum",
+            "da": "Ethereum",
+            "de": "Ethereum",
+            "el": "Ethereum",
+            "en": "Ethereum",
+            "eo": "Ethereum",
+            "es": "Éter/Ether",
+            "et": "Ethereum",
+            "eu": "Ethereum",
+            "fa": "اتیریم",
+            "fi": "Ethereum",
+            "fr": "Ethereum",
+            "he": "אתריום",
+            "hr": "Ethereum",
+            "hu": "Ethereum",
+            "it": "Ethereum",
+            "ja": "イーサリアム",
+            "nl": "Ethereum",
+            "pl": "Ethereum",
+            "pt": "Ethereum",
+            "ro": "Ethereum",
+            "ru": "Ethereum",
+            "sk": "Ethereum",
+            "sv": "Ethereum",
+            "ta": "ஈத்தரீயம்",
+            "tr": "Ethereum",
+            "uk": "Ethereum",
+            "vi": "Ethereum",
+            "zh": "以太坊",
+            "lt": "Eteris",
+            "sr": "Етеријум"
+        },
+        "EUR": {
+            "ar": "يورو",
+            "bg": "Евро",
+            "ca": "euro",
+            "cs": "euro",
+            "cy": "Ewro",
+            "da": "Euro",
+            "de": "Euro",
+            "el": "ευρώ",
+            "en": "euro",
+            "eo": "eŭro",
+            "es": "euro",
+            "et": "Euro",
+            "eu": "Euro",
+            "fa": "یورو",
+            "fi": "euro",
+            "fr": "euro",
+            "gl": "euro",
+            "he": "אירו",
+            "hr": "Euro",
+            "hu": "euró",
+            "ia": "Euro",
+            "it": "Euro",
+            "ja": "ユーロ",
+            "lt": "Euras",
+            "nl": "euro",
+            "oc": "Èuro",
+            "pl": "euro",
+            "pt": "euro",
+            "ro": "euro",
+            "ru": "евро",
+            "sk": "Euro",
+            "sl": "Evro",
+            "sr": "евро",
+            "sv": "euro",
+            "ta": "ஐரோ",
+            "te": "యూరో",
+            "tr": "Euro",
+            "uk": "євро",
+            "vi": "Euro",
+            "zh": "欧元"
+        },
+        "FJD": {
+            "ar": "دولار فيجي",
+            "bg": "Фиджийски долар",
+            "ca": "dòlar fijià",
+            "cs": "Fidžijský dolar",
+            "de": "Fidschi-Dollar",
+            "el": "Δολάριο Φίτζι",
+            "en": "Fijian dollar",
+            "eo": "fiĝia dolaro",
+            "es": "dólar fiyiano",
+            "fa": "دلار فیجی",
+            "fi": "Fidžin dollari",
+            "fr": "dollar de Fidji",
+            "gl": "Dólar fidxiano",
+            "hr": "Fidžijski dolar",
+            "hu": "Fidzsi dollár",
+            "it": "dollaro delle Figi",
+            "ja": "フィジー・ドル",
+            "lt": "Fidžio doleris",
+            "nl": "Fiji-dollar",
+            "pl": "Dolar Fidżi",
+            "pt": "dólar de Fiji",
+            "ro": "Dolar fijian",
+            "ru": "доллар Фиджи",
+            "sk": "Fidžijský dolár",
+            "sr": "фиџијски долар",
+            "sv": "Fijidollar",
+            "ta": "பிஜி டாலர்",
+            "tr": "Fiji doları",
+            "uk": "долар Фіджі",
+            "zh": "斐濟元",
+            "da": "Fijiansk dollar",
+            "he": "דולר פיג'י"
+        },
+        "FKP": {
+            "ar": "جنيه جزر فوكلاند",
+            "ca": "lliura de les Malvines",
+            "cs": "Falklandská libra",
+            "de": "Falkland-Pfund",
+            "el": "Λίρα Φώκλαντ",
+            "en": "Falkland Islands pound",
+            "eo": "falklanda pundo",
+            "es": "libra malvinense",
+            "eu": "Libera falklandar",
+            "fa": "پوند جزایر فالکلند",
+            "fi": "Falklandin punta",
+            "fr": "livre des Îles Malouines",
+            "he": "לירה שטרלינג של איי פוקלנד",
+            "hr": "Falklandska funta",
+            "hu": "Falkland-szigeteki font",
+            "it": "sterlina delle Falkland",
+            "ja": "フォークランド諸島ポンド",
+            "lt": "Folklando svaras",
+            "nl": "Falklandeilands pond",
+            "pl": "Funt falklandzki",
+            "pt": "libra das Malvinas",
+            "ro": "Liră din Insulele Falkland",
+            "ru": "фунт Фолклендских островов",
+            "sv": "Falklandspund",
+            "tr": "Falkland Adaları poundu",
+            "uk": "Фолклендський фунт",
+            "zh": "福克蘭群島鎊"
+        },
+        "FOK": {
+            "ar": "كرونة فاروية",
+            "ca": "corona feroesa",
+            "cs": "Faerská koruna",
+            "da": "Færøske kroner",
+            "de": "färöische Krone",
+            "en": "Faroese króna",
+            "eo": "Feroa krono",
+            "es": "corona feroesa",
+            "et": "Fääri kroon",
+            "fa": "کرون فاروئی",
+            "fi": "Färsaarten kruunu",
+            "fr": "couronne féroïenne",
+            "gl": "Coroa feroesa",
+            "hr": "Føroyarska kruna",
+            "hu": "Feröeri korona",
+            "it": "corona delle Fær Øer",
+            "ja": "フェロー・クローネ",
+            "lt": "Farerų krona",
+            "nl": "Faeröerse kroon",
+            "pl": "Korona Wysp Owczych",
+            "pt": "coroa feroesa",
+            "ro": "Coroană feroeză",
+            "ru": "Фарерская крона",
+            "sk": "Faerská koruna",
+            "sr": "фарска круна",
+            "sv": "Färöisk krona",
+            "ta": "பரோயே குரோனா",
+            "tr": "Faroe kronu",
+            "uk": "Фарерська крона",
+            "zh": "法羅群島克朗"
+        },
+        "GBP": {
+            "ar": "جنيه إسترليني",
+            "bg": "Британска лира",
+            "ca": "lliura esterlina",
+            "cs": "libra šterlinků",
+            "cy": "punt sterling",
+            "da": "Britisk pund",
+            "de": "Pfund Sterling",
+            "el": "Στερλίνα",
+            "en": "pound sterling",
+            "eo": "brita pundo",
+            "es": "libra esterlina",
+            "et": "Suurbritannia naelsterling",
+            "eu": "Libera esterlina",
+            "fa": "پوند استرلینگ",
+            "fi": "Englannin punta",
+            "fr": "livre sterling",
+            "gl": "Libra esterlina",
+            "he": "לירה שטרלינג",
+            "hr": "Britanska funta",
+            "hu": "font sterling",
+            "it": "sterlina britannica",
+            "ja": "スターリング・ポンド",
+            "lt": "Svaras sterlingų",
+            "nl": "pond sterling",
+            "oc": "Liure esterlina",
+            "pl": "funt szterling",
+            "pt": "libra esterlina",
+            "ro": "liră sterlină",
+            "ru": "фунт стерлингов",
+            "sk": "Libra šterlingov",
+            "sl": "Funt šterling",
+            "sr": "британска фунта",
+            "sv": "Brittiskt pund",
+            "ta": "பிரித்தானிய பவுண்டு",
+            "tr": "İngiliz sterlini",
+            "uk": "фунт стерлінгів",
+            "vi": "Bảng Anh",
+            "zh": "英镑",
+            "ia": "libra sterling"
+        },
+        "GEL": {
+            "ar": "لاري جورجي",
+            "bg": "Грузинско лари",
+            "ca": "lari",
+            "cs": "Gruzínské lari",
+            "da": "Lari",
+            "de": "georgischer Lari",
+            "el": "Λάρι Γεωργίας",
+            "en": "Georgian lari",
+            "eo": "kartvela lario",
+            "es": "lari georgiano",
+            "et": "Lari",
+            "fa": "لاری",
+            "fi": "Georgian lari",
+            "fr": "lari",
+            "he": "לארי גאורגי",
+            "hr": "Gruzijski lari",
+            "hu": "grúz lari",
+            "ia": "lari georgian",
+            "it": "lari georgiano",
+            "ja": "ラリ",
+            "lt": "Laris",
+            "nl": "Georgische lari",
+            "pl": "Lari",
+            "pt": "lari",
+            "ro": "Lari",
+            "ru": "грузинский лари",
+            "sk": "Gruzínske lari",
+            "sr": "грузијски лари",
+            "sv": "Georgiska lari",
+            "ta": "ஜார்ஜிய லாரி",
+            "tr": "Gürcistan larisi",
+            "uk": "Ларі",
+            "zh": "格鲁吉亚拉里",
+            "oc": "Lari"
+        },
+        "GGP": {
+            "ar": "جنيه جيرنزي",
+            "ca": "lliura de Guernsey",
+            "cs": "Guernseyská libra",
+            "de": "Guernsey-Pfund",
+            "en": "Guernsey pound",
+            "es": "libra de Guernsey",
+            "fa": "پوند گرنزی",
+            "fi": "Guernseyn punta",
+            "fr": "livre de Guernesey",
+            "hr": "Guernseyjska funta",
+            "hu": "Guernsey-i font",
+            "it": "sterlina di Guernsey",
+            "ja": "ガーンジー・ポンド",
+            "lt": "Gernsio svaras",
+            "nl": "Guernseypond",
+            "pl": "Funt Guernsey",
+            "ro": "Liră din Guernsey",
+            "ru": "Гернсийский фунт",
+            "sk": "Guernseyská libra",
+            "sr": "гернзијска фунта",
+            "sv": "Guernseypund",
+            "ta": "குயெர்ன்சி பவுண்டு",
+            "tr": "Guernsey sterlini",
+            "uk": "Гернсійський фунт",
+            "zh": "根西島鎊",
+            "eo": "gernezeja pundo",
+            "ia": "libra de Guernsey"
+        },
+        "GHS": {
+            "ar": "سيدي غاني",
+            "bg": "Ганайско кеди",
+            "ca": "cedi",
+            "cs": "Ghanský cedi",
+            "cy": "Cedi",
+            "da": "Cedi",
+            "de": "Cedi",
+            "el": "Σέντι της Γκάνας",
+            "en": "Ghana cedi",
+            "eo": "ganaa cedio",
+            "es": "cedi",
+            "fa": "سدی غنا",
+            "fi": "Cedi",
+            "fr": "cedi",
+            "gl": "Cedi",
+            "hr": "Ganski cedi",
+            "hu": "Ghánai cedi",
+            "it": "cedi ghanese",
+            "ja": "セディ",
+            "lt": "Sedis",
+            "nl": "Ghanese cedi",
+            "pl": "Cedi",
+            "pt": "cedi",
+            "ru": "Ганский седи",
+            "sk": "Cedi",
+            "sr": "гански седи",
+            "sv": "Ghana Cedi",
+            "tr": "Cedi",
+            "uk": "Ганський седі",
+            "zh": "迦納塞地",
+            "he": "סדי גאני",
+            "oc": "Cedi"
+        },
+        "GIP": {
+            "ar": "جنيه جبل طارق",
+            "bg": "Гибралтарска лира",
+            "ca": "lliura de Gibraltar",
+            "cs": "Gibraltarská libra",
+            "da": "Gibraltar-pund",
+            "de": "Gibraltar-Pfund",
+            "en": "Gibraltar pound",
+            "eo": "ĝibraltara pundo",
+            "es": "libra gibraltareña",
+            "et": "Gibraltari nael",
+            "fa": "پوند جبل الطارق",
+            "fi": "Gibraltarin punta",
+            "fr": "livre de Gibraltar",
+            "gl": "Libra de Xibraltar",
+            "hr": "Gibraltarska funta",
+            "hu": "Gibraltári font",
+            "it": "sterlina di Gibilterra",
+            "ja": "ジブラルタル・ポンド",
+            "lt": "Gibraltaro svaras",
+            "nl": "Gibraltarees pond",
+            "pl": "Funt gibraltarski",
+            "pt": "libra de Gibraltar",
+            "ro": "Liră din Gibraltar",
+            "ru": "Гибралтарский фунт",
+            "sk": "Gibraltárska libra",
+            "sr": "гибралтарска фунта",
+            "sv": "Gibraltarpund",
+            "ta": "கிப்ரால்ட்டர் பவுண்டு",
+            "uk": "Гібралтарський фунт",
+            "vi": "Bảng Gibraltar",
+            "zh": "直布羅陀鎊",
+            "cy": "punt Gibraltar",
+            "el": "Λίρα Γιβραλτάρ",
+            "he": "לירה גיברלטרית"
+        },
+        "GMD": {
+            "ar": "دالاسي غامبي",
+            "bg": "Гамбийско даласи",
+            "ca": "dalasi",
+            "cs": "Gambijský dalasi",
+            "de": "Dalasi",
+            "el": "Νταλάζι",
+            "en": "dalasi",
+            "eo": "gambia dalasio",
+            "es": "dalasi",
+            "et": "Dalasi",
+            "eu": "Dalasi",
+            "fa": "دالاسی گامبیا",
+            "fi": "Dalasi",
+            "fr": "Dalasi",
+            "hr": "Gambijski dalasi",
+            "hu": "Gambiai dalasi",
+            "it": "Dalasi gambese",
+            "ja": "ダラシ",
+            "lt": "Dalasis",
+            "nl": "Gambiaanse dalasi",
+            "pl": "Dalasi",
+            "pt": "Dalasi",
+            "ru": "гамбийский даласи",
+            "sr": "гамбијски даласи",
+            "sv": "Dalasi",
+            "tr": "Dalasi",
+            "uk": "Даласі",
+            "zh": "甘比亞達拉西",
+            "he": "דלסי"
+        },
+        "GNF": {
+            "ar": "فرنك غيني",
+            "bg": "Гвинейски франк",
+            "ca": "franc guineà",
+            "cs": "Guinejský frank",
+            "de": "Franc Guinéen",
+            "el": "Φράγκο Γουινέας",
+            "en": "Guinean franc",
+            "eo": "gvinea franko",
+            "es": "Franco guineano",
+            "fa": "فرانک گینه",
+            "fi": "Guinean frangi",
+            "fr": "franc guinéen",
+            "he": "פרנק גינאי",
+            "hr": "Gvinejski franak",
+            "hu": "Guineai frank",
+            "it": "Franco guineano",
+            "ja": "ギニア・フラン",
+            "lt": "Gvinėjos frankas",
+            "nl": "Guineese frank",
+            "pl": "frank gwinejski",
+            "pt": "Franco da Guiné",
+            "ru": "Гвинейский франк",
+            "sr": "гвинејски франак",
+            "sv": "Guinesisk franc",
+            "tr": "Gine frangı",
+            "uk": "Гвінейський франк",
+            "zh": "幾內亞法郎"
+        },
+        "GTQ": {
+            "ar": "كتزال غواتيمالي",
+            "bg": "Гватемалски кецал",
+            "ca": "quetzal",
+            "cs": "Guatemalský quetzal",
+            "de": "Guatemaltekischer Quetzal",
+            "el": "Κετσάλ",
+            "en": "quetzal",
+            "eo": "gvatemala kecalo",
+            "es": "quetzal",
+            "eu": "Quetzal",
+            "fa": "کوتزال گواتمالا",
+            "fi": "Guatemalan quetzal",
+            "fr": "Quetzal",
+            "gl": "Quetzal",
+            "he": "קצאל",
+            "hr": "Gvatemalski kvecal",
+            "hu": "Guatemalai quetzal",
+            "it": "Quetzal guatemalteco",
+            "ja": "ケツァル",
+            "lt": "Gvatemalos kecalis",
+            "nl": "Guatemalteekse quetzal",
+            "oc": "Quetzal",
+            "pl": "Quetzal",
+            "pt": "Quetzal",
+            "ru": "гватемальский кетсаль",
+            "sr": "гватемалски квецал",
+            "sv": "Quetzal",
+            "tr": "Guatemala quetzalı",
+            "uk": "Гватемальський кетсаль",
+            "zh": "瓜地馬拉格查爾",
+            "cy": "Quetzal Gwatemala"
+        },
+        "GWE": {
+            "en": "Portuguese Guinean escudo",
+            "es": "escudo guineoportugués",
+            "fa": "اسکودوی گینه پرتغال",
+            "fi": "Portugalin Guinean escudo",
+            "fr": "escudo de Guinée-Bissau",
+            "ja": "ポルトガル領ギニア・エスクード",
+            "ru": "Гвинейский эскудо",
+            "eo": "portugal-gvinea eskudo"
+        },
+        "GYD": {
+            "ar": "دولار غوياني",
+            "bg": "Гаянски долар",
+            "ca": "dòlar de Guyana",
+            "cs": "Guyanský dolar",
+            "de": "Guyana-Dollar",
+            "el": "Δολάριο Γουιάνας",
+            "en": "Guyanese dollar",
+            "eo": "gujana dolaro",
+            "es": "Dólar guyanés",
+            "eu": "Dolar guyanar",
+            "fa": "دلار گویان",
+            "fi": "Guyanan dollari",
+            "fr": "Dollar guyanien",
+            "gl": "Dólar güianés",
+            "hr": "Gvajanski dolar",
+            "hu": "Guyanai dollár",
+            "it": "Dollaro della Guyana",
+            "ja": "ガイアナ・ドル",
+            "lt": "Gajanos doleris",
+            "nl": "Guyaanse dollar",
+            "pl": "dolar gujański",
+            "pt": "Dólar da Guiana",
+            "ro": "Dolar guyanez",
+            "ru": "гайанский доллар",
+            "sr": "гвајански долар",
+            "sv": "Guyansk dollar",
+            "tr": "Guyana doları",
+            "uk": "Гаянський долар",
+            "zh": "圭亞那元",
+            "he": "דולר גיאני"
+        },
+        "HKD": {
+            "ar": "دولار هونغ كونغ",
+            "bg": "Хонконгски долар",
+            "ca": "dòlar de Hong Kong",
+            "cs": "Hongkongský dolar",
+            "cy": "Doler Hong Kong",
+            "da": "Hongkong-dollar",
+            "de": "Hongkong-Dollar",
+            "el": "Δολάριο Χονγκ Κονγκ",
+            "en": "Hong Kong dollar",
+            "eo": "honkonga dolaro",
+            "es": "dólar de Hong Kong",
+            "et": "Hongkongi dollar",
+            "eu": "Dolar hongkongtar",
+            "fa": "دلار هنگکنگ",
+            "fi": "Hongkongin dollari",
+            "fr": "dollar de Hong Kong",
+            "gl": "Dólar de Hong Kong",
+            "he": "דולר הונג קונגי",
+            "hr": "Honkonški dolar",
+            "hu": "hongkongi dollár",
+            "it": "dollaro di Hong Kong",
+            "ja": "香港ドル",
+            "lt": "Honkongo doleris",
+            "nl": "Hongkongse dollar",
+            "pl": "dolar Hongkongu",
+            "pt": "dólar de Hong Kong",
+            "ru": "гонконгский доллар",
+            "sk": "Hongkonský dolár",
+            "sr": "хонгконшки долар",
+            "sv": "Hongkongdollar",
+            "ta": "ஹொங்கொங் டொலர்",
+            "tr": "Hong Kong doları",
+            "uk": "Гонконгський долар",
+            "vi": "đô la Hồng Kông",
+            "zh": "港元",
+            "ro": "dolar din Hong Kong"
+        },
+        "HNL": {
+            "ar": "لمبيرة هندوراسية",
+            "bg": "Хондураска лемпира",
+            "ca": "lempira",
+            "cs": "Honduraská lempira",
+            "de": "Lempira",
+            "el": "Λεμπίρα",
+            "en": "Honduran lempira",
+            "eo": "hondura lempiro",
+            "es": "lempira",
+            "eu": "Lempira",
+            "fa": "لامپیرای هندوراس",
+            "fi": "Hondurasin lempira",
+            "fr": "lempira",
+            "he": "למפירה",
+            "hr": "Honduraška lempira",
+            "hu": "hondurasi lempira",
+            "it": "lempira honduregna",
+            "ja": "レンピラ",
+            "lt": "Hondūro lempira",
+            "nl": "Hondurese lempira",
+            "oc": "Lempira",
+            "pl": "Lempira",
+            "pt": "lempira",
+            "ro": "Lempira",
+            "ru": "гондурасская лемпира",
+            "sr": "хондурашка лемпира",
+            "sv": "Lempira",
+            "tr": "Honduras lempirası",
+            "uk": "Гондураська лемпіра",
+            "zh": "宏都拉斯倫皮拉",
+            "cy": "Lempira Hondwraidd"
+        },
+        "HRK": {
+            "ar": "كونا كرواتية",
+            "bg": "Хърватска куна",
+            "ca": "kuna",
+            "cs": "Chorvatská kuna",
+            "da": "Kuna",
+            "de": "kroatische Kuna",
+            "el": "Κούνα Κροατίας",
+            "en": "Croatian kuna",
+            "eo": "kroata kunao",
+            "es": "kuna croata",
+            "et": "Kuna",
+            "fa": "کونا",
+            "fi": "Kroatian kuna",
+            "fr": "kuna croate",
+            "gl": "Kuna croata",
+            "he": "קונה",
+            "hr": "hrvatska kuna",
+            "hu": "horvát kuna",
+            "it": "kuna croata",
+            "ja": "クーナ",
+            "lt": "Kroatijos kuna",
+            "nl": "Kroatische kuna",
+            "pl": "kuna",
+            "pt": "kuna croata",
+            "ro": "Kuna",
+            "ru": "хорватская куна",
+            "sk": "Chorvátska kuna",
+            "sl": "hrvaška kuna",
+            "sr": "хрватска куна",
+            "sv": "Kroatisk kuna",
+            "ta": "குனா",
+            "tr": "Hırvatistan kunası",
+            "uk": "хорватська куна",
+            "vi": "Kuna Croatia",
+            "zh": "克羅埃西亞庫納",
+            "ia": "kuna croate",
+            "oc": "kuna"
+        },
+        "HTG": {
+            "ar": "جوردة هايتية",
+            "ca": "gourde",
+            "cs": "Haitský gourde",
+            "da": "Gourde",
+            "de": "Gourde",
+            "el": "Γκουρντ",
+            "en": "gourde",
+            "eo": "haitia gurdo",
+            "es": "gourde",
+            "eu": "Gourde",
+            "fa": "گورد هائیتی",
+            "fi": "Haitin gourde",
+            "fr": "Gourde",
+            "hr": "Haićanski gourd",
+            "hu": "haiti gourde",
+            "it": "Gourde haitiano",
+            "ja": "グールド",
+            "lt": "Gurdas",
+            "nl": "Haïtiaanse gourde",
+            "pl": "Gourde",
+            "pt": "Gourde",
+            "ru": "гаитянский гурд",
+            "sr": "хаићански гурд",
+            "sv": "Gourde",
+            "tr": "Gourde",
+            "uk": "Гаїтянський гурд",
+            "zh": "海地古德",
+            "he": "גורד"
+        },
+        "HUF": {
+            "ar": "فورنت مجري",
+            "bg": "Унгарски форинт",
+            "ca": "fòrint",
+            "cs": "maďarský forint",
+            "da": "Forint",
+            "de": "Forint",
+            "el": "Φόριντ Ουγγαρίας",
+            "en": "forint",
+            "eo": "hungara forinto",
+            "es": "forinto húngaro",
+            "et": "Forint",
+            "eu": "Hungariar forint",
+            "fa": "فورینت مجارستان",
+            "fi": "Unkarin forintti",
+            "fr": "forint",
+            "gl": "Florín húngaro",
+            "he": "פורינט",
+            "hr": "Mađarska forinta",
+            "hu": "magyar forint",
+            "it": "fiorino ungherese",
+            "ja": "フォリント",
+            "lt": "Forintas",
+            "nl": "Hongaarse forint",
+            "pl": "forint",
+            "pt": "florim húngaro",
+            "ro": "Forint",
+            "ru": "венгерский форинт",
+            "sk": "Maďarský forint",
+            "sl": "Madžarski forint",
+            "sr": "мађарска форинта",
+            "sv": "Forint",
+            "ta": "அங்கேரிய போரிண்ட்",
+            "tr": "Macar forinti",
+            "uk": "угорський форинт",
+            "vi": "Forint",
+            "zh": "匈牙利福林",
+            "ia": "forint hungare"
+        },
+        "HUP": {
+            "ca": "pengő",
+            "cs": "Maďarské pengő",
+            "cy": "Pengő",
+            "da": "Pengő",
+            "de": "Pengő",
+            "en": "Hungarian pengő",
+            "eo": "Pengo",
+            "es": "pengő",
+            "et": "Pengö",
+            "fa": "پنگوی مجارستان",
+            "fi": "Unkarin pengő",
+            "fr": "pengő",
+            "he": "פנגו הונגרי",
+            "hr": "Mađarski peng",
+            "hu": "magyar pengő",
+            "ia": "Pengő",
+            "it": "pengő ungherese",
+            "ja": "ペンゲー",
+            "lt": "Pengė",
+            "nl": "pengő",
+            "pl": "Pengő",
+            "pt": "pengő",
+            "ro": "Pengheu maghiar",
+            "ru": "венгерский пенгё",
+            "sk": "Maďarské pengő",
+            "sl": "Pengő",
+            "sv": "Pengő",
+            "uk": "Угорський пенге",
+            "zh": "帕戈",
+            "sr": "мађарски пенгу"
+        },
+        "IDR": {
+            "ar": "روبية إندونيسية",
+            "bg": "Индонезийска рупия",
+            "ca": "rupia indonèsia",
+            "cs": "Indonéská rupie",
+            "da": "Rupiah",
+            "de": "indonesische Rupiah",
+            "el": "Ρουπία Ινδονησίας",
+            "en": "rupiah",
+            "eo": "indonezia rupio",
+            "es": "rupia indonesia",
+            "eu": "Indonesiar errupia",
+            "fa": "روپیه اندونزی",
+            "fi": "Indonesian rupia",
+            "fr": "roupie indonésienne",
+            "hr": "Indonezijska rupija",
+            "hu": "indonéz rúpia",
+            "it": "rupia indonesiana",
+            "ja": "ルピア",
+            "lt": "Indonezijos rupija",
+            "nl": "Indonesische roepia",
+            "pl": "rupia indonezyjska",
+            "pt": "rupia indonésia",
+            "ru": "индонезийская рупия",
+            "sl": "Indonezijska rupija",
+            "sr": "индонежанска рупија",
+            "sv": "Rupiah",
+            "ta": "இந்தோனேசிய ரூபாய்",
+            "tr": "Endonezya rupiahı",
+            "uk": "індонезійська рупія",
+            "vi": "Rupiah",
+            "zh": "印尼盾",
+            "oc": "ropia d'Indonesia"
+        },
+        "ILS": {
+            "ar": "شيكل إسرائيلي جديد",
+            "bg": "Израелски шекел",
+            "ca": "nou xéquel",
+            "cs": "nový izraelský šekel",
+            "cy": "Sicl newydd Israel",
+            "da": "Ny Shekel",
+            "de": "Schekel",
+            "el": "νέο σέκελ Ισραήλ",
+            "en": "new shekel",
+            "eo": "nova israela siklo",
+            "es": "nuevo séquel",
+            "et": "Iisraeli seekel",
+            "eu": "Shekel berri",
+            "fa": "شکل جدید اسرائیل",
+            "fi": "Uusi Israelin sekeli",
+            "fr": "shekel",
+            "gl": "Novo sheqel",
+            "he": "שקל חדש",
+            "hr": "Izraelski novi šekel",
+            "hu": "izraeli új sékel",
+            "it": "nuovo siclo israeliano",
+            "ja": "新シェケル",
+            "lt": "Izraelio naujasis šekelis",
+            "nl": "Israëlische sjekel",
+            "pl": "Nowy izraelski szekel",
+            "pt": "novo shekel israelense",
+            "ro": "Shekel",
+            "ru": "новый израильский шекель",
+            "sk": "Nový izraelský šekel",
+            "sr": "нови израелски шекел",
+            "sv": "Shekel",
+            "ta": "புது இசுரேலிய சேக்கல்",
+            "tr": "Yeni İsrail Şekeli",
+            "uk": "ізраїльський новий шекель",
+            "zh": "以色列新谢克尔",
+            "oc": "shekel novèl"
+        },
+        "IMP": {
+            "ar": "جنيه مانكس",
+            "ca": "lliura de l'illa de Man",
+            "cs": "Manská libra",
+            "de": "Isle-of-Man-Pfund",
+            "en": "Manx pound",
+            "es": "libra manesa",
+            "fa": "پوند مانکس",
+            "fi": "Mansaaren punta",
+            "fr": "livre mannoise",
+            "gl": "Libra da Illa de Man",
+            "hr": "Manska funta",
+            "hu": "Man-szigeti font",
+            "it": "sterlina di Man",
+            "ja": "マンクス・ポンド",
+            "lt": "Meno salos svaras",
+            "nl": "Isle of Man-pond",
+            "pl": "Funt manx",
+            "pt": "Libra manesa",
+            "ro": "Liră din Insula Man",
+            "ru": "фунт Острова Мэн",
+            "sk": "Manská libra",
+            "sr": "манска фунта",
+            "sv": "Isle of Man-pund",
+            "ta": "மான்க்ஸ் பவுண்டு",
+            "uk": "Фунт острова Мен",
+            "zh": "曼島鎊",
+            "eo": "maninsula pundo",
+            "ia": "libra mannese"
+        },
+        "INR": {
+            "ar": "روبية هندية",
+            "bg": "Индийска рупия",
+            "ca": "rupia índia",
+            "cs": "Indická rupie",
+            "da": "Indiske rupier",
+            "de": "Indische Rupie",
+            "el": "Ρουπία Ινδίας",
+            "en": "Indian rupee",
+            "eo": "barata rupio",
+            "es": "rupia india",
+            "et": "India ruupia",
+            "eu": "Indiar errupia",
+            "fa": "روپیه هند",
+            "fi": "Intian rupia",
+            "fr": "roupie indienne",
+            "he": "רופי הודי",
+            "hr": "Indijska rupija",
+            "hu": "Indiai rúpia",
+            "it": "rupia indiana",
+            "ja": "インド・ルピー",
+            "lt": "Indijos rupija",
+            "nl": "Indiase roepie",
+            "oc": "Ropia d'Índia",
+            "pl": "Rupia indyjska",
+            "pt": "rupia indiana",
+            "ro": "Rupie indiană",
+            "ru": "индийская рупия",
+            "sk": "Indická rupia",
+            "sr": "индијска рупија",
+            "sv": "Indisk rupee",
+            "ta": "இந்திய ரூபாய்",
+            "te": "రూపాయి",
+            "tr": "Hindistan rupisi",
+            "uk": "індійська рупія",
+            "vi": "Rupee Ấn Độ",
+            "zh": "印度盧比"
+        },
+        "IQD": {
+            "ar": "دينار عراقي",
+            "bg": "Иракски динар",
+            "ca": "dinar iraquià",
+            "da": "Irakiske dinarer",
+            "de": "irakischer Dinar",
+            "en": "Iraqi dinar",
+            "eo": "iraka dinaro",
+            "es": "dinar iraquí",
+            "fa": "دینار عراق",
+            "fi": "Irakin dinaari",
+            "fr": "dinar irakien",
+            "he": "דינר עיראקי",
+            "hr": "Irački dinar",
+            "hu": "iraki dinár",
+            "it": "dinaro iracheno",
+            "ja": "イラク・ディナール",
+            "lt": "Irako dinaras",
+            "nl": "Iraakse dinar",
+            "pl": "Dinar iracki",
+            "pt": "dinar iraquiano",
+            "ru": "иракский динар",
+            "sr": "ирачки динар",
+            "sv": "Irakisk dinar",
+            "tr": "Irak dinarı",
+            "uk": "Іракський динар",
+            "zh": "伊拉克第納爾",
+            "cs": "irácký dinár",
+            "el": "Ιρακινό δηνάριο",
+            "ta": "இராக்கிய தீனார்"
+        },
+        "IRR": {
+            "ar": "ريال إيراني",
+            "bg": "Ирански риал",
+            "ca": "rial iranià",
+            "cs": "Íránský riál",
+            "da": "Rial",
+            "de": "iranischer Rial",
+            "el": "Ιρανικό ριάλ",
+            "en": "Iranian rial",
+            "eo": "irana rialo",
+            "es": "rial iraní",
+            "eu": "Irandar rial",
+            "fa": "ریال ایران",
+            "fi": "Iranin rial",
+            "fr": "rial iranien",
+            "he": "ריאל איראני",
+            "hr": "Iranski rijal",
+            "hu": "iráni riál",
+            "it": "riyal iraniano",
+            "ja": "イラン・リヤル",
+            "lt": "Irano rialas",
+            "nl": "Iraanse rial",
+            "pl": "Rial irański",
+            "pt": "rial iraniano",
+            "ro": "Rial iranian",
+            "ru": "иранский риал",
+            "sk": "Iránsky rial",
+            "sr": "ирански ријал",
+            "sv": "Iransk rial",
+            "tr": "İran riyali",
+            "uk": "Іранський ріал",
+            "vi": "Rial Iran",
+            "zh": "伊朗里亞爾",
+            "oc": "rial"
+        },
+        "ISK": {
+            "ar": "كرونة آيسلندية",
+            "bg": "Исландска крона",
+            "ca": "corona islandesa",
+            "cs": "Islandská koruna",
+            "da": "Islandsk króna",
+            "de": "isländische Krone",
+            "el": "Κορόνα Ισλανδίας",
+            "en": "Icelandic króna",
+            "eo": "islanda krono",
+            "es": "corona islandesa",
+            "et": "Islandi kroon",
+            "eu": "Islandiar koroa",
+            "fa": "کرونا ایسلند",
+            "fi": "Islannin kruunu",
+            "fr": "couronne islandaise",
+            "gl": "Coroa islandesa",
+            "he": "קרונה איסלנדית",
+            "hr": "Islandska kruna",
+            "hu": "izlandi korona",
+            "it": "corona islandese",
+            "ja": "アイスランド・クローナ",
+            "lt": "Islandijos krona",
+            "nl": "IJslandse kroon",
+            "pl": "Korona islandzka",
+            "pt": "coroa islandesa",
+            "ro": "Coroană islandeză",
+            "ru": "исландская крона",
+            "sk": "Islandská koruna",
+            "sl": "islandska krona",
+            "sr": "исландска круна",
+            "sv": "Isländsk krona",
+            "ta": "ஐஸ்லாந்திய குரோனா",
+            "tr": "İzlanda kronası",
+            "uk": "Ісландська крона",
+            "zh": "冰岛克朗",
+            "ia": "corona islandese"
+        },
+        "JEP": {
+            "ar": "جنيه جيرزي",
+            "ca": "lliura de Jersey",
+            "cs": "Jerseyská libra",
+            "de": "Jersey-Pfund",
+            "en": "Jersey pound",
+            "eo": "ĵerzeja pundo",
+            "es": "libra de Jersey",
+            "fa": "پوند جرسی",
+            "fi": "Jerseyn punta",
+            "fr": "livre de Jersey",
+            "hr": "Jerseyjska funta",
+            "hu": "Jersey-i font",
+            "it": "sterlina di Jersey",
+            "ja": "ジャージー・ポンド",
+            "lt": "Džersio svaras",
+            "nl": "Jerseypond",
+            "pl": "Funt Jersey",
+            "ro": "Liră din Jersey",
+            "ru": "джерсийский фунт",
+            "sk": "Jerseyská libra",
+            "sr": "џерсијска фунта",
+            "sv": "Jerseypund",
+            "ta": "ஜெர்சி பவுண்டு",
+            "uk": "Джерсійський фунт",
+            "zh": "澤西島鎊",
+            "he": "לירה ג'רזית",
+            "ia": "libra de Jersey"
+        },
+        "JMD": {
+            "ar": "دولار جامايكي",
+            "bg": "Ямайски долар",
+            "ca": "dòlar jamaicà",
+            "cs": "Jamajský dolar",
+            "de": "Jamaika-Dollar",
+            "el": "Δολάριο Τζαμάικας",
+            "en": "Jamaican dollar",
+            "eo": "jamajka dolaro",
+            "es": "Dólar jamaiquino",
+            "eu": "Dolar jamaikar",
+            "fa": "دلار جامائیکا",
+            "fi": "Jamaikan dollari",
+            "fr": "Dollar jamaïcain",
+            "gl": "Dólar xamaicano",
+            "hr": "Jamajčanski dolar",
+            "hu": "Jamaicai dollár",
+            "it": "Dollaro giamaicano",
+            "ja": "ジャマイカ・ドル",
+            "lt": "Jamaikos doleris",
+            "nl": "Jamaicaanse dollar",
+            "pl": "Dolar jamajski",
+            "pt": "Dólar jamaicano",
+            "ru": "ямайский доллар",
+            "sr": "јамајкански долар",
+            "sv": "Jamaicansk dollar",
+            "tr": "Jamaika doları",
+            "uk": "Ямайський долар",
+            "zh": "牙買加元",
+            "he": "דולר ג'מייקי"
+        },
+        "JOD": {
+            "ar": "دينار أردني",
+            "bg": "Йордански динар",
+            "ca": "dinar jordà",
+            "cs": "Jordánský dinár",
+            "de": "jordanischer Dinar",
+            "el": "Ιορδανικό δηνάριο",
+            "en": "Jordanian dinar",
+            "eo": "jordania dinaro",
+            "es": "dinar jordano",
+            "et": "Jordaania dinaar",
+            "eu": "Jordaniako dinar",
+            "fa": "دینار اردن",
+            "fi": "Jordanian dinaari",
+            "fr": "dinar jordanien",
+            "he": "דינר ירדני",
+            "hr": "Jordanski dinar",
+            "hu": "jordán dinár",
+            "it": "dinaro giordano",
+            "ja": "ヨルダン・ディナール",
+            "lt": "Jordanijos dinaras",
+            "nl": "Jordaanse dinar",
+            "pl": "Dinar jordański",
+            "pt": "dinar jordano",
+            "ro": "Dinar iordanian",
+            "ru": "иорданский динар",
+            "sr": "јордански динар",
+            "sv": "Jordansk dinar",
+            "tr": "Ürdün dinarı",
+            "uk": "Йорданський динар",
+            "zh": "約旦第納爾",
+            "cy": "dinar (Iorddonen)",
+            "oc": "Dinar jordanian"
+        },
         "JPY": {
-            "fr": "Yen", 
-            "en": "Japanese yen", 
-            "nl": "Japanse yen", 
-            "de": "Yen", 
-            "it": "Yen giapponese", 
-            "hu": "Jap\u00e1n jen", 
-            "es": "yen"
-        }, 
-        "ARA": {
-            "fr": "Austral (monnaie)", 
-            "en": "Argentine austral", 
-            "de": "Austral (W\u00e4hrung)", 
-            "it": "Austral argentino", 
-            "es": "Austral"
-        }, 
+            "ar": "ين ياباني",
+            "bg": "Японска йена",
+            "ca": "ien",
+            "cs": "japonský jen",
+            "cy": "Yen",
+            "da": "Yen",
+            "de": "Yen",
+            "el": "Γιεν",
+            "en": "Japanese yen",
+            "eo": "japana eno",
+            "es": "yen",
+            "et": "Jaapani jeen",
+            "eu": "Yen",
+            "fa": "ین",
+            "fi": "Japanin jeni",
+            "fr": "yen",
+            "gl": "Ien",
+            "he": "ין יפני",
+            "hr": "Japanski jen",
+            "hu": "japán jen",
+            "it": "yen",
+            "ja": "円",
+            "lt": "Jena",
+            "nl": "Japanse yen",
+            "oc": "Yen",
+            "pl": "jen",
+            "pt": "iene",
+            "ro": "yeni",
+            "ru": "японская иена",
+            "sk": "Jen",
+            "sl": "Jen",
+            "sr": "јапански јен",
+            "sv": "yen",
+            "ta": "யென்",
+            "tr": "Japon yeni",
+            "uk": "єна",
+            "vi": "Yên Nhật",
+            "zh": "日圓"
+        },
+        "KES": {
+            "ar": "شيلينغ كيني",
+            "bg": "Кенийски шилинг",
+            "ca": "xíling kenyà",
+            "cs": "keňský šilink",
+            "da": "kenyansk shilling",
+            "de": "Kenia-Schilling",
+            "el": "Σελίνι της Κένυας",
+            "en": "Kenyan shilling",
+            "eo": "kenja ŝilingo",
+            "es": "Chelín keniano",
+            "et": "Kenya šilling",
+            "fa": "شیلینگ کنیا",
+            "fi": "Kenian šillinki",
+            "fr": "Shilling kényan",
+            "gl": "Xilin kenyano",
+            "he": "שילינג קנייתי",
+            "hr": "Kenijski šiling",
+            "hu": "Kenyai shilling",
+            "it": "Scellino keniota",
+            "ja": "ケニア・シリング",
+            "lt": "Kenijos šilingas",
+            "nl": "Keniaanse shilling",
+            "pl": "Szyling kenijski",
+            "pt": "Xelim queniano",
+            "ru": "кенийский шиллинг",
+            "sr": "кенијски шилинг",
+            "sv": "Kenyansk shilling",
+            "tr": "Kenya şilini",
+            "uk": "кенійський шилінг",
+            "zh": "肯亞先令"
+        },
+        "KGS": {
+            "ar": "سوم قرغيزستاني",
+            "bg": "Сом",
+            "ca": "som kirguís",
+            "cs": "Kyrgyzský som",
+            "de": "Som",
+            "el": "Σομ Κιργιζίας",
+            "en": "Kyrgyzstani som",
+            "eo": "kirgiza somo",
+            "es": "som kirguís",
+            "fa": "سوم قرقیزستان",
+            "fi": "Kirgisian som",
+            "fr": "som",
+            "gl": "Som kirguiz",
+            "hr": "Kirgistanski som",
+            "hu": "kirgiz szom",
+            "it": "som kirghizo",
+            "ja": "キルギス・ソム",
+            "lt": "Somas",
+            "nl": "Kirgizische som",
+            "pl": "Som",
+            "pt": "Som",
+            "ro": "Som kîrgîz",
+            "ru": "киргизский сом",
+            "sr": "киргиски сом",
+            "sv": "Kirgizistansk som",
+            "tr": "Kırgızistan somu",
+            "uk": "Сом",
+            "zh": "吉尔吉斯斯坦索姆"
+        },
+        "KHR": {
+            "ar": "ريال كمبودي",
+            "bg": "Камбоджански риел",
+            "ca": "riel",
+            "cs": "Kambodžský riel",
+            "de": "Kambodschanischer Riel",
+            "el": "Ριέλ Καμπότζης",
+            "en": "riel",
+            "eo": "kamboĝa rielo",
+            "es": "riel camboyano",
+            "eu": "Kanbodiar bigarren riel",
+            "fa": "ریال کامبوج",
+            "fi": "Kambodžan riel",
+            "fr": "Riel",
+            "hr": "Kambodžanski rijel",
+            "hu": "kambodzsai riel",
+            "it": "Riel cambogiano",
+            "ja": "リエル",
+            "lt": "Kambodžos rielis",
+            "nl": "Cambodjaanse riel",
+            "pl": "Riel",
+            "pt": "riel cambojano",
+            "ru": "камбоджийский риель",
+            "sr": "камбоџански ријел",
+            "sv": "Riel",
+            "tr": "Riel",
+            "uk": "Камбоджійський рієль",
+            "vi": "Riel Campuchia",
+            "zh": "柬埔寨瑞爾",
+            "he": "ריאל קמבודי",
+            "oc": "riel",
+            "ta": "ரைல்"
+        },
+        "KID": {
+            "ar": "دولار كريباتي",
+            "cs": "Kiribatský dolar",
+            "de": "Kiribati-Dollar",
+            "el": "Δολάριο Κιριμπάτι",
+            "en": "Kiribati dollar",
+            "eo": "Kiribata dolaro",
+            "es": "Dólar de Kiribati",
+            "fa": "دلار کیریباتی",
+            "fi": "Kiribatin dollari",
+            "fr": "dollar des Kiribati",
+            "gl": "Dólar de Kiribati",
+            "hr": "Kiribatski dolar",
+            "it": "Dollaro di Kiribati",
+            "ja": "キリバス・ドル",
+            "lt": "Kiribačio doleris",
+            "pl": "Dolar Kiribati",
+            "pt": "Dólar de Kiribati",
+            "ro": "Dolar din Kiribati",
+            "ru": "доллар Кирибати",
+            "uk": "долар Кірибаті",
+            "zh": "基里巴斯元",
+            "ca": "dòlar de Kiribati",
+            "nl": "Kiribati dollar",
+            "sr": "кирибатски долар"
+        },
+        "KMF": {
+            "ar": "فرنك قمري",
+            "bg": "Коморски франк",
+            "ca": "franc de les Comores",
+            "cs": "Komorský frank",
+            "de": "Komoren-Franc",
+            "el": "Φράγκο Κομορών",
+            "en": "Comorian franc",
+            "eo": "komora franko",
+            "es": "franco comorense",
+            "fa": "فرانک کمر",
+            "fi": "Komorien frangi",
+            "fr": "franc comorien",
+            "hr": "Komorski franak",
+            "hu": "Comore-i frank",
+            "it": "franco delle Comore",
+            "ja": "コモロ・フラン",
+            "lt": "Komorų frankas",
+            "nl": "Comorese frank",
+            "pl": "frank Komorów",
+            "pt": "Franco comoriano",
+            "ro": "Franc comorian",
+            "ru": "Франк Комор",
+            "sr": "коморски франак",
+            "sv": "Komoransk franc",
+            "tr": "Komor frangı",
+            "uk": "Коморський франк",
+            "zh": "葛摩法郎"
+        },
+        "KPW": {
+            "ar": "وون كوري شمالي",
+            "bg": "Севернокорейски вон",
+            "ca": "won nord-coreà",
+            "cs": "Severokorejský won",
+            "da": "Nordkoreanske won",
+            "de": "nordkoreanischer Won",
+            "el": "Γουόν Βόρειας Κορέας",
+            "en": "North Korean won",
+            "eo": "nord-korea vono",
+            "es": "wŏn norcoreano",
+            "et": "Põhja-Korea vonn",
+            "fa": "وون کره شمالی",
+            "fi": "Pohjois-Korean won",
+            "fr": "won nord-coréen",
+            "gl": "Won norcoreano",
+            "he": "וון צפון-קוריאני",
+            "hr": "Sjevernokorejski von",
+            "hu": "észak-koreai von",
+            "it": "won nordcoreano",
+            "ja": "朝鮮民主主義人民共和国ウォン",
+            "lt": "Šiaurės Korėjos vona",
+            "nl": "Noord-Koreaanse won",
+            "pl": "Won północnokoreański",
+            "pt": "won norte-coreano",
+            "ro": "Won nord-coreean",
+            "ru": "вона КНДР",
+            "sr": "севернокорејски вон",
+            "sv": "Nordkoreansk won",
+            "tr": "Kuzey Kore wonu",
+            "uk": "Північнокорейська вона",
+            "vi": "Won Cộng hòa Dân chủ Nhân dân Triều Tiên",
+            "zh": "朝鮮圓"
+        },
+        "KRW": {
+            "ar": "وون كوري جنوبي",
+            "bg": "Южнокорейски вон",
+            "ca": "won sud-coreà",
+            "cs": "Jihokorejský won",
+            "da": "Sydkoreanske won",
+            "de": "Südkoreanischer Won",
+            "el": "Γουόν Νότιας Κορέας",
+            "en": "South Korean won",
+            "eo": "sud-korea vono",
+            "es": "Won surcoreano",
+            "et": "Lõuna-Korea vonn",
+            "fa": "وون کره جنوبی",
+            "fi": "Etelä-Korean won",
+            "fr": "won sud-coréen",
+            "hr": "Južnokorejski von",
+            "hu": "dél-koreai von",
+            "it": "won sudcoreano",
+            "ja": "大韓民国ウォン",
+            "lt": "Pietų Korėjos vonas",
+            "nl": "Zuid-Koreaanse won",
+            "pl": "Won południowokoreański",
+            "pt": "Won sul-coreano",
+            "ro": "Won sud-coreean",
+            "ru": "южнокорейская вона",
+            "sr": "јужнокорејски вон",
+            "sv": "Sydkoreansk won",
+            "tr": "Güney Kore wonu",
+            "uk": "південнокорейська вона",
+            "vi": "Won Hàn Quốc",
+            "zh": "韓圓",
+            "he": "וון דרום קוריאני",
+            "oc": "Won sud-corean",
+            "ta": "tamil langauges"
+        },
+        "KWD": {
+            "ar": "دينار كويتي",
+            "bg": "Кувейтски динар",
+            "ca": "dinar kuwaitià",
+            "cs": "Kuvajtský dinár",
+            "da": "Kuwaitiske dinarer",
+            "de": "Kuwait-Dinar",
+            "el": "Δηνάριο Κουβέιτ",
+            "en": "Kuwaiti dinar",
+            "eo": "kuvajta dinaro",
+            "es": "dinar kuwaití",
+            "fa": "دینار کویت",
+            "fi": "Kuwaitin dinaari",
+            "fr": "dinar koweïtien",
+            "he": "דינר כוויתי",
+            "hu": "kuvaiti dinár",
+            "it": "dinaro kuwaitiano",
+            "ja": "クウェート・ディナール",
+            "lt": "Kuveito dinaras",
+            "nl": "Koeweitse dinar",
+            "pl": "Dinar kuwejcki",
+            "pt": "dinar kuwaitiano",
+            "ru": "кувейтский динар",
+            "sr": "кувајтски динар",
+            "sv": "Kuwaitisk dinar",
+            "ta": "குவைத் தினார்",
+            "tr": "Kuveyt dinarı",
+            "uk": "Кувейтський динар",
+            "vi": "Dinar Kuwait",
+            "zh": "科威特第纳尔"
+        },
+        "KYD": {
+            "ar": "دولار جزر كايمان",
+            "ca": "dòlar de les illes Caiman",
+            "cs": "Dolar Kajmanských ostrovů",
+            "de": "Kaiman-Dollar",
+            "el": "Δολάριο Νησιών Καϋμάν",
+            "en": "Cayman Islands dollar",
+            "eo": "kajmana dolaro",
+            "es": "Dólar de las Islas Caimán",
+            "eu": "Dolar kaimandar",
+            "fa": "دلار جزایر کیمن",
+            "fi": "Caymansaarten dollari",
+            "fr": "Dollar des îles Caïmans",
+            "hr": "Kajmanski dolar",
+            "hu": "Kajmán-szigeteki dollár",
+            "it": "Dollaro delle Cayman",
+            "ja": "ケイマン諸島・ドル",
+            "lt": "Kaimanų salų doleris",
+            "nl": "Kaaimaneilandse dollar",
+            "pl": "Dolar kajmański",
+            "pt": "Dólar das Ilhas Cayman",
+            "ru": "доллар Каймановых островов",
+            "sr": "долар Кајманских Острва",
+            "sv": "Caymansk dollar",
+            "tr": "Cayman Adaları doları",
+            "uk": "Долар Кайманових островів",
+            "vi": "Đô la Quần đảo Cayman",
+            "zh": "開曼群島元",
+            "he": "דולר קיימני",
+            "oc": "Dolar de las illas Caiman"
+        },
+        "KZT": {
+            "ar": "تينغ كازاخستاني",
+            "bg": "Казахстанско тенге",
+            "ca": "tenge",
+            "cs": "Tenge",
+            "de": "Tenge",
+            "el": "Τένγκε",
+            "en": "Kazakhstani tenge",
+            "eo": "kazaĥa tengo",
+            "es": "tenge kazajo",
+            "eu": "Kazakhstani Tenge",
+            "fa": "تنگه",
+            "fi": "Kazakstanin tenge",
+            "fr": "tenge kazakh",
+            "hr": "Kazahstanski tenge",
+            "hu": "kazah tenge",
+            "it": "tenge kazako",
+            "ja": "テンゲ",
+            "lt": "Kazachijos tengė",
+            "nl": "Kazachse tenge",
+            "pl": "Tenge",
+            "pt": "tenge",
+            "ro": "Tenge",
+            "ru": "казахстанский тенге",
+            "sk": "Kazachstanský tenge",
+            "sr": "казахстански тенге",
+            "sv": "Tenge",
+            "ta": "கசக்ஸ்தானிய டெங்கே",
+            "tr": "Tenge",
+            "uk": "Казахстанський тенге",
+            "vi": "Tenge Kazakhstan",
+            "zh": "哈萨克斯坦坚戈",
+            "he": "טנגה",
+            "ia": "tenge kazakh",
+            "oc": "tenge"
+        },
+        "LAK": {
+            "ar": "كيب لاوي",
+            "bg": "Лаоски кип",
+            "ca": "kip",
+            "cs": "Laoský kip",
+            "cy": "Kip",
+            "de": "Kip",
+            "el": "Κιπ",
+            "en": "Lao kip",
+            "eo": "laosa kipo",
+            "es": "kip laosiano",
+            "eu": "Laostar kip berria",
+            "fa": "کیپ لائوس",
+            "fi": "Laosin kip",
+            "fr": "Kip laotien",
+            "hr": "laoski kip",
+            "hu": "laoszi kip",
+            "it": "Kip laotiano",
+            "ja": "キープ",
+            "lt": "Laoso kipas",
+            "nl": "Laotiaanse kip",
+            "pl": "Kip",
+            "pt": "Kip",
+            "ru": "лаосский кип",
+            "sr": "лаоски кип",
+            "sv": "Kip",
+            "tr": "Laos kipi",
+            "uk": "Лаоський кіп",
+            "vi": "Kíp Lào",
+            "zh": "寮國基普"
+        },
+        "LBP": {
+            "ar": "ليرة لبنانية",
+            "bg": "Ливанска лира",
+            "ca": "lliura libanesa",
+            "de": "libanesisches Pfund",
+            "el": "Λίρα του Λιβάνου",
+            "en": "Lebanese pound",
+            "eo": "libana liro",
+            "es": "libra libanesa",
+            "fa": "لیره لبنان",
+            "fi": "Libanonin punta",
+            "fr": "livre libanaise",
+            "he": "לירה לבנונית",
+            "hr": "Libanonska funta",
+            "hu": "libanoni font",
+            "it": "lira libanese",
+            "ja": "レバノン・ポンド",
+            "lt": "Libano svaras",
+            "nl": "Libanees pond",
+            "pl": "Funt libański",
+            "pt": "libra libanesa",
+            "ru": "ливанский фунт",
+            "sl": "Libanonski funt",
+            "sr": "либанска фунта",
+            "sv": "Libanesiskt pund",
+            "tr": "Lübnan lirası",
+            "uk": "Ліванський фунт",
+            "zh": "黎巴嫩鎊",
+            "cy": "punt Libanus",
+            "oc": "Liura libanesa"
+        },
+        "LKR": {
+            "ar": "روبية سريلانكية",
+            "bg": "Шриланкийска рупия",
+            "ca": "rupia de Sri Lanka",
+            "da": "Sri Lanka rupee",
+            "de": "Sri-Lanka-Rupie",
+            "en": "Sri Lankan rupee",
+            "eo": "srilanka rupio",
+            "es": "rupia esrilanquesa",
+            "eu": "Errupia srilankar",
+            "fa": "روپیه سریلانکا",
+            "fi": "Sri Lankan rupia",
+            "fr": "roupie srilankaise",
+            "gl": "Rupia de Sri Lanka",
+            "hr": "Šrilanska rupija",
+            "hu": "Srí Lanka-i rúpia",
+            "it": "rupia singalese",
+            "ja": "スリランカ・ルピー",
+            "lt": "Šri Lankos rupija",
+            "nl": "Sri Lankaanse roepie",
+            "pl": "Rupia lankijska",
+            "pt": "rúpia do Sri Lanka",
+            "ru": "Ланкийская рупия",
+            "sr": "шриланчанска рупија",
+            "sv": "Lankesisk rupee",
+            "ta": "இலங்கை ரூபாய்",
+            "tr": "Sri Lanka rupisi",
+            "uk": "ланкійська рупія",
+            "vi": "Rupee Sri Lanka",
+            "zh": "斯里蘭卡盧比",
+            "cy": "Rupee Sri Lanca"
+        },
+        "LRD": {
+            "ar": "دولار ليبيري",
+            "bg": "Либерийски долар",
+            "ca": "dòlar liberià",
+            "cs": "liberijský dolar",
+            "da": "Liberiansk dollar",
+            "de": "Liberianischer Dollar",
+            "el": "Δολάριο Λιβερίας",
+            "en": "Liberian dollar",
+            "eo": "liberia dolaro",
+            "es": "Dólar liberiano",
+            "fa": "دلار لیبریا",
+            "fi": "Liberian dollari",
+            "fr": "dollar libérien",
+            "gl": "Dólar liberiano",
+            "he": "דולר ליברי",
+            "hr": "Liberijski dolar",
+            "hu": "Libériai dollár",
+            "it": "Dollaro liberiano",
+            "ja": "リベリア・ドル",
+            "lt": "Liberijos doleris",
+            "nl": "Liberiaanse dollar",
+            "pl": "Dolar liberyjski",
+            "pt": "Dólar liberiano",
+            "ru": "Либерийский доллар",
+            "sr": "либеријски долар",
+            "sv": "Liberiansk dollar",
+            "tr": "Liberya doları",
+            "uk": "Ліберійський долар",
+            "zh": "賴比瑞亞元",
+            "oc": "Dolar liberian"
+        },
+        "LSL": {
+            "ar": "لوتي ليسوتو",
+            "ca": "loti",
+            "cs": "Lesothský loti",
+            "cy": "Maloti",
+            "da": "Loti",
+            "de": "Lesothischer Loti",
+            "el": "Λότι",
+            "en": "Lesotho loti",
+            "eo": "lesota lotio",
+            "es": "Loti",
+            "fa": "لوتی لسوتو",
+            "fi": "Lesothon loti",
+            "fr": "Loti",
+            "gl": "Loti",
+            "hr": "Lesotski loti",
+            "hu": "Lesothói loti",
+            "it": "Loti lesothiano",
+            "ja": "ロチ",
+            "lt": "Loti",
+            "nl": "Lesothaanse loti",
+            "pl": "Loti",
+            "pt": "Loti",
+            "ru": "Лоти Лесото",
+            "sr": "лесотски лоти",
+            "sv": "Loti",
+            "tr": "Loti",
+            "uk": "Лоті",
+            "zh": "賴索托洛蒂"
+        },
+        "LYD": {
+            "ar": "دينار ليبي",
+            "bg": "Либийски динар",
+            "ca": "dinar libi",
+            "cs": "Libyjský dinár",
+            "cy": "Dinar Libya",
+            "da": "Libyske dinarer",
+            "de": "libyscher Dinar",
+            "el": "Δηνάριο Λιβύης",
+            "en": "Libyan dinar",
+            "eo": "libia dinaro",
+            "es": "dinar libio",
+            "fa": "دینار لیبی",
+            "fi": "Libyan dinaari",
+            "fr": "dinar libyen",
+            "he": "דינר לובי ",
+            "hr": "Libijski dinar",
+            "hu": "Líbiai dinár",
+            "it": "dinaro libico",
+            "ja": "リビア・ディナール",
+            "lt": "Libijos dinaras",
+            "nl": "Libische dinar",
+            "pl": "Dinar libijski",
+            "pt": "dinar líbio",
+            "ru": "ливийский динар",
+            "sr": "либијски динар",
+            "sv": "Libysk dinar",
+            "tr": "Libya dinarı",
+            "uk": "Лівійський динар",
+            "zh": "利比亞第納爾",
+            "oc": "Dinar libian"
+        },
+        "MAD": {
+            "ar": "درهم مغربي",
+            "bg": "Марокански дирхам",
+            "ca": "dírham marroquí",
+            "cs": "Marocký dirham",
+            "cy": "Dirham Moroco",
+            "de": "Marokkanischer Dirham",
+            "el": "Ντιρχάμ Μαρόκου",
+            "en": "Moroccan dirham",
+            "eo": "maroka dirhamo",
+            "es": "dírham marroquí",
+            "eu": "Marokoar dirham",
+            "fa": "درهم مراکش",
+            "fi": "Marokon dirhami",
+            "fr": "Dirham marocain",
+            "gl": "Dirham",
+            "he": "דירהם מרוקני",
+            "hr": "Marokanski dirham",
+            "hu": "Marokkói dirham",
+            "it": "Dirham marocchino",
+            "ja": "モロッコ・ディルハム",
+            "lt": "Maroko dirhamas",
+            "nl": "Marokkaanse dirham",
+            "pl": "dirham marokański",
+            "pt": "Dirham marroquino",
+            "ro": "Dirham marocan",
+            "ru": "марокканский дирхам",
+            "sr": "марокански дирхам",
+            "sv": "Marockansk dirham",
+            "tr": "Fas dirhemi",
+            "uk": "Марокканський дирхам",
+            "zh": "摩洛哥迪尔汗",
+            "oc": "Dirham"
+        },
+        "MCF": {
+            "ar": "فرنك موناكو",
+            "bg": "Монаски франк",
+            "ca": "franc monegasc",
+            "cs": "Monacký frank",
+            "de": "monegassischer Franc",
+            "el": "Φράγκο του Μονακό",
+            "en": "Monegasque franc",
+            "es": "franco monegasco",
+            "fa": "فرانک موناکو",
+            "fr": "franc monégasque",
+            "hr": "Monegaški franak",
+            "it": "franco monegasco",
+            "ja": "モネガスク・フラン",
+            "lt": "Monako frankas",
+            "nl": "monegaskische frank",
+            "pl": "frank monakijski",
+            "pt": "franco monegasco",
+            "ro": "Franc monegasc",
+            "ru": "Монегасский франк",
+            "uk": "Франк Монако",
+            "zh": "摩納哥法郎",
+            "eo": "monaka franko",
+            "hu": "Monacói frank",
+            "ia": "franc monegasc"
+        },
+        "MDL": {
+            "ar": "ليو مولدوفي",
+            "bg": "Молдовска лея",
+            "ca": "leu moldau",
+            "cs": "moldavský lei",
+            "de": "moldauischer Leu",
+            "el": "Μολδαβικό Λέου",
+            "en": "Moldovan leu",
+            "eo": "moldava leo",
+            "es": "leu moldavo",
+            "et": "Moldova leu",
+            "fa": "لئوی مولداوی",
+            "fi": "Moldovan leu",
+            "fr": "leu moldave",
+            "he": "לאו מולדובני",
+            "hr": "moldavski lej",
+            "hu": "moldován lej",
+            "it": "leu moldavo",
+            "ja": "モルドバ・レウ",
+            "lt": "Moldavijos lėja",
+            "nl": "Moldavische leu",
+            "pl": "lej Mołdawii",
+            "pt": "leu moldávio",
+            "ro": "Leu moldovenesc",
+            "ru": "молдавский лей",
+            "sk": "Moldavský lei",
+            "sl": "Moldavski lej",
+            "sr": "молдавски леј",
+            "sv": "Moldavisk leu",
+            "ta": "மல்டோவிய லியு",
+            "tr": "Moldova leyi",
+            "uk": "Молдовський лей",
+            "zh": "摩爾多瓦列伊",
+            "ia": "leu moldave",
+            "oc": "Leu moldau"
+        },
+        "MGA": {
+            "ar": "أرياري مدغشقري",
+            "ca": "ariary",
+            "cs": "Malgašský ariary",
+            "da": "Ariary",
+            "de": "Ariary",
+            "el": "Αριάρι",
+            "en": "ariary",
+            "eo": "malagasa ariaro",
+            "es": "ariary",
+            "fa": "آریاری",
+            "fi": "Madagaskarin ariary",
+            "fr": "ariary",
+            "he": "אריארי",
+            "hr": "Malgaški arijari",
+            "hu": "Madagaszkári ariary",
+            "it": "ariary malgascio",
+            "ja": "マダガスカル・アリアリ",
+            "lt": "Madagaskaro ariaris",
+            "nl": "Malagassische ariary",
+            "pl": "Ariary",
+            "pt": "ariary malgaxe",
+            "ru": "малагасийский ариари",
+            "sr": "ариари",
+            "sv": "Ariary",
+            "tr": "Ariary",
+            "uk": "Малагасійський аріарі",
+            "zh": "馬達加斯加阿里亞里",
+            "oc": "Ariary"
+        },
+        "MKD": {
+            "ar": "دينار مقدوني",
+            "bg": "македонски денар",
+            "ca": "denar",
+            "cs": "Makedonský denár",
+            "da": "Makedonske denarer",
+            "de": "nordmazedonischer Denar",
+            "el": "Δηνάριο Βόρειας Μακεδονίας",
+            "en": "denar",
+            "eo": "makedona denaro",
+            "es": "denar macedonio",
+            "et": "Makedoonia denaar",
+            "fa": "دینار مقدونیه",
+            "fi": "Makedonian denaari",
+            "fr": "dinar macédonien",
+            "gl": "Dinar macedonio",
+            "he": "דינר מקדוני",
+            "hr": "Makedonski denar",
+            "hu": "macedón dénár",
+            "it": "Dinaro macedone",
+            "ja": "マケドニア・デナール",
+            "lt": "Makedonijos denaras",
+            "nl": "Noord-Macedonische denar",
+            "pl": "denar",
+            "pt": "dinar macedónio",
+            "ro": "Denar macedonean",
+            "ru": "македонский денар",
+            "sk": "Macedónsky denár",
+            "sl": "Makedonski denar",
+            "sr": "македонски денар",
+            "sv": "Makedonisk denar",
+            "ta": "மாசிடோனிய தெனார்",
+            "tr": "Makedon denarı",
+            "uk": "Македонський денар",
+            "vi": "Denar Bắc Macedonia",
+            "zh": "馬其頓代納爾",
+            "cy": "denar (Macedonia)",
+            "ia": "denar macedone"
+        },
+        "MMK": {
+            "ar": "كيات ميانماري",
+            "ca": "kyat",
+            "cs": "Myanmarský kyat",
+            "de": "Kyat",
+            "en": "kyat",
+            "eo": "birma kjato",
+            "es": "Kyat birmano",
+            "fa": "کیات",
+            "fi": "Myanmarin kyat",
+            "fr": "Kyat",
+            "hr": "Mijanmarski kjat",
+            "hu": "mianmari kjap",
+            "it": "Kyat birmano",
+            "ja": "チャット",
+            "lt": "Kijatas",
+            "nl": "Myanmarese kyat",
+            "pl": "Kiat",
+            "pt": "Quiate",
+            "ro": "Kyat",
+            "ru": "кьят",
+            "sr": "мјанмарски кјат",
+            "sv": "Kyat",
+            "tr": "Kyat",
+            "uk": "М'янмський к'ят",
+            "vi": "Kyat",
+            "zh": "缅元",
+            "oc": "Kyat"
+        },
+        "MNT": {
+            "ar": "توغروغ منغولي",
+            "bg": "монголски тугрик",
+            "ca": "tögrög",
+            "cs": "Tugrik",
+            "da": "Tugrik",
+            "de": "Tögrög",
+            "el": "Τουγκρίκ",
+            "en": "tugrik",
+            "eo": "mongola tugriko",
+            "es": "tugrik mongol",
+            "fa": "توگروگ",
+            "fi": "Mongolian tugrik",
+            "fr": "tugrik",
+            "gl": "Tugrik",
+            "he": "טוגרוג",
+            "hr": "Mongolski tugrik",
+            "hu": "mongol tugrik",
+            "it": "tugrik mongolo",
+            "ja": "トゥグルグ",
+            "lt": "Tugrikas",
+            "nl": "Mongoolse tugrik",
+            "pl": "tugrik",
+            "pt": "Tugrik",
+            "ru": "монгольский тугрик",
+            "sk": "Mongolský tugrik",
+            "sr": "монголски тугрик",
+            "sv": "Tögrög",
+            "tr": "Tögrög",
+            "uk": "Монгольський тугрик",
+            "vi": "Tögrög",
+            "zh": "蒙古图格里克",
+            "cy": "tögrög Mongolia"
+        },
+        "MOP": {
+            "ar": "باتاكا ماكاوية",
+            "ca": "pataca",
+            "cs": "Macajská pataca",
+            "de": "Macao-Pataca",
+            "el": "Πατάκα",
+            "en": "Macanese pataca",
+            "eo": "makaa patako",
+            "es": "pataca macaense",
+            "eu": "Pataca macautar",
+            "fa": "پاتاکای ماکانز",
+            "fi": "Macaon pataca",
+            "fr": "pataca",
+            "gl": "Pataca macaense",
+            "he": "פטקה",
+            "hr": "Makaonska pataka",
+            "hu": "Makaói pataca",
+            "it": "Pataca di Macao",
+            "ja": "マカオ・パタカ",
+            "lt": "Pataka",
+            "nl": "Macause pataca",
+            "pl": "Pataca",
+            "pt": "Pataca",
+            "ru": "патака Макао",
+            "sv": "Pataca",
+            "tr": "Pataka",
+            "uk": "Аоминська патака",
+            "vi": "Pataca Macau",
+            "zh": "澳門幣",
+            "sr": "макаонска патака"
+        },
+        "MRO": {
+            "fr": "Ouguiya",
+            "ca": "Ouguiya",
+            "cs": "Ouguiya",
+            "cy": "Ouguiya",
+            "da": "Ouguiya",
+            "de": "Ouguiya",
+            "en": "Ouguiya (1973-2017)",
+            "eo": "Ouguiya",
+            "es": "Ouguiya",
+            "et": "Ouguiya",
+            "eu": "Ouguiya",
+            "fi": "Ouguiya",
+            "gl": "Ouguiya",
+            "hr": "Ouguiya",
+            "hu": "Ouguiya (1973-2017)",
+            "ia": "Ouguiya",
+            "it": "Ouguiya",
+            "lt": "Ouguiya",
+            "nl": "Ouguiya",
+            "oc": "Ouguiya",
+            "pl": "Ouguiya",
+            "pt": "Ouguiya",
+            "ro": "Ouguiya",
+            "sk": "Ouguiya",
+            "sv": "Ouguiya (1973-2017)",
+            "tr": "Ouguiya",
+            "vi": "Ouguiya"
+        },
+        "MUR": {
+            "ar": "روبي موريشي",
+            "ca": "rupia de Maurici",
+            "cs": "Mauricijská rupie",
+            "da": "Mauritiske rupee",
+            "de": "Mauritius-Rupie",
+            "el": "Ρουπία του Μαυρίκιου",
+            "en": "Mauritian rupee",
+            "eo": "maŭricia rupio",
+            "es": "rupia mauricia",
+            "eu": "Errupia mauriziar",
+            "fa": "روپیه موریس",
+            "fi": "Mauritiuksen rupia",
+            "fr": "Roupie mauricienne",
+            "gl": "Rupia de Mauricio",
+            "hr": "Mauricijska rupija",
+            "hu": "Mauritiusi rúpia",
+            "it": "Rupia mauriziana",
+            "ja": "モーリシャス・ルピー",
+            "lt": "Mauricijaus rupija",
+            "nl": "Mauritiaanse roepie",
+            "pl": "Rupia Mauritiusu",
+            "pt": "Rupia mauriciana",
+            "ru": "Маврикийская рупия",
+            "sr": "маурицијска рупија",
+            "sv": "Mauritisk rupie",
+            "tr": "Mauritius rupisi",
+            "uk": "Маврикійська рупія",
+            "zh": "模里西斯盧比",
+            "he": "רופי מאוריציני",
+            "oc": "Ropia de Maurici"
+        },
+        "MVR": {
+            "ar": "روفيه مالديفية",
+            "bg": "Малдивска рупия",
+            "ca": "rupia de les Maldives",
+            "cs": "Maledivská rupie",
+            "da": "Rufiyaa",
+            "de": "Rufiyaa",
+            "el": "Ρουφίγια",
+            "en": "Maldivian rufiyaa",
+            "eo": "maldiva rufijao",
+            "es": "rupia maldiva",
+            "eu": "Errupia maldivar",
+            "fa": "روفیه مالدیو",
+            "fi": "Malediivien rufiyaa",
+            "fr": "Rufiyaa",
+            "hr": "Maldivska rufija",
+            "hu": "maldív-szigeteki rúfia",
+            "it": "rufiyaa delle Maldive",
+            "ja": "ルフィヤ",
+            "lt": "Maldyvų rufija",
+            "nl": "Maldivische rufiyaa",
+            "pl": "Rupia malediwska",
+            "pt": "Rupia maldívia",
+            "ru": "мальдивская руфия",
+            "sr": "малдивска руфија",
+            "sv": "Rufiyah",
+            "ta": "மாலத்தீவின் ருஃபியா",
+            "tr": "Rufiyaa",
+            "uk": "Мальдівська руфія",
+            "zh": "馬爾地夫拉菲亞",
+            "oc": "Rópia de las Maldivas"
+        },
+        "MWK": {
+            "ar": "كواشا ملاوية",
+            "ca": "kwacha malawià",
+            "cs": "malawiská kwacha",
+            "de": "Malawi-Kwacha",
+            "el": "Κουάτσα του Μαλάουι",
+            "en": "Malawian kwacha",
+            "eo": "malavia kvaĉo",
+            "es": "kwacha malauí",
+            "et": "Malawi kvatša",
+            "fa": "کواچا مالاویا",
+            "fi": "Malawin kwacha",
+            "fr": "Kwacha malawien",
+            "gl": "Kwacha de Malawi",
+            "hr": "Malavijska kvača",
+            "hu": "Malawi kwacha",
+            "it": "Kwacha malawiano",
+            "ja": "マラウイ・クワチャ",
+            "lt": "Malavio kvača",
+            "nl": "Malawische kwacha",
+            "pl": "Kwacha malawijska",
+            "pt": "Kwacha do Maláui",
+            "ru": "малавийская квача",
+            "sr": "малавијска квача",
+            "sv": "Malawisk kwacha",
+            "tr": "Malavi kwachası",
+            "uk": "Малавійська квача",
+            "zh": "馬拉威克瓦查"
+        },
+        "MXN": {
+            "ar": "بيزو مكسيكي",
+            "bg": "Мексиканско песо",
+            "ca": "peso mexicà",
+            "cs": "Mexické peso",
+            "de": "Mexikanischer Peso",
+            "el": "Μεξικάνικο πέσο",
+            "en": "Mexican peso",
+            "eo": "meksika peso",
+            "es": "peso mexicano",
+            "eu": "Mexikar peso",
+            "fa": "پزو مکزیک",
+            "fi": "Meksikon peso",
+            "fr": "peso mexicain",
+            "gl": "Peso mexicano",
+            "he": "פסו מקסיקני",
+            "hr": "Meksički pezo",
+            "hu": "mexikói peso",
+            "ia": "Peso mexican",
+            "it": "peso messicano",
+            "ja": "メキシコ・ペソ",
+            "lt": "Meksikos pesas",
+            "nl": "Mexicaanse peso",
+            "pl": "Peso meksykańskie",
+            "pt": "peso mexicano",
+            "ro": "Peso mexican",
+            "ru": "мексиканское песо",
+            "sr": "мексички пезос",
+            "sv": "Mexikansk peso",
+            "ta": "மெக்சிகோ பெசோ",
+            "tr": "Meksika pesosu",
+            "uk": "мексиканський песо",
+            "vi": "Peso Mexico",
+            "zh": "墨西哥比索",
+            "cy": "peso (Mecsico)",
+            "et": "Mehhiko peeso"
+        },
+        "MXV": {
+            "en": "Mexican unidad de inversión",
+            "es": "Unidades de Inversión",
+            "de": "UNIDAD DE INVERSION",
+            "ja": "メキシコ投資単位"
+        },
+        "MYR": {
+            "ar": "رينغيت ماليزي",
+            "bg": "Малайзийски рингит",
+            "ca": "ringgit",
+            "cs": "Malajsijský ringgit",
+            "de": "Ringgit",
+            "el": "Ρινγκίτ",
+            "en": "Malaysian ringgit",
+            "eo": "malajzia ringito",
+            "es": "ringgit",
+            "eu": "Ringgit",
+            "fa": "رینگیت",
+            "fi": "Malesian ringgit",
+            "fr": "ringgit",
+            "hr": "Malezijski ringit",
+            "hu": "maláj ringgit",
+            "it": "ringgit malaysiano",
+            "ja": "リンギット",
+            "lt": "Malaizijos ringitas",
+            "nl": "Maleisische ringgit",
+            "pl": "Ringgit",
+            "pt": "ringgit malaio",
+            "ro": "Ringgit",
+            "ru": "малайзийский ринггит",
+            "sr": "малезијски рингит",
+            "sv": "ringgit",
+            "ta": "மலேசிய ரிங்கிட்",
+            "tr": "Ringgit",
+            "uk": "малайзійський ринґіт",
+            "vi": "Ringgit",
+            "zh": "马來西亚令吉",
+            "he": "רינגיט מלזי"
+        },
+        "MZN": {
+            "ar": "متكال موزمبيقي",
+            "ca": "metical",
+            "cs": "Mosambický metical",
+            "da": "Metical",
+            "de": "Metical",
+            "el": "Μετικάλ",
+            "en": "Mozambican metical",
+            "eo": "mozambika metikalo",
+            "es": "Metical mozambiqueño",
+            "fa": "متیکال موزایکی",
+            "fi": "Mosambikin metical",
+            "fr": "Metical",
+            "gl": "Metical",
+            "hr": "Mozambijski metikal",
+            "hu": "Mozambiki metical",
+            "it": "Metical mozambicano",
+            "ja": "メティカル",
+            "lt": "Metikalis",
+            "nl": "Mozambikaanse metical",
+            "pl": "Metical",
+            "pt": "Metical",
+            "ru": "мозамбикский метикал",
+            "sr": "мозамбички метикал",
+            "sv": "Metical",
+            "tr": "Metical",
+            "uk": "Мозамбіцький метікал",
+            "zh": "莫三比克梅蒂卡爾",
+            "cy": "Metical Mosambic",
+            "he": "מטיקל מוזמביני"
+        },
+        "NAD": {
+            "ar": "دولار ناميبي",
+            "bg": "Намибийски долар",
+            "ca": "dòlar namibià",
+            "cs": "Namibijský dolar",
+            "da": "Namibisk dollar",
+            "de": "Namibia-Dollar",
+            "en": "Namibian dollar",
+            "eo": "namibia dolaro",
+            "es": "Dólar namibio",
+            "fa": "دلار نامیبیا",
+            "fi": "Namibian dollari",
+            "fr": "Dollar namibien",
+            "gl": "Dólar namibio",
+            "he": "דולר נמיבי",
+            "hr": "Namibijski dolar",
+            "hu": "Namíbiai dollár",
+            "it": "Dollaro namibiano",
+            "ja": "ナミビア・ドル",
+            "lt": "Namibijos doleris",
+            "nl": "Namibische dollar",
+            "oc": "Dolar namibian",
+            "pl": "Dolar namibijski",
+            "pt": "Dólar da Namíbia",
+            "ru": "доллар Намибии",
+            "sr": "намибијски долар",
+            "sv": "Namibisk dollar",
+            "tr": "Namibya doları",
+            "uk": "Намібійський долар",
+            "zh": "納米比亞元"
+        },
+        "NGN": {
+            "ar": "نيرة نيجيرية",
+            "ca": "naira",
+            "cs": "Nigerijská naira",
+            "de": "Naira",
+            "en": "Nigerian naira",
+            "eo": "niĝeria najro",
+            "es": "naira",
+            "fa": "نایرا نیجریه",
+            "fi": "Nigerian naira",
+            "fr": "Naira",
+            "gl": "Naira",
+            "he": "נאירה",
+            "hr": "Nigerijska naira",
+            "hu": "nigériai naira",
+            "it": "Naira nigeriana",
+            "ja": "ナイラ",
+            "lt": "Naira",
+            "nl": "Nigeriaanse naira",
+            "pl": "Naira",
+            "pt": "Naira",
+            "ru": "нигерийская найра",
+            "sk": "Naira",
+            "sr": "нигеријска наира",
+            "sv": "naira",
+            "tr": "Nijerya nairası",
+            "uk": "нігерійська найра",
+            "zh": "奈及利亞奈拉",
+            "oc": "Naira"
+        },
+        "NIO": {
+            "ar": "كوردبا نيكاراغوا",
+            "bg": "Никарагуанска кордоба",
+            "ca": "córdoba",
+            "cs": "Nikaragujská córdoba",
+            "de": "Córdoba Oro",
+            "el": "Κόρδοβα Νικαράγουας",
+            "en": "Nicaraguan córdoba",
+            "eo": "nikaragva kordovo",
+            "es": "córdoba",
+            "eu": "Córdoba",
+            "fa": "کوردوبا نیکاراگوئه",
+            "fi": "Nicaraguan córdoba",
+            "fr": "Córdoba",
+            "gl": "Córdoba",
+            "he": "קורדובה",
+            "hr": "Nikaragvanska kordoba",
+            "hu": "Nicaraguai córdoba",
+            "it": "Córdoba nicaraguense",
+            "ja": "ニカラグア・コルドバ",
+            "lt": "Nikaragvos kordoba",
+            "nl": "Nicaraguaanse córdoba",
+            "pl": "Cordoba oro",
+            "pt": "Córdoba (moeda)",
+            "ro": "Córdoba",
+            "ru": "никарагуанская кордоба",
+            "sr": "никарагванска кордоба",
+            "sv": "Córdoba",
+            "tr": "Kordoba",
+            "uk": "Нікарагуанська кордоба",
+            "zh": "尼加拉瓜科多巴",
+            "oc": "Córdoba (moneda)"
+        },
+        "NKD": {
+            "ar": "درام كراباخي",
+            "de": "Bergkarabach-Dram",
+            "en": "Nagorno-Karabakh dram",
+            "es": "dram de Artsaj",
+            "fa": "درام قرهباغ",
+            "fi": "Vuoristo-Karabahin dram",
+            "fr": "dram de l'Artsakh",
+            "gl": "Dram de Nagorno-Karabakh",
+            "hr": "Gorskokarabaški dram",
+            "hu": "Hegyi-karabahi dram",
+            "it": "dram karabakho",
+            "lt": "Karabacho dramas",
+            "ru": "карабахский драм",
+            "sv": "Nagorno-Karabach dram",
+            "tr": "Karabağ dramı",
+            "uk": "карабаський драм",
+            "zh": "阿尔察赫德拉姆",
+            "ca": "dram d'Artsakh",
+            "ja": "ナゴルノ・カラバフ・ドラム",
+            "nl": "Nagorno-Karabakh dram"
+        },
+        "NOK": {
+            "ar": "كرونة نروجية",
+            "bg": "Норвежка крона",
+            "ca": "corona noruega",
+            "cs": "Norská koruna",
+            "da": "Norske kroner",
+            "de": "norwegische Krone",
+            "el": "Κορόνα Νορβηγίας",
+            "en": "Norwegian krone",
+            "eo": "norvega krono",
+            "es": "corona noruega",
+            "et": "Norra kroon",
+            "eu": "Norvegiar koroa",
+            "fa": "کرون نروژ",
+            "fi": "Norjan kruunu",
+            "fr": "couronne norvégienne",
+            "gl": "Coroa norueguesa",
+            "he": "כתר נורווגי",
+            "hr": "Norveška kruna",
+            "hu": "norvég korona",
+            "it": "corona norvegese",
+            "ja": "ノルウェー・クローネ",
+            "lt": "Norvegijos krona",
+            "nl": "Noorse kroon",
+            "pl": "Korona norweska",
+            "pt": "coroa norueguesa",
+            "ro": "Coroană norvegiană",
+            "ru": "норвежская крона",
+            "sk": "Nórska koruna",
+            "sl": "Norveška krona",
+            "sr": "норвешка круна",
+            "sv": "norsk krona",
+            "ta": "நார்வே குரோனா",
+            "tr": "Norveç kronu",
+            "uk": "норвезька крона",
+            "vi": "Krone Na Uy",
+            "zh": "挪威克朗",
+            "ia": "corona norvegian",
+            "oc": "corona norvegiana"
+        },
+        "NPR": {
+            "ar": "روبي نيبالي",
+            "bg": "Непалска рупия",
+            "ca": "rupia nepalesa",
+            "cs": "Nepálská rupie",
+            "da": "Nepalesiske rupee",
+            "de": "Nepalesische Rupie",
+            "el": "Ρουπία Νεπάλ",
+            "en": "Nepalese rupee",
+            "eo": "nepala rupio",
+            "es": "rupia nepalí",
+            "et": "Nepali ruupia",
+            "eu": "Errupia nepaldar",
+            "fa": "روپیه نپال",
+            "fi": "Nepalin rupia",
+            "fr": "Roupie népalaise",
+            "gl": "Rupia nepalesa",
+            "he": "רופי נפאלי",
+            "hr": "Nepalska rupija",
+            "hu": "nepáli rúpia",
+            "it": "Rupia nepalese",
+            "ja": "ネパール・ルピー",
+            "lt": "Nepalo rupija",
+            "nl": "Nepalese roepie",
+            "pl": "Rupia nepalska",
+            "pt": "Rupia nepalesa",
+            "ru": "непальская рупия",
+            "sr": "непалска рупија",
+            "sv": "Nepalesisk rupee",
+            "ta": "நேபாள ரூபாய்",
+            "tr": "Nepal rupisi",
+            "uk": "Непальська рупія",
+            "vi": "Rupee Nepal",
+            "zh": "尼泊尔卢比"
+        },
+        "NUD": {
+            "en": "Niue dollar",
+            "fa": "دلار نیوئه",
+            "fi": "Niuen dollari",
+            "ru": "доллар Ниуэ",
+            "zh": "纽埃元",
+            "sr": "нијујски долар"
+        },
+        "NZD": {
+            "ar": "دولار نيوزيلندي",
+            "bg": "Новозеландски долар",
+            "ca": "dòlar neozelandès",
+            "cs": "Novozélandský dolar",
+            "da": "Newzealandske dollar",
+            "de": "Neuseeland-Dollar",
+            "el": "Δολάριο Νέας Ζηλανδίας",
+            "en": "New Zealand dollar",
+            "eo": "nov-zelanda dolaro",
+            "es": "dólar neozelandés",
+            "eu": "Zeelandaberritar dolar",
+            "fa": "دلار نیوزیلند",
+            "fi": "Uuden-Seelannin dollari",
+            "fr": "dollar néo-zélandais",
+            "gl": "Dólar neozelandés",
+            "he": "דולר ניו זילנדי",
+            "hr": "Novozelandski dolar",
+            "hu": "új-zélandi dollár",
+            "it": "dollaro neozelandese",
+            "ja": "ニュージーランド・ドル",
+            "lt": "Naujosios Zelandijos doleris",
+            "nl": "Nieuw-Zeelandse dollar",
+            "pl": "Dolar nowozelandzki",
+            "pt": "dólar neozelandês",
+            "ro": "Dolar neozeelandez",
+            "ru": "новозеландский доллар",
+            "sk": "Novozélandský dolár",
+            "sr": "новозеландски долар",
+            "sv": "Nyzeeländsk dollar",
+            "tr": "Yeni Zelanda doları",
+            "uk": "Новозеландський долар",
+            "vi": "Đô la New Zealand",
+            "zh": "紐西蘭元",
+            "oc": "Dolar neozelandés"
+        },
+        "OMR": {
+            "ar": "ريال عماني",
+            "bg": "Омански риял",
+            "ca": "rial omanita",
+            "cs": "Ománský rial",
+            "da": "Omansk rial",
+            "de": "Omanischer Rial",
+            "el": "Ριάλ του Ομάν",
+            "en": "Omani rial",
+            "eo": "omana rialo",
+            "es": "Rial omaní",
+            "fa": "ریال عمان",
+            "fi": "Omanin rial",
+            "fr": "Rial omanais",
+            "he": "ריאל עומאני",
+            "hr": "Omanski rijal",
+            "hu": "Ománi riál",
+            "it": "Riyal dell'Oman",
+            "ja": "オマーン・リアル",
+            "lt": "Omano rialas",
+            "nl": "Omaanse rial",
+            "pl": "Rial omański",
+            "pt": "Rial omanense",
+            "ru": "оманский риал",
+            "sr": "омански ријал",
+            "sv": "Omansk rial",
+            "ta": "ஓமானி ரியால்",
+            "tr": "Umman riyali",
+            "uk": "Оманський ріал",
+            "zh": "阿曼里亞爾"
+        },
+        "PAB": {
+            "ar": "بالبوا بنمي",
+            "bg": "Панамска балбоа",
+            "ca": "balboa",
+            "cs": "Panamská balboa",
+            "de": "Panamaischer Balboa",
+            "el": "Μπαλμπόα Παναμά",
+            "en": "Panamanian balboa",
+            "eo": "panama balboo",
+            "es": "Balboa",
+            "eu": "Balboa",
+            "fa": "بالبوآ پاناما",
+            "fi": "Panaman balboa",
+            "fr": "Balboa",
+            "gl": "Balboa",
+            "he": "בלבואה",
+            "hr": "Panamska balboa",
+            "hu": "Panamai balboa",
+            "it": "Balboa panamense",
+            "ja": "バルボア",
+            "lt": "Balboa",
+            "nl": "Panamese balboa",
+            "pl": "Balboa",
+            "pt": "Balboa",
+            "ru": "панамский бальбоа",
+            "sr": "панамска балбоа",
+            "sv": "Balboa",
+            "tr": "Panama balboası",
+            "uk": "Панамське бальбоа",
+            "zh": "巴拿馬巴波亞"
+        },
+        "PEN": {
+            "ar": "سول بيروفي جديد",
+            "ca": "sol",
+            "cs": "Peruánský sol",
+            "da": "Nuevo sol",
+            "de": "Nuevo Sol",
+            "el": "Νέο Σολ Περού",
+            "en": "Peruvian sol",
+            "eo": "perua nova suno",
+            "es": "sol soleno",
+            "eu": "Sol",
+            "fa": "سل جدید پرو",
+            "fi": "Perun nuevo sol",
+            "fr": "nouveau sol",
+            "gl": "Nuevo sol",
+            "he": "סול",
+            "hr": "Peruanski novi sol",
+            "hu": "perui új sol",
+            "it": "Nuevo Sol peruviano",
+            "ja": "ヌエボ・ソル",
+            "lt": "Naujasis solis",
+            "nl": "Peruviaanse sol",
+            "pl": "Sol",
+            "pt": "Sol novo",
+            "ru": "перуанский новый соль",
+            "sr": "перуански нови сол",
+            "sv": "Nuevo sol",
+            "tr": "Nuevo Sol",
+            "uk": "Новий соль",
+            "vi": "Sol Peru",
+            "zh": "秘魯新索爾",
+            "oc": "Nuevo Sol"
+        },
+        "PGK": {
+            "ar": "كينا بابوا غينيا الجديدة",
+            "bg": "Кина на Папуа Нова Гвинея",
+            "ca": "kina",
+            "cs": "Papuánská kina",
+            "da": "Kina",
+            "de": "Kina",
+            "el": "Κίνα Παπούα-Νέας Γουινέας",
+            "en": "kina",
+            "eo": "papuonovgvinea kinao",
+            "es": "Kina",
+            "fa": "کینای پاپوآ گینه نو",
+            "fi": "Papua-Uuden-Guinean kina",
+            "fr": "Kina",
+            "gl": "Kina",
+            "hr": "Papuanska kina",
+            "hu": "Pápua új-guineai kina",
+            "it": "Kina papuana",
+            "ja": "キナ",
+            "lt": "Kina",
+            "nl": "Papoea-Nieuw-Guinese kina",
+            "pl": "Kina",
+            "pt": "Kina",
+            "ro": "Kina",
+            "ru": "Кина",
+            "sr": "папуанска кина",
+            "sv": "Kina",
+            "tr": "Papua Yeni Gine kinası",
+            "uk": "Кіна",
+            "vi": "Kina Papua New Guinea",
+            "zh": "巴布亞紐幾內亞基那",
+            "he": "קינה"
+        },
+        "PHP": {
+            "ar": "بيسو فلبيني",
+            "bg": "Филипинско песо",
+            "ca": "peso filipí",
+            "cs": "Filipínské peso",
+            "de": "philippinischer Peso",
+            "el": "Πέσο Φιλιππίνων",
+            "en": "Philippine peso",
+            "eo": "filipina peso",
+            "es": "peso filipino",
+            "fa": "پزو فیلیپین",
+            "fi": "Filippiinien peso",
+            "fr": "peso philippin",
+            "he": "פסו פיליפיני",
+            "hr": "Filipinski pezo",
+            "hu": "Fülöp-szigeteki peso",
+            "it": "peso filippino",
+            "ja": "フィリピン・ペソ",
+            "lt": "Filipinų pesas",
+            "nl": "Filipijnse peso",
+            "pl": "Peso filipińskie",
+            "pt": "peso filipino",
+            "ru": "филиппинское песо",
+            "sk": "Filipínske peso",
+            "sr": "филипински пезо",
+            "sv": "Filippinsk peso",
+            "ta": "பிலிப்பைன் பெசோ",
+            "tr": "Filipinler pesosu",
+            "uk": "філіппінський песо",
+            "vi": "peso Philippines",
+            "zh": "菲律賓披索",
+            "oc": "Peso de las Filipinas"
+        },
+        "PKR": {
+            "ar": "روبية باكستانية",
+            "bg": "Пакистанска рупия",
+            "ca": "rupia pakistanesa",
+            "cs": "Pákistánská rupie",
+            "da": "Pakistanske rupee",
+            "de": "pakistanische Rupie",
+            "el": "Πακιστανική ρουπία",
+            "en": "Pakistani rupee",
+            "eo": "pakistana rupio",
+            "es": "rupia pakistaní",
+            "eu": "Errupia pakistandar",
+            "fa": "روپیه پاکستان",
+            "fi": "Pakistanin rupia",
+            "fr": "roupie pakistanaise",
+            "hr": "Pakistanska rupija",
+            "hu": "pakisztáni rúpia",
+            "it": "rupia pakistana",
+            "ja": "パキスタン・ルピー",
+            "lt": "Pakistano rupija",
+            "nl": "Pakistaanse roepie",
+            "oc": "Ropia de Paquistan",
+            "pl": "rupia pakistańska",
+            "pt": "Rupia do Paquistão",
+            "ru": "пакистанская рупия",
+            "sr": "пакистанска рупија",
+            "sv": "Pakistansk rupee",
+            "ta": "பாக்கித்தானிய ரூபாய்",
+            "tr": "Pakistan rupisi",
+            "uk": "пакистанська рупія",
+            "vi": "Rupee Pakistan",
+            "zh": "巴基斯坦盧比",
+            "he": "רופי פקיסטני "
+        },
+        "PLN": {
+            "ar": "زلوتي بولندي",
+            "bg": "Полска злотаПолска злота",
+            "ca": "złoty",
+            "cs": "zlotý",
+            "da": "Zloty",
+            "de": "Złoty",
+            "el": "Ζλότι",
+            "en": "złoty",
+            "eo": "pola zloto",
+            "es": "złoty",
+            "et": "Poola zlott",
+            "eu": "Złoty",
+            "fa": "زلوتی",
+            "fi": "Puolan złoty",
+            "fr": "złoty",
+            "gl": "Złoty",
+            "he": "זלוטי",
+            "hr": "Poljski zlot",
+            "hu": "lengyel złoty",
+            "it": "złoty polacco",
+            "ja": "ズウォティ",
+            "lt": "Zlotas",
+            "nl": "Poolse złoty",
+            "pl": "złoty",
+            "pt": "złoty",
+            "ro": "Zlot polonez",
+            "ru": "польский злотый",
+            "sk": "Poľský zlotý",
+            "sr": "пољски злот",
+            "sv": "Złoty",
+            "ta": "ஸ்வாட்டெ",
+            "tr": "Złoty",
+            "uk": "злотий",
+            "vi": "Złoty Ba Lan",
+            "zh": "波兰兹罗提",
+            "ia": "zloty polonese",
+            "oc": "złoty"
+        },
+        "PND": {
+            "en": "Pitcairn Islands dollar",
+            "fa": "دلار جزایر پیتکارین",
+            "fi": "Pitcairnin dollari",
+            "ru": "доллар Островов Питкэрн",
+            "ca": "dòlar de les illes Pitcairn",
+            "zh": "皮特凱恩群島元"
+        },
+        "PRB": {
+            "ar": "روبل ترانسنيستري",
+            "bg": "Приднестровска рубла",
+            "ca": "ruble de Transnístria",
+            "cs": "Podněsterský rubl",
+            "de": "transnistrischer Rubel",
+            "en": "Transnistrian ruble",
+            "eo": "Ĉednestria rublo",
+            "es": "rublo transnistrio",
+            "fa": "روبل ترانسنیسترین",
+            "fi": "Transnistrian rupla",
+            "fr": "rouble de Transnistrie",
+            "gl": "Rublo de Transnistria",
+            "he": "רובל טרנסדנייסטרי",
+            "hr": "Pridnjestrovska rublja",
+            "hu": "Dnyeszter menti rubel",
+            "it": "rublo transnistriano",
+            "ja": "沿ドニエストル・ルーブル",
+            "lt": "Padniestrės rublis",
+            "nl": "Transnistrische roebel",
+            "pl": "Rubel naddniestrzański",
+            "pt": "Rublo transnístrio",
+            "ro": "Rublă transnistreană",
+            "ru": "приднестровский рубль",
+            "sk": "Podnesterský rubeľ",
+            "sr": "придњестарска рубља",
+            "sv": "Transnistrisk rubel",
+            "tr": "Transdinyester rublesi",
+            "uk": "придністровський рубль",
+            "zh": "德涅斯特河沿岸盧布"
+        },
+        "PYG": {
+            "ar": "غواراني باراغواي",
+            "ca": "guaraní",
+            "cs": "Paraguayský guaraní",
+            "de": "Paraguayischer Guaraní",
+            "el": "Γκουαρανί",
+            "en": "Paraguayan guaraní",
+            "eo": "paragvaja gvaranio",
+            "es": "guaraní",
+            "eu": "Guarani",
+            "fa": "گوارانی پاراگوئه",
+            "fi": "Paraguayn guaraní",
+            "fr": "Guaraní",
+            "gl": "Guaraní",
+            "hr": "Paragvajski gvarani",
+            "hu": "Paraguayi guaraní",
+            "it": "guaraní paraguaiano",
+            "ja": "グアラニー",
+            "lt": "Gvaranis",
+            "nl": "Paraguayaanse guaraní",
+            "pl": "Guarani",
+            "pt": "Guarani",
+            "ru": "парагвайский гуарани",
+            "sk": "Guarani",
+            "sr": "парагвајски гварани",
+            "sv": "Guarani",
+            "tr": "Paraguay guaranísi",
+            "uk": "Парагвайський гуарані",
+            "zh": "巴拉圭瓜拉尼",
+            "oc": "Guaraní"
+        },
+        "QAR": {
+            "ar": "ريال قطري",
+            "bg": "Катарски риал",
+            "ca": "riyal de Qatar",
+            "de": "Katar-Riyal",
+            "el": "Ριγιάλ του Κατάρ",
+            "en": "Qatari riyal",
+            "eo": "katara rialo",
+            "es": "riyal catarí",
+            "fa": "ریال قطر",
+            "fi": "Qatarin rial",
+            "fr": "Riyal qatarien",
+            "he": "ריאל קטרי",
+            "hr": "Katarski rijal",
+            "hu": "katari riál",
+            "it": "riyal del Qatar",
+            "ja": "カタール・リヤル",
+            "lt": "Kataro rialas",
+            "nl": "Qatarese rial",
+            "pl": "Rial Kataru",
+            "pt": "Rial catarense",
+            "ru": "катарский риал",
+            "sr": "катарски ријал",
+            "sv": "Qatarisk rial",
+            "ta": "கத்தாரி ரியால்",
+            "tr": "Katar riyali",
+            "uk": "Катарський ріал",
+            "vi": "Riyal Qatar",
+            "zh": "卡達里亞爾"
+        },
+        "RON": {
+            "ar": "ليو روماني",
+            "bg": "Румънска лея",
+            "ca": "leu romanès",
+            "cs": "rumunský lei",
+            "da": "Leu",
+            "de": "rumänischer Leu",
+            "el": "Λέι",
+            "en": "Romanian leu",
+            "eo": "rumana leo",
+            "es": "leu rumano",
+            "et": "Rumeenia leu",
+            "fa": "لئوی رومانی",
+            "fi": "Romanian leu",
+            "fr": "leu roumain",
+            "gl": "Leu romanés",
+            "he": "לאו רומני",
+            "hr": "Rumunjski lej",
+            "hu": "román lej",
+            "it": "leu romeno",
+            "ja": "ルーマニア・レウ",
+            "lt": "Naujoji Rumunijos lėja",
+            "nl": "Roemeense leu",
+            "oc": "Leu romanés",
+            "pl": "Lej rumuński",
+            "pt": "leu romeno",
+            "ro": "leu românesc",
+            "ru": "румынский лей",
+            "sk": "Nový rumunský lei",
+            "sl": "Romunski lej",
+            "sr": "румунски леј",
+            "sv": "Rumänsk leu",
+            "ta": "ரொமேனிய லியு",
+            "tr": "Rumen leyi",
+            "uk": "румунський лей",
+            "vi": "Leu România",
+            "zh": "罗马尼亚列伊",
+            "ia": "leu romanian"
+        },
+        "RSD": {
+            "ar": "دينار صربي",
+            "bg": "Сръбски динар",
+            "ca": "dinar serbi",
+            "cs": "Srbský dinár",
+            "da": "Serbiske dinarer",
+            "de": "serbischer Dinar",
+            "el": "Δηνάριο Σερβίας",
+            "en": "Serbian dinar",
+            "eo": "serba dinaro",
+            "es": "dinar serbio",
+            "et": "Serbia dinaar",
+            "eu": "Serbiar dinar",
+            "fa": "دینار صربی",
+            "fi": "Serbian dinaari",
+            "fr": "dinar serbe",
+            "gl": "Dinar serbio",
+            "he": "דינר סרבי",
+            "hr": "Srpski dinar",
+            "hu": "szerb dinár",
+            "it": "dinaro serbo",
+            "ja": "セルビア・ディナール",
+            "lt": "Serbijos dinaras",
+            "nl": "Servische dinar",
+            "pl": "Dinar serbski",
+            "pt": "dinar sérvio",
+            "ro": "Dinar sârbesc",
+            "ru": "сербский динар",
+            "sk": "Srbský dinár",
+            "sl": "Srbski dinar",
+            "sr": "српски динар",
+            "sv": "Serbisk dinar",
+            "ta": "செர்பிய தினார்",
+            "tr": "Sırp dinarı",
+            "uk": "Сербський динар",
+            "zh": "塞爾維亞第納爾",
+            "cy": "dinar (Serbia)",
+            "ia": "dinar serbe"
+        },
+        "RUB": {
+            "ar": "روبل روسي",
+            "bg": "Руска рубла",
+            "ca": "ruble rus",
+            "cs": "ruský rubl",
+            "cy": "Rŵbl Rwsiaidd",
+            "da": "Russiske rubler",
+            "de": "russischer Rubel",
+            "el": "Ρούβλι Ρωσίας",
+            "en": "Russian ruble",
+            "eo": "rusa rublo",
+            "es": "rublo ruso",
+            "et": "Venemaa rubla",
+            "eu": "Errusiar errublo",
+            "fa": "روبل روسیه",
+            "fi": "Venäjän rupla",
+            "fr": "rouble russe",
+            "gl": "Rublo ruso",
+            "he": "רובל רוסי",
+            "hr": "Ruska rublja",
+            "hu": "orosz rubel",
+            "it": "rublo russo",
+            "ja": "ロシア・ルーブル",
+            "lt": "Rusijos rublis",
+            "nl": "Russische roebel",
+            "pl": "rubel rosyjski",
+            "pt": "rublo russo",
+            "ro": "Rublă rusă",
+            "ru": "российский рубль",
+            "sk": "Ruský rubeľ",
+            "sr": "руска рубља",
+            "sv": "rysk rubel",
+            "ta": "உருசிய ரூபிள்",
+            "tr": "Rus rublesi",
+            "uk": "російський рубль",
+            "vi": "Rúp Nga",
+            "zh": "俄罗斯卢布",
+            "ia": "rublo russe",
+            "sl": "ruski rubelj"
+        },
+        "RWF": {
+            "ar": "فرنك رواندي",
+            "bg": "Руандийски франк",
+            "ca": "franc ruandès",
+            "cs": "Rwandský frank",
+            "da": "Rwandisk franc",
+            "de": "Ruanda-Franc",
+            "el": "Φράγκο της Ρουάντα",
+            "en": "Rwandan franc",
+            "eo": "ruanda franko",
+            "es": "franco ruandés",
+            "et": "Rwanda frank",
+            "fa": "فرانک رواندا",
+            "fi": "Ruandan frangi",
+            "fr": "franc rwandais",
+            "gl": "Franco ruandés",
+            "he": "פרנק רואנדי",
+            "hr": "Ruandski franak",
+            "hu": "Ruandai frank",
+            "it": "franco ruandese",
+            "ja": "ルワンダ・フラン",
+            "lt": "Ruandos frankas",
+            "nl": "Rwandese frank",
+            "pl": "frank rwandyjski",
+            "pt": "franco ruandês",
+            "ru": "руандийский франк",
+            "sr": "руандски франак",
+            "sv": "Rwandisk franc",
+            "tr": "Ruanda frangı",
+            "uk": "Руандійський франк",
+            "zh": "卢旺达法郎"
+        },
+        "SAR": {
+            "ar": "ريال سعودي",
+            "bg": "Саудитски риал",
+            "ca": "riyal saudita",
+            "de": "Saudi-Rial",
+            "el": "Ριάλ Σαουδικής Αραβίας",
+            "en": "Saudi riyal",
+            "eo": "sauda rialo",
+            "es": "riyal saudí",
+            "et": "Saudi Araabia riaal",
+            "fa": "ریال سعودی",
+            "fi": "Saudi-Arabian rial",
+            "fr": "riyal saoudien",
+            "he": "ריאל סעודי",
+            "hr": "Saudijski rijal",
+            "hu": "szaúdi riál",
+            "it": "riyal saudita",
+            "ja": "サウジアラビア・リヤル",
+            "lt": "Saudo Arabijos rialas",
+            "nl": "Saoedi-Arabische riyal",
+            "pl": "Rial saudyjski",
+            "pt": "Riyal",
+            "ro": "Rial saudit",
+            "ru": "саудовский риял",
+            "sr": "саудијски ријал",
+            "sv": "Saudiarabisk rial",
+            "ta": "சவூதி ரியால்",
+            "tr": "Suudi Arabistan riyali",
+            "uk": "саудівський ріал",
+            "vi": "Riyal Ả Rập Xê Út",
+            "zh": "沙特阿拉伯里亚尔",
+            "oc": "rial saudian"
+        },
+        "SBD": {
+            "ar": "دولار جزر سليمان",
+            "bg": "Соломоновски долар",
+            "ca": "dòlar de Salomó",
+            "cs": "Dolar Šalomounových ostrovů",
+            "da": "Salomondollar",
+            "de": "Salomonen-Dollar",
+            "el": "Δολάριο Νήσων Σολομώντα",
+            "en": "Solomon Islands dollar",
+            "eo": "salomona dolaro",
+            "es": "dólar de las Islas Salomón",
+            "fa": "دلار جزایر سلیمان",
+            "fi": "Salomonsaarten dollari",
+            "fr": "dollar des îles Salomon",
+            "gl": "Dólar das Illas Salomón",
+            "he": "דולר איי שלמה",
+            "hr": "Salomonskootočni dolar",
+            "hu": "Salamon-szigeteki dollár",
+            "it": "dollaro delle Salomone",
+            "ja": "ソロモン諸島ドル",
+            "lt": "Saliamono salų doleris",
+            "nl": "Salomon-dollar",
+            "pl": "Dolar Wysp Salomona",
+            "pt": "Dólar das Ilhas Salomão",
+            "ro": "Dolar din Insulele Solomon",
+            "ru": "доллар Соломоновых Островов",
+            "sr": "соломонски долар",
+            "sv": "Salomondollar",
+            "tr": "Solomon Adaları doları",
+            "uk": "Долар Соломонових островів",
+            "zh": "所罗门群岛元",
+            "oc": "dolar de las Illas Salamon"
+        },
+        "SCR": {
+            "ar": "روبية سيشلية",
+            "bg": "Сейшелска рупия",
+            "ca": "rupia de les Seychelles",
+            "cs": "Seychelská rupie",
+            "da": "Seychellisk rupee",
+            "de": "Seychellen-Rupie",
+            "el": "Ρουπία Σεϋχελλών",
+            "en": "Seychellois rupee",
+            "eo": "sejŝela rupio",
+            "es": "rupia seychelense",
+            "et": "Seišelli ruupia",
+            "eu": "Errupia seychelletar",
+            "fa": "روپیه سیشل",
+            "fi": "Seychellien rupia",
+            "fr": "roupie seychelloise",
+            "hr": "Sejšelska rupija",
+            "hu": "Seychelle-i rúpia",
+            "it": "rupia delle Seychelles",
+            "ja": "セーシェル・ルピー",
+            "lt": "Seišelių rupija",
+            "nl": "Seychelse roepie",
+            "pl": "Rupia seszelska",
+            "pt": "rupia das Seicheles",
+            "ru": "сейшельская рупия",
+            "sr": "сејшелска рупија",
+            "sv": "Seychellisk rupee",
+            "tr": "Seyşeller rupisi",
+            "uk": "Сейшельська рупія",
+            "zh": "塞席爾盧比"
+        },
         "SDG": {
-            "fr": "Livre soudanaise", 
-            "en": "Sudanese pound", 
-            "nl": "Soedanees pond", 
-            "de": "Sudanesisches Pfund", 
-            "it": "Sterlina sudanese", 
-            "hu": "Szud\u00e1ni font", 
-            "es": "Libra sudanesa"
+            "ar": "جنيه سوداني",
+            "ca": "lliura sudanesa",
+            "cs": "Súdánská libra",
+            "de": "sudanesisches Pfund",
+            "el": "Λίρα του Σουδάν",
+            "en": "Sudanese pound",
+            "eo": "sudana pundo",
+            "es": "libra sudanesa",
+            "fa": "پوند سودان",
+            "fi": "Sudanin punta",
+            "fr": "livre soudanaise",
+            "hr": "Sudanska funta",
+            "hu": "Szudáni font",
+            "it": "sterlina sudanese",
+            "ja": "スーダン・ポンド",
+            "lt": "Sudano svaras",
+            "nl": "Soedanees pond",
+            "pl": "Funt sudański",
+            "pt": "Libra sudanesa",
+            "ro": "Liră sudaneză",
+            "ru": "суданский фунт",
+            "sr": "суданска фунта",
+            "sv": "Sudanesiskt pund",
+            "tr": "Sudan sterlini",
+            "uk": "Суданський фунт",
+            "zh": "蘇丹鎊",
+            "bg": "Суданска лира",
+            "he": "לירה סודאנית"
+        },
+        "SEK": {
+            "ar": "كرونة سويدية",
+            "bg": "Шведска крона",
+            "ca": "corona sueca",
+            "cs": "Švédská koruna",
+            "da": "Svenske kronor",
+            "de": "schwedische Krone",
+            "el": "Κορόνα Σουηδίας",
+            "en": "Swedish krona",
+            "eo": "sveda krono",
+            "es": "corona sueca",
+            "et": "Rootsi kroon",
+            "eu": "Suediar koroa",
+            "fa": "کرون سوئد",
+            "fi": "Ruotsin kruunu",
+            "fr": "couronne suédoise",
+            "gl": "Coroa sueca",
+            "he": "קרונה שוודית",
+            "hr": "Švedska kruna",
+            "hu": "svéd korona",
+            "it": "corona svedese",
+            "ja": "スウェーデン・クローナ",
+            "lt": "Švedijos krona",
+            "nl": "Zweedse kroon",
+            "pl": "Korona szwedzka",
+            "pt": "coroa sueca",
+            "ro": "Coroană suedeză",
+            "ru": "шведская крона",
+            "sk": "Švédska koruna",
+            "sl": "Švedska krona",
+            "sr": "шведска круна",
+            "sv": "svensk krona",
+            "ta": "சுவீடிய குரோனா",
+            "tr": "İsveç kronu",
+            "uk": "шведська крона",
+            "vi": "Krona Thụy Điển",
+            "zh": "瑞典克朗",
+            "cy": "krona",
+            "oc": "Corona"
+        },
+        "SGD": {
+            "ar": "دولار سنغافوري",
+            "bg": "Сингапурски долар",
+            "ca": "dòlar de Singapur",
+            "cs": "Singapurský dolar",
+            "da": "Singaporeanske dollar",
+            "de": "Singapur-Dollar",
+            "el": "Δολάριο Σιγκαπούρης",
+            "en": "Singapore dollar",
+            "eo": "singapura dolaro",
+            "es": "dólar de Singapur",
+            "eu": "Dolar singapurtar",
+            "fa": "دلار سنگاپور",
+            "fi": "Singaporen dollari",
+            "fr": "dollar de Singapour",
+            "gl": "Dólar de Singapur",
+            "he": "דולר סינגפורי",
+            "hr": "Singapurski dolar",
+            "hu": "szingapúri dollár",
+            "it": "dollaro di Singapore",
+            "ja": "シンガポールドル",
+            "lt": "Singapūro doleris",
+            "nl": "Singaporese dollar",
+            "pl": "Dolar singapurski",
+            "pt": "dólar de Singapura",
+            "ru": "сингапурский доллар",
+            "sr": "сингапурски долар",
+            "sv": "Singaporiansk dollar",
+            "ta": "சிங்கப்பூர் வெள்ளி",
+            "tr": "Singapur doları",
+            "uk": "сінгапурський долар",
+            "vi": "Đô la Singapore",
+            "zh": "新加坡元",
+            "oc": "Dolar de Singapor"
+        },
+        "SHP": {
+            "ar": "جنيه سانت هيليني",
+            "ca": "lliura de Santa Helena",
+            "cs": "Svatohelenská libra",
+            "de": "St.-Helena-Pfund",
+            "el": "Λίρα Αγίας Ελένης",
+            "en": "Saint Helena pound",
+            "eo": "sankthelena pundo",
+            "es": "libra de Santa Elena",
+            "fa": "پوند سنت هلن",
+            "fi": "Saint Helenan punta",
+            "fr": "livre de Sainte-Hélène",
+            "hr": "Svetohelenska funta",
+            "hu": "Szent Ilona-i font",
+            "it": "sterlina di Sant'Elena",
+            "ja": "セントヘレナ・ポンド",
+            "nl": "Sint-Heleens pond",
+            "pl": "Funt Świętej Heleny",
+            "pt": "libra de Santa Helena",
+            "ro": "Liră din Sfânta Elena",
+            "ru": "фунт Святой Елены",
+            "sv": "Sankthelenskt pund",
+            "tr": "Saint Helena sterlini",
+            "uk": "Фунт Святої Єлени",
+            "zh": "圣赫勒拿镑"
+        },
+        "SLL": {
+            "ar": "ليون سيراليوني",
+            "bg": "Леоне на Сиера Леоне",
+            "ca": "leone",
+            "cs": "sierraleonský leone",
+            "de": "Sierra-leonischer Leone",
+            "el": "Λεόνε της Σιέρα Λεόνε",
+            "en": "Sierra Leonean leone",
+            "eo": "sieraleona leono",
+            "es": "leone",
+            "fa": "لئون سیرالئون",
+            "fi": "Sierra Leonen leone",
+            "fr": "leone",
+            "gl": "Leone",
+            "he": "ליאון",
+            "hr": "Sijeraleonski leone",
+            "hu": "Sierra Leone-i leone",
+            "it": "leone sierraleonese",
+            "ja": "レオン (通貨)",
+            "lt": "Leonė",
+            "nl": "Sierra Leoonse leone",
+            "pl": "Leone",
+            "pt": "leone",
+            "ro": "Leone",
+            "ru": "леоне",
+            "sr": "сијералеонски леоне",
+            "sv": "Leone",
+            "tr": "Sierra Leone leonesi",
+            "uk": "Леоне",
+            "zh": "塞拉利昂利昂",
+            "oc": "Leone"
+        },
+        "SOS": {
+            "ar": "شلن صومالي",
+            "bg": "Сомалийски шилинг",
+            "ca": "xíling somali",
+            "cs": "Somálský šilink",
+            "da": "Somalisk shilling",
+            "de": "Somalia-Schilling",
+            "en": "Somali shilling",
+            "eo": "somalia ŝilingo",
+            "es": "chelín somalí",
+            "fa": "شیلینگ سومالی",
+            "fi": "Somalian šillinki",
+            "fr": "shilling somalien",
+            "he": "שילינג סומלי",
+            "hr": "Somalijski šiling",
+            "hu": "Szomáliai shilling",
+            "it": "scellino somalo",
+            "ja": "ソマリア・シリング",
+            "lt": "Somalio šilingas",
+            "nl": "Somalische shilling",
+            "pl": "Szyling somalijski",
+            "pt": "xelim somaliano",
+            "ru": "сомалийский шиллинг",
+            "sr": "сомалијски шилинг",
+            "sv": "Somalisk shilling",
+            "tr": "Somali şilini",
+            "uk": "сомалійський шилінг",
+            "zh": "索馬利亞先令",
+            "el": "Σελίνι της Σομαλίας"
+        },
+        "SRD": {
+            "ar": "دولار سورينامي",
+            "bg": "Суринамски долар",
+            "ca": "dòlar de Surinam",
+            "cs": "Surinamský dolar",
+            "de": "Suriname-Dollar",
+            "el": "Δολάριο Σουρινάμ",
+            "en": "Surinamese dollar",
+            "eo": "surinama dolaro",
+            "es": "Dólar surinamés",
+            "eu": "Dolar surinamdar",
+            "fa": "دلار سورینام",
+            "fi": "Surinamen dollari",
+            "fr": "Dollar du Surinam",
+            "gl": "Dólar surinamés",
+            "hr": "Surinamski dolar",
+            "hu": "suriname-i dollár",
+            "it": "Dollaro surinamese",
+            "ja": "スリナム・ドル",
+            "lt": "Surinamo doleris",
+            "nl": "Surinaamse dollar",
+            "pl": "Dolar surinamski",
+            "pt": "Dólar do Suriname",
+            "ru": "суринамский доллар",
+            "sr": "суринамски долар",
+            "sv": "Surinamesisk dollar",
+            "tr": "Surinam doları",
+            "uk": "Суринамський долар",
+            "zh": "蘇利南元"
+        },
+        "SSP": {
+            "ar": "جنيه جنوب سوداني",
+            "bg": "Южносудански паунд",
+            "ca": "lliura sud-sudanesa",
+            "cs": "Jihosúdánská libra",
+            "de": "südsudanesisches Pfund",
+            "en": "South Sudanese pound",
+            "es": "libra sursudanesa",
+            "et": "Lõuna-Sudaani nael",
+            "fa": "پوند سودان جنوبی",
+            "fi": "Etelä-Sudanin punta",
+            "fr": "livre sud-soudanaise",
+            "gl": "Libra sursudanesa",
+            "he": "לירה דרום סודאנית",
+            "hr": "Južnosudanska funta",
+            "hu": "Dél-szudáni font",
+            "it": "sterlina sudsudanese",
+            "ja": "南スーダン・ポンド",
+            "lt": "Pietų Sudano svaras",
+            "nl": "Zuid-Soedanees pond",
+            "pl": "Funt południowosudański",
+            "pt": "libra sul-sudanesa",
+            "ro": "Liră sud-sudaneză",
+            "ru": "южносуданский фунт",
+            "sk": "Juhosudánska libra",
+            "sr": "јужносуданска фунта",
+            "sv": "Sydsudanesiskt pund",
+            "uk": "Південносуданський фунт",
+            "vi": "Bảng Nam Sudan",
+            "zh": "南蘇丹鎊",
+            "eo": "sud-sudana pundo",
+            "oc": "liura sodanesa"
+        },
+        "STN": {
+            "ar": "دوبرا ساو تومي وبرينسيب",
+            "ca": "dobra",
+            "cs": "Svatotomášská dobra",
+            "da": "Dobra",
+            "de": "São-toméischer Dobra",
+            "el": "Ντόμπρα",
+            "en": "São Tomé and Príncipe dobra",
+            "eo": "saotomea dobro",
+            "es": "dobra santotomense",
+            "fa": "دبرای سائوتومه و پرینسیپ",
+            "fi": "São Tomén ja Príncipen dobra",
+            "fr": "dobra",
+            "gl": "Dobra",
+            "hr": "svetotomska dobra",
+            "hu": "São Tomé és Príncipe-i dobra",
+            "it": "dobra di São Tomé e Príncipe",
+            "ja": "ドブラ",
+            "lt": "Dobra",
+            "nl": "Santomese dobra",
+            "pl": "Dobra",
+            "pt": "dobra",
+            "ro": "Dobra",
+            "ru": "Добра Сан-Томе и Принсипи",
+            "sk": "Dobra",
+            "sr": "саотомска добра",
+            "sv": "Dobra",
+            "tr": "São Tomé ve Príncipe dobrası",
+            "uk": "Добра Сан-Томе і Принсіпі",
+            "zh": "圣多美和普林西比多布拉",
+            "he": "דוברה",
+            "oc": "Dobra"
+        },
+        "SYP": {
+            "ar": "ليرة سورية",
+            "bg": "Сирийска лира",
+            "ca": "lliura siriana",
+            "cs": "Syrská libra",
+            "de": "syrische Lira",
+            "el": "Λίρα Συρίας",
+            "en": "Syrian liyra",
+            "eo": "siria pundo",
+            "es": "Dolar sirio",
+            "fa": "لیره سوریه",
+            "fi": "Syyrian punta",
+            "fr": "livre syrienne",
+            "he": "לירה סורית",
+            "hr": "Sirijska funta",
+            "hu": "szír font",
+            "it": "lira siriana",
+            "ja": "シリア・ポンド",
+            "lt": "Sirijos svaras",
+            "nl": "Syrisch pond",
+            "pl": "Funt syryjski",
+            "pt": "libra síria",
+            "ru": "сирийский фунт",
+            "sl": "Sirski funt",
+            "sr": "сиријска фунта",
+            "sv": "Syriskt pund",
+            "tr": "Suriye lirası",
+            "uk": "Сирійський фунт",
+            "zh": "敘利亞鎊"
+        },
+        "SZL": {
+            "ar": "ليلانغيني سوازيلندي",
+            "ca": "lilangeni",
+            "cs": "Svazijský lilangeni",
+            "da": "Lilangeni",
+            "de": "Lilangeni",
+            "el": "Λιλανγκένι",
+            "en": "lilangeni",
+            "eo": "svazilanda lilangenio",
+            "es": "lilangeni",
+            "fa": "لیلانگنی سوازیلند",
+            "fi": "Lilangeni",
+            "fr": "lilangeni",
+            "gl": "Lilangeni",
+            "he": "לילנגני",
+            "hr": "Svazijski lilangeni",
+            "hu": "Szváziföldi lilangeni",
+            "it": "lilangeni dello Swaziland",
+            "ja": "リランゲニ",
+            "lt": "Lilangenis",
+            "nl": "Swazische lilangeni",
+            "pl": "Lilangeni",
+            "pt": "Lilangeni suázi",
+            "ru": "Свазилендский лилангени",
+            "sr": "свазилендски лилангени",
+            "sv": "Lilangeni",
+            "tr": "Lilangeni",
+            "uk": "Ліланджені",
+            "vi": "Lilangeni Swaziland",
+            "zh": "史瓦濟蘭里蘭吉尼",
+            "oc": "Lilangeni"
+        },
+        "THB": {
+            "ar": "بات تايلاندي",
+            "bg": "Тайландски бат",
+            "ca": "Baht",
+            "cs": "Thajský baht",
+            "cy": "Baht",
+            "da": "Thailandske baht",
+            "de": "Baht",
+            "el": "Μπατ",
+            "en": "baht",
+            "eo": "tajlanda bahto",
+            "es": "baht tailandés",
+            "et": "Baat",
+            "eu": "Thailandiar baht",
+            "fa": "بات",
+            "fi": "Baht",
+            "fr": "baht",
+            "gl": "Baht",
+            "he": "באט",
+            "hr": "Tajlandski baht",
+            "hu": "thai bát",
+            "it": "baht thailandese",
+            "ja": "バーツ",
+            "lt": "Tailando batas",
+            "nl": "Thaise baht",
+            "pl": "bat",
+            "pt": "baht",
+            "ru": "тайский бат",
+            "sk": "Thajský baht",
+            "sr": "тајландски бат",
+            "sv": "Baht",
+            "ta": "தாய்லாந்தின் பாட்",
+            "tr": "Baht",
+            "uk": "бат",
+            "vi": "Baht",
+            "zh": "泰銖"
+        },
+        "TJS": {
+            "ar": "ساماني طاجيكي",
+            "bg": "Таджикистански сомони",
+            "ca": "somoni",
+            "cs": "Tádžický somoni",
+            "cy": "Somoni",
+            "da": "Somoni",
+            "de": "Somoni",
+            "el": "Σομόνι",
+            "en": "Tajikistani somoni",
+            "eo": "taĝika somonio",
+            "es": "somoni tayiko",
+            "et": "Tadžikistani somoni",
+            "fa": "سامانی",
+            "fi": "Tadžikistanin somoni",
+            "fr": "somoni",
+            "gl": "somoni",
+            "hr": "Tadžikistanski somoni",
+            "hu": "tádzsik szomoni",
+            "it": "somoni tagico",
+            "ja": "ソモニ",
+            "lt": "Somonis",
+            "nl": "Tadzjiekse somoni",
+            "pl": "Somoni",
+            "pt": "Somoni",
+            "ro": "Somoni tadjic",
+            "ru": "таджикский сомони",
+            "sr": "таџикистански сомони",
+            "sv": "Somoni",
+            "tr": "Somoni",
+            "uk": "Таджицький сомоні",
+            "zh": "塔吉克索莫尼",
+            "he": "סומוני טג'קיסטני"
+        },
+        "TLD": {
+            "ar": "عملات سنتافو تيمورية شرقية",
+            "cs": "Východotimorské centavové mince",
+            "de": "Münzen Osttimors",
+            "en": "East Timor centavo coins",
+            "es": "centavo de dólar de Timor Oriental",
+            "fa": "سکه کنتاووی تیمور خاوری",
+            "he": "סנטאבו מזרח טימורי",
+            "hr": "Istočnotimorski sentavo",
+            "hu": "Kelet-timori centavoérmék",
+            "it": "Centavo est timorense",
+            "ja": "東ティモール・センターボ",
+            "pt": "moedas de centavo do Timor-Leste",
+            "ru": "тиморское сентаво",
+            "sk": "Východotimorské obehové mince",
+            "uk": "Східнотиморське сентаво",
+            "vi": "Centavo"
+        },
+        "TMT": {
+            "ar": "منات تركمانستاني",
+            "bg": "Туркменски манат",
+            "ca": "manat turcman",
+            "cs": "Turkmenský manat",
+            "de": "Turkmenistan-Manat",
+            "el": "Μανάτ του Τουρκμενιστάν",
+            "en": "Turkmenistan manat",
+            "eo": "turkmena manato",
+            "es": "manat turkmeno",
+            "fa": "منات ترکمنستان",
+            "fi": "Turkmenistanin manat",
+            "fr": "Manat turkmène",
+            "gl": "Manat turcomán",
+            "hr": "Turkmenistanski manat",
+            "hu": "Türkmén manat",
+            "it": "Manat turkmeno",
+            "ja": "トルクメニスタン・マナト",
+            "lt": "Turkmėnijos manatas",
+            "nl": "Turkmeense manat",
+            "pl": "Manat turkmeński",
+            "pt": "Manate do Turcomenistão",
+            "ro": "Manat turkmen",
+            "ru": "туркменский манат",
+            "sk": "Turkménsky manat",
+            "sr": "туркменистански манат",
+            "sv": "Turkmenistansk manat",
+            "tr": "Türkmenistan manatı",
+            "uk": "Туркменський манат",
+            "zh": "土庫曼馬納特",
+            "oc": "manat turcmèn"
+        },
+        "TND": {
+            "ar": "دينار تونسي",
+            "bg": "Тунизийски динар",
+            "ca": "dinar tunisià",
+            "cs": "tuniský dinár",
+            "cy": "Dinar Tunisiaidd",
+            "de": "tunesischer Dinar",
+            "en": "Tunisian dinar",
+            "eo": "tunizia dinaro",
+            "es": "dinar tunecino",
+            "et": "Tuneesia dinaar",
+            "fa": "دینار تونس",
+            "fi": "Tunisian dinaari",
+            "fr": "dinar tunisien",
+            "he": "דינר תוניסאי",
+            "hr": "tuniski dinar",
+            "hu": "Tunéziai dinár",
+            "it": "dinaro tunisino",
+            "ja": "チュニジア・ディナール",
+            "lt": "Tuniso dinaras",
+            "nl": "tunesische dinar",
+            "pl": "Dinar tunezyjski",
+            "pt": "dinar tunisiano",
+            "ru": "тунисский динар",
+            "sl": "Tunizijski dinar",
+            "sr": "туниски динар",
+            "sv": "Tunisisk dinar",
+            "tr": "Tunus dinarı",
+            "uk": "Туніський динар",
+            "zh": "突尼斯第納爾"
+        },
+        "TOP": {
+            "ar": "بانجا تونجي",
+            "ca": "Paʻanga",
+            "cs": "Tonžská paʻanga",
+            "de": "Paʻanga",
+            "el": "Παάνγκα",
+            "en": "Tongan paʻanga",
+            "eo": "tonga paangao",
+            "es": "pa'anga",
+            "fa": "پاآنگای تنگو",
+            "fi": "Tongan paʻanga",
+            "fr": "pa’anga",
+            "gl": "Paʻanga",
+            "he": "פאנגה טונגאית",
+            "hr": "Tongaška pa’anga",
+            "hu": "Tongai paʻanga",
+            "it": "pa'anga tongano",
+            "ja": "パ・アンガ",
+            "lt": "Tongos paanga",
+            "nl": "Tongaanse pa'anga",
+            "pl": "Pa'anga",
+            "pt": "pa'anga",
+            "ru": "тонганская паанга",
+            "sr": "тонганска панга",
+            "sv": "Pa'anga",
+            "tr": "Pa'anga",
+            "uk": "Тонганська паанга",
+            "vi": "Paʻanga Tonga",
+            "zh": "汤加潘加"
+        },
+        "TRY": {
+            "ar": "ليرة تركية",
+            "bg": "Турска лира",
+            "ca": "lira turca",
+            "cs": "Turecká lira",
+            "cy": "Lira Twrcaidd",
+            "da": "Tyrkisk lira",
+            "de": "türkische Lira",
+            "el": "Τουρκική λίρα",
+            "en": "Turkish lira",
+            "eo": "turka liro",
+            "es": "lira turca",
+            "et": "Türgi liir",
+            "eu": "Turkiar lira",
+            "fa": "لیره جدید ترکیه",
+            "fi": "Turkin liira",
+            "fr": "livre turque",
+            "gl": "Lira turca",
+            "he": "לירה טורקית",
+            "hr": "Turska lira",
+            "hu": "török líra",
+            "it": "lira turca",
+            "ja": "トルコ・リラ",
+            "lt": "Turkijos lira",
+            "nl": "Turkse lira",
+            "pl": "lira turecka",
+            "pt": "lira turca",
+            "ro": "Liră turcească",
+            "ru": "турецкая лира",
+            "sk": "Turecká líra",
+            "sr": "турска лира",
+            "sv": "Turkisk lira",
+            "ta": "துருக்கிய லிரா",
+            "tr": "Türk lirası",
+            "uk": "Турецька ліра",
+            "vi": "Lira Thổ Nhĩ Kỳ",
+            "zh": "新土耳其里拉",
+            "ia": "lira turc",
+            "oc": "lira turca"
+        },
+        "TTD": {
+            "ar": "دولار ترينيداد وتوباغو",
+            "bg": "Тринидадски и тобагски долар",
+            "ca": "dòlar de Trinitat i Tobago",
+            "cs": "Dolar Trinidadu a Tobaga",
+            "de": "Trinidad-und-Tobago-Dollar",
+            "el": "Δολάριο Τρινιδάδ και Τομπάγκο",
+            "en": "Trinidad and Tobago dollar",
+            "eo": "trinidada dolaro",
+            "es": "dólar trinitense",
+            "et": "Trinidadi ja Tobago dollar",
+            "eu": "Trinidad eta Tobagoko dolar",
+            "fa": "دلار ترینیداد و توباگو",
+            "fi": "Trinidad ja Tobagon dollari",
+            "fr": "Dollar de Trinité-et-Tobago",
+            "gl": "Dólar de Trinidad e Tobago",
+            "hr": "Trinidadtobaški dolar",
+            "hu": "Trinidad és Tobagó-i dollár",
+            "it": "Dollaro di Trinidad e Tobago",
+            "ja": "トリニダード・トバゴ・ドル",
+            "lt": "Trinidado ir Tobago doleris",
+            "nl": "Trinidad en Tobagodollar",
+            "pl": "Dolar Trynidadu i Tobago",
+            "pt": "Dólar de Trinidad e Tobago",
+            "ru": "доллар Тринидада и Тобаго",
+            "sr": "долар Тринидада и Тобага",
+            "sv": "Trinidaddollar",
+            "tr": "Trinidad ve Tobago doları",
+            "uk": "Долар Тринідаду та Тобаго",
+            "zh": "千里達托貝哥元",
+            "sk": "Trinidadsko-tobažský dolár"
+        },
+        "TVD": {
+            "ar": "دولار توفالو",
+            "ca": "dòlar de Tuvalu",
+            "cs": "Tuvalský dolar",
+            "de": "Tuvaluischer Dollar",
+            "el": "Δολάριο Τουβαλού",
+            "en": "Tuvaluan dollar",
+            "eo": "tuvala dolaro",
+            "es": "dólar tuvaluano",
+            "fa": "دلار تووالوان",
+            "fi": "Tuvalun dollari",
+            "fr": "Dollar de Tuvalu",
+            "gl": "Dólar tuvalés",
+            "hr": "Tuvaluški dolar",
+            "hu": "Tuvalui dollár",
+            "it": "Dollaro di Tuvalu",
+            "ja": "ツバル・ドル",
+            "pl": "Dolar Tuvalu",
+            "ro": "Dolar din Tuvalu",
+            "ru": "доллар Тувалу",
+            "sr": "тувалуански долар",
+            "sv": "Tuvaluansk dollar",
+            "tr": "Tuvalu doları",
+            "uk": "Долар Тувалу",
+            "zh": "圖瓦盧元",
+            "et": "Tuvalu dollar",
+            "nl": "Tuvaluan dollar"
+        },
+        "TWD": {
+            "ar": "دولار تايواني جديد",
+            "bg": "Нов тайвански долар",
+            "ca": "nou dòlar de Taiwan",
+            "cs": "Tchajwanský dolar",
+            "de": "Neuer Taiwan-Dollar",
+            "el": "Δολάριο Ταϊβάν",
+            "en": "New Taiwan dollar",
+            "eo": "nova tajvana dolaro",
+            "es": "nuevo dólar taiwanés",
+            "et": "Uus Taiwani dollar",
+            "fa": "دلار جدید تایوان",
+            "fi": "Uusi Taiwanin dollari",
+            "fr": "nouveau dollar de Taïwan",
+            "hr": "Novotajvanski dolar",
+            "hu": "Tajvani új dollár",
+            "it": "Dollaro taiwanese",
+            "ja": "ニュー台湾ドル",
+            "lt": "Naujasis Taivano doleris",
+            "nl": "Taiwanese dollar",
+            "pl": "Dolar tajwański",
+            "pt": "Novo dólar taiwanês",
+            "ru": "новый тайваньский доллар",
+            "sr": "нови тајвански долар",
+            "sv": "Taiwanesisk dollar",
+            "tr": "Yeni Tayvan doları",
+            "uk": "новий тайванський долар",
+            "vi": "Tân Đài tệ",
+            "zh": "新臺幣",
+            "cy": "Doler Newydd Taiwan"
+        },
+        "TZS": {
+            "ar": "شيلينغ تانزاني",
+            "bg": "Танзанийски шилинг",
+            "ca": "xíling tanzà",
+            "cs": "Tanzanský šilink",
+            "cy": "Swllt Tanzania",
+            "de": "Tansania-Schilling",
+            "en": "Tanzanian shilling",
+            "eo": "tanzania ŝilingo",
+            "es": "chelín tanzano",
+            "fa": "شیلینگ تانزانیا",
+            "fi": "Tansanian šillinki",
+            "fr": "shilling tanzanien",
+            "he": "שילינג טנזני",
+            "hr": "Tanzanijski šiling",
+            "hu": "Tanzániai shilling",
+            "it": "scellino tanzaniano",
+            "ja": "タンザニア・シリング",
+            "lt": "Tanzanijos šilingas",
+            "nl": "Tanzaniaanse shilling",
+            "pl": "Szyling tanzański",
+            "pt": "xelim tanzaniano",
+            "ru": "танзанийский шиллинг",
+            "sk": "Tanzánijský šiling",
+            "sr": "танзанијски шилинг",
+            "sv": "Tanzanisk shilling",
+            "tr": "Tanzanya şilini",
+            "uk": "танзанійський шилінг",
+            "zh": "坦尚尼亞先令"
+        },
+        "UAH": {
+            "ar": "هريفنا أوكرانية",
+            "bg": "Украинска гривна",
+            "ca": "hrívnia",
+            "cs": "ukrajinská hřivna",
+            "da": "Hryvnia",
+            "de": "Hrywnja",
+            "el": "Γρίβνα Ουκρανίας",
+            "en": "hryvnia",
+            "eo": "ukraina hrivno",
+            "es": "grivna",
+            "et": "Ukraina grivna",
+            "fa": "گریونا",
+            "fi": "Ukrainan hryvnia",
+            "fr": "hryvnia",
+            "gl": "Hrivna",
+            "he": "הריבניה",
+            "hr": "Grivnja",
+            "hu": "ukrán hrivnya",
+            "it": "grivnia ucraina",
+            "ja": "フリヴニャ",
+            "lt": "Grivina",
+            "nl": "Oekraïense hryvnja",
+            "pl": "hrywna",
+            "pt": "hryvnia",
+            "ro": "Grivnă",
+            "ru": "украинская гривна",
+            "sk": "Ukrajinská hrivna",
+            "sl": "ukrajinska grivna",
+            "sr": "украјинска хривња",
+            "sv": "Hryvnja",
+            "ta": "ஹிருன்யா",
+            "tr": "Grivna",
+            "uk": "гривня",
+            "vi": "Hryvnia Ukraina",
+            "zh": "乌克兰格里夫纳",
+            "ia": "hryvnja ukrainian"
+        },
+        "UGX": {
+            "ar": "شيلينغ أوغندي",
+            "bg": "Угандийски шилинг",
+            "ca": "xíling ugandès",
+            "cs": "Ugandský šilink",
+            "de": "Uganda-Schilling",
+            "el": "Σελίνι της Ουγκάντας",
+            "en": "Ugandan shilling",
+            "eo": "uganda ŝilingo",
+            "es": "chelín ugandés",
+            "fa": "شیلینگ اوگاندا",
+            "fi": "Ugandan šillinki",
+            "fr": "shilling ougandais",
+            "he": "שילינג אוגנדי",
+            "hr": "Ugandski šiling",
+            "hu": "Ugandai shilling",
+            "it": "scellino ugandese",
+            "ja": "ウガンダ・シリング",
+            "lt": "Ugandos šilingas",
+            "nl": "Oegandese shilling",
+            "oc": "Shilling ogandés",
+            "pl": "Szyling ugandyjski",
+            "pt": "xelim Ugandês",
+            "ru": "угандийский шиллинг",
+            "sk": "Ugandský šiling",
+            "sr": "угандски шилинг",
+            "sv": "Ugandisk shilling",
+            "tr": "Uganda şilini",
+            "uk": "угандійський шилінг",
+            "zh": "烏干達先令"
+        },
+        "USD": {
+            "ar": "دولار أمريكي",
+            "bg": "Щатски долар",
+            "ca": "dòlar dels Estats Units",
+            "cs": "americký dolar",
+            "cy": "$ (UDA)",
+            "da": "amerikansk dollar",
+            "de": "US-Dollar",
+            "el": "Δολάριο ΗΠΑ",
+            "en": "United States dollar",
+            "eo": "Usona dolaro",
+            "es": "dólar estadounidense",
+            "et": "USA dollar",
+            "eu": "Estatubatuar dolar",
+            "fa": "دلار آمریکا",
+            "fi": "Yhdysvaltain dollari",
+            "fr": "dollar américain",
+            "gl": "dólar estadounidense",
+            "he": "דולר אמריקני",
+            "hr": "Američki dolar",
+            "hu": "amerikai dollár",
+            "ia": "dollar statounitese",
+            "it": "dollaro statunitense",
+            "ja": "アメリカ合衆国ドル",
+            "lt": "Jungtinių Valstijų doleris",
+            "nl": "US dollar",
+            "oc": "Dolar american",
+            "pl": "dolar amerykański",
+            "pt": "dólar americano",
+            "ro": "dolari americani",
+            "ru": "доллар США",
+            "sk": "Americký dolár",
+            "sl": "Ameriški dolar",
+            "sr": "амерички долар",
+            "sv": "amerikansk dollar",
+            "ta": "அமெரிக்க டாலர்",
+            "tr": "Amerikan doları",
+            "uk": "долар США",
+            "vi": "đô la Mỹ",
+            "zh": "美元"
+        },
+        "UYU": {
+            "ar": "بيزو أوروغواني",
+            "bg": "Уругвайско песо",
+            "ca": "peso uruguaià",
+            "cs": "Uruguayské peso",
+            "de": "uruguayischer Peso",
+            "en": "Uruguayan peso",
+            "eo": "urugvaja peso",
+            "es": "peso uruguayo",
+            "eu": "Peso uruguaitar",
+            "fa": "پزوی اوروگوئه",
+            "fi": "Uruguayn peso",
+            "fr": "peso uruguayen",
+            "gl": "Peso uruguaio",
+            "hr": "Urugvajski pezo",
+            "hu": "Uruguayi peso",
+            "it": "peso uruguaiano",
+            "ja": "ウルグアイ・ペソ",
+            "lt": "Urugvajaus pesas",
+            "nl": "Uruguayaanse peso",
+            "pl": "Peso urugwajskie",
+            "pt": "peso uruguaio",
+            "ru": "уругвайское песо",
+            "sr": "уругвајски пезос",
+            "sv": "Uruguayansk peso",
+            "tr": "Uruguay pesosu",
+            "uk": "Уругвайський песо",
+            "zh": "烏拉圭比索",
+            "he": "פסו של אורוגוואי",
+            "oc": "Peso uruguaian"
+        },
+        "UZS": {
+            "ar": "سوم أوزبكستاني",
+            "bg": "Узбекистански сом",
+            "ca": "som uzbek",
+            "cs": "Uzbecký sum",
+            "de": "Soʻm",
+            "el": "Σομ του Ουζμπεκιστάν",
+            "en": "Uzbekistani som",
+            "eo": "uzbeka somo",
+            "es": "som",
+            "fa": "سم ازبکستان",
+            "fi": "Uzbekistanin som",
+            "fr": "Sum",
+            "he": "סום אוזבקי",
+            "hr": "Uzbekistanski som",
+            "hu": "Üzbég szom",
+            "it": "Som uzbeco",
+            "ja": "スム",
+            "lt": "Uzbekijos sumas",
+            "nl": "Oezbeekse sum",
+            "pl": "Sum",
+            "pt": "som usbeque",
+            "ro": "Som uzbec",
+            "ru": "узбекский сум",
+            "sr": "узбекистански сом",
+            "sv": "Uzbekistansk som",
+            "tr": "Özbekistan somu",
+            "uk": "Узбецький сом",
+            "zh": "烏茲別克索姆"
+        },
+        "VES": {
+            "en": "Sovereign Bolivar",
+            "es": "bolívar soberano",
+            "fr": "Bolivar souverain",
+            "hu": "venezuelai bolívar",
+            "ja": "ボリバル・ソベラノ",
+            "pt": "Bolívar soberano",
+            "ru": "Суверенный боливар",
+            "uk": "Суверенний Болівар"
+        },
+        "VND": {
+            "ar": "دونغ فيتنامي",
+            "bg": "виетнамски донг",
+            "ca": "dong",
+            "cs": "Vietnamský dong",
+            "da": "Dong",
+            "de": "vietnamesischer Đồng",
+            "el": "Ντονγκ",
+            "en": "Vietnamese dong",
+            "eo": "vjetnama dongo",
+            "es": "đồng vietnamita",
+            "eu": "Vietnamdar dong",
+            "fa": "دانگ ویتنام",
+            "fi": "Vietnamin đồng",
+            "fr": "dong",
+            "hr": "Vijetnamski dong",
+            "hu": "vietnámi đồng",
+            "it": "Đồng vietnamita",
+            "ja": "ドン",
+            "lt": "Vietnamo dongas",
+            "nl": "Vietnamese dong",
+            "pl": "Dong",
+            "pt": "dong",
+            "ru": "вьетнамский донг",
+            "sk": "Dong",
+            "sr": "вијетнамски донг",
+            "sv": "Dong",
+            "tr": "Đồng",
+            "uk": "в'єтнамський донг",
+            "vi": "Việt Nam đồng",
+            "zh": "越南盾",
+            "he": "דונג וייטנאמי ",
+            "oc": "Dong"
+        },
+        "VUV": {
+            "ar": "فاتو فانواتي",
+            "ca": "vatu",
+            "cs": "Vanuatský vatu",
+            "de": "Vatu",
+            "el": "Βάτου",
+            "en": "Vanuatu vatus",
+            "eo": "vanuatua vatuo",
+            "es": "vatu",
+            "fa": "واتوی وانواتو",
+            "fi": "Vanuatun vatu",
+            "fr": "Vatu",
+            "gl": "Vatu",
+            "he": "ואטו",
+            "hr": "Vanuatski vatu",
+            "hu": "Vanuatui vatu",
+            "it": "Vatu di Vanuatu",
+            "ja": "バツ",
+            "lt": "Vatu",
+            "nl": "Vanuatuaanse vatu",
+            "pl": "Vatu",
+            "pt": "Vatu",
+            "ro": "Vatu",
+            "ru": "вату",
+            "sr": "вануатски вату",
+            "sv": "Vatu",
+            "tr": "Vatu",
+            "uk": "Вануатський вату",
+            "vi": "Vatu Vanuatu",
+            "zh": "萬那杜瓦圖",
+            "sk": "Vanuatský vatu"
+        },
+        "WST": {
+            "ar": "تالا ساموي",
+            "ca": "tala",
+            "cs": "Samojská tala",
+            "de": "samoanischer Tala",
+            "el": "Τάλα Σαμόα",
+            "en": "Samoan tālā",
+            "eo": "samoa talao",
+            "es": "tālā",
+            "et": "Samoa tala",
+            "fa": "طلای ساموآ",
+            "fi": "Samoan tala",
+            "fr": "tala",
+            "gl": "Tala samoana",
+            "hr": "Samoanska tala",
+            "hu": "Szamoai tala",
+            "it": "tala samoano",
+            "ja": "タラ",
+            "lt": "Tala",
+            "nl": "Samoaanse tala",
+            "pl": "Tala",
+            "pt": "tala",
+            "ro": "Tala samoan",
+            "ru": "самоанская тала",
+            "sk": "Tala",
+            "sr": "самоанска тала",
+            "sv": "Tala",
+            "uk": "Самоанська тала",
+            "zh": "薩摩亞塔拉",
+            "he": "טלה",
+            "oc": "Tala"
+        },
+        "XAF": {
+            "ar": "فرنك وسط أفريقي",
+            "bg": "Централноафрикански CFA франк",
+            "ca": "franc CFA de l'Àfrica Central",
+            "cs": "Středoafrický frank",
+            "de": "CFA-Franc BEAC",
+            "el": "Φράγκο CFA Κεντρικής Αφρικής",
+            "en": "Central African CFA franc",
+            "es": "franco CFA de África Central",
+            "fa": "فرانک سیافای آفریقای میانه",
+            "fr": "franc CFA d'Afrique Centrale",
+            "hr": "Srednjoafrički CFA franak",
+            "ja": "中部アフリカCFAフラン",
+            "oc": "Franc CFA d'Africa Centrala",
+            "pt": "franco",
+            "ro": "Franc CFA BEAC",
+            "ru": "франк КФА BEAC",
+            "sk": "Stredoafrický frank",
+            "tr": "Orta Afrika CFA frangı",
+            "uk": "центральноафриканський франк",
+            "vi": "CFA franc Trung Phi",
+            "zh": "中非法郎",
+            "cy": "Ffranc Canol Affrica (CFA)",
+            "eo": "centr-afrika franko",
+            "fi": "Keski-Afrikan CFA-frangi",
+            "he": "פרנק CFA מרכז אפריקני",
+            "ia": "CFA",
+            "it": "franco CFA dell'Africa centrale",
+            "nl": "Central African CFA franc",
+            "sv": "Central Africa CFA Franc",
+            "ta": "மத்திய ஆப்பிரிக்க சி.எஃப்.ஏ பிராங்க்"
+        },
+        "XAG": {
+            "ar": "فضة",
+            "bg": "сребро",
+            "bo": "དངུལ།",
+            "ca": "plata",
+            "cs": "stříbro",
+            "cy": "arian",
+            "da": "sølv",
+            "de": "Silber",
+            "el": "άργυρος",
+            "en": "silver",
+            "eo": "arĝento",
+            "es": "plata",
+            "et": "hõbe",
+            "eu": "zilar",
+            "fa": "نقره",
+            "fi": "hopea",
+            "fr": "argent",
+            "gl": "prata",
+            "he": "כסף",
+            "hr": "srebro",
+            "hu": "ezüst",
+            "ia": "argento",
+            "it": "argento",
+            "ja": "銀",
+            "lt": "sidabras",
+            "nl": "zilver",
+            "oc": "argent",
+            "pl": "srebro",
+            "pt": "prata",
+            "ro": "argint",
+            "ru": "серебро",
+            "sk": "striebro",
+            "sl": "srebro",
+            "sr": "сребро",
+            "sv": "silver",
+            "ta": "வெள்ளி",
+            "te": "వెండి",
+            "tr": "gümüş",
+            "uk": "срібло",
+            "vi": "bạc",
+            "zh": "銀"
+        },
+        "XAU": {
+            "ar": "ذهب",
+            "bg": "злато",
+            "bo": "གསེར།",
+            "ca": "or",
+            "cs": "zlato",
+            "cy": "aur",
+            "da": "guld",
+            "de": "Gold",
+            "el": "χρυσός",
+            "en": "gold",
+            "eo": "oro",
+            "es": "oro",
+            "et": "kuld",
+            "eu": "urre",
+            "fa": "طلا",
+            "fi": "kulta",
+            "fr": "or",
+            "gl": "ouro",
+            "he": "זהב",
+            "hr": "Zlato",
+            "hu": "arany",
+            "ia": "Auro",
+            "it": "oro",
+            "ja": "金",
+            "lt": "Auksas",
+            "nl": "goud",
+            "oc": "Aur",
+            "pl": "złoto",
+            "pt": "ouro",
+            "ro": "aur",
+            "ru": "золото",
+            "sk": "Zlato",
+            "sl": "zlato",
+            "sr": "злато",
+            "sv": "guld",
+            "ta": "தங்கம்",
+            "te": "బంగారం",
+            "tr": "Altın",
+            "uk": "золото",
+            "vi": "vàng",
+            "zh": "金"
+        },
+        "XBT": {
+            "ar": "بيتكوين",
+            "bg": "Биткойн",
+            "ca": "bitcoin",
+            "cs": "Bitcoin",
+            "cy": "Bitcoin",
+            "da": "Bitcoin",
+            "de": "Bitcoin",
+            "el": "Bitcoin",
+            "en": "bitcoin",
+            "eo": "Bitmono",
+            "es": "bitcoin",
+            "et": "Bitcoin",
+            "eu": "Bitcoin",
+            "fa": "بیتکوین",
+            "fi": "Bitcoin",
+            "fr": "Bitcoin",
+            "gl": "Bitcoin",
+            "he": "ביטקוין",
+            "hr": "Bitcoin",
+            "hu": "Bitcoin",
+            "ia": "Bitcoin",
+            "it": "Bitcoin",
+            "ja": "ビットコイン",
+            "lt": "Bitcoin",
+            "nl": "Bitcoin",
+            "oc": "Bitcoin",
+            "pl": "Bitcoin",
+            "pt": "Bitcoin",
+            "ro": "Bitcoin",
+            "ru": "Bitcoin",
+            "sk": "Bitcoin",
+            "sl": "Bitcoin",
+            "sr": "Биткоин",
+            "sv": "Bitcoin",
+            "ta": "பிட்காயின்",
+            "te": "బిట్ కాయిన్",
+            "tr": "Bitcoin",
+            "uk": "біткоїн",
+            "vi": "Bitcoin",
+            "zh": "比特幣"
+        },
+        "XCD": {
+            "ar": "دولار شرق الكاريبي",
+            "bg": "Източнокарибски долар",
+            "ca": "dòlar del Carib Oriental",
+            "cs": "Východokaribský dolar",
+            "cy": "Doler Dwyrain y Caribî",
+            "de": "Ostkaribischer Dollar",
+            "el": "Δολάριο Ανατολικής Καραϊβικής",
+            "en": "Eastern Caribbean dollar",
+            "eo": "orientkaribia dolaro",
+            "es": "dólar del Caribe Oriental",
+            "eu": "Ekialdeko Karibeko dolar",
+            "fa": "دلار کارائیب شرقی",
+            "fi": "Itä-Karibian dollari",
+            "fr": "dollar des Caraïbes orientales",
+            "gl": "Dólar Caribe-Leste",
+            "he": "דולר מזרח קריבי",
+            "hr": "Istočnokaripski dolar",
+            "hu": "kelet-karibi dollár",
+            "it": "dollaro dei Caraibi Orientali",
+            "ja": "東カリブ・ドル",
+            "lt": "Rytų Karibų doleris",
+            "nl": "Oost-Caribische dollar",
+            "pl": "Dolar wschodniokaraibski",
+            "pt": "Dólar do Caribe Oriental",
+            "ru": "восточно-карибский доллар",
+            "sl": "Vzhodnokaribski dolar",
+            "sr": "источнокарипски долар",
+            "sv": "Östkaribisk dollar",
+            "tr": "Doğu Karayip doları",
+            "uk": "Східно-карибський долар",
+            "vi": "Đô la Đông Caribe",
+            "zh": "東加勒比元",
+            "oc": "Dolar de las Caribas Orientalas",
+            "ta": "கிழக்குக் கரிபியன் டாலர்"
+        },
+        "XDR": {
+            "ar": "حقوق السحب الخاصة",
+            "bg": "Специални права на тираж",
+            "ca": "drets especials de gir",
+            "cs": "Zvláštní práva čerpání",
+            "de": "Sonderziehungsrecht",
+            "en": "special drawing rights",
+            "eo": "specialaj rajtoj de enspezo",
+            "es": "Derechos Especiales de Giro",
+            "fi": "Erityisnosto-oikeus",
+            "fr": "droits de tirage spéciaux",
+            "hr": "Posebna prava vučenja",
+            "hu": "SDR",
+            "it": "Diritti speciali di prelievo",
+            "ja": "特別引出権",
+            "lt": "Specialiosios skolinimosi teisės",
+            "nl": "speciale trekkingsrechten",
+            "oc": "Drechs de tiratge Especials",
+            "pl": "Specjalne prawa ciągnienia",
+            "pt": "direitos especiais de saque",
+            "ro": "Drepturi speciale de tragere",
+            "ru": "специальные права заимствования",
+            "sk": "Zvláštne práva čerpania",
+            "sl": "Posebne pravice črpanja",
+            "sv": "Särskilda dragningsrätter",
+            "tr": "Özel çekme hakları",
+            "uk": "Спеціальні права запозичення",
+            "vi": "Quyền rút vốn đặc biệt",
+            "zh": "特别提款权",
+            "ta": "Special drawings right"
+        },
+        "XEU": {
+            "bg": "ЕКЮ",
+            "ca": "Unitat Monetària Europea",
+            "cs": "Evropská měnová jednotka",
+            "da": "European Currency Unit",
+            "de": "Europäische Währungseinheit",
+            "el": "Ευρωπαϊκή λογιστική μονάδα",
+            "en": "European Currency Unit",
+            "es": "Unidad Monetaria Europea",
+            "et": "ECU",
+            "eu": "Europako kontu-unitate",
+            "fa": "واحد ارزی اروپا",
+            "fi": "Euroopan valuuttayksikkö",
+            "fr": "European Currency Unit",
+            "gl": "ECU",
+            "he": "יחידת מטבע אירופית",
+            "hu": "Európai valutaegység",
+            "it": "Unità di conto europea",
+            "ja": "欧州通貨単位",
+            "lt": "Ekiu",
+            "nl": "Europese rekeneenheid",
+            "pl": "European Currency Unit",
+            "pt": "Unidade Monetária Europeia",
+            "ro": "ECU",
+            "ru": "ЭКЮ",
+            "sk": "Európska menová jednotka",
+            "sv": "Europeiska valutaenheten",
+            "tr": "ECU",
+            "uk": "Екю",
+            "zh": "歐洲通貨單位",
+            "eo": "Eŭropa Monunuo"
+        },
+        "XMR": {
+            "ar": "مونيرو",
+            "bg": "Monero",
+            "ca": "Monero",
+            "cs": "Monero",
+            "da": "Monero",
+            "de": "Monero",
+            "en": "Monero",
+            "eo": "Monero (ĉifromono)",
+            "es": "Monero",
+            "fa": "مونرو",
+            "fi": "Monero",
+            "fr": "Monero",
+            "he": "מונרו (מטבע מבוזר)",
+            "ia": "Monero",
+            "it": "Monero",
+            "ja": "Monero",
+            "pt": "Monero",
+            "ru": "Monero",
+            "sv": "Monero",
+            "tr": "Monero",
+            "uk": "Monero",
+            "vi": "Monero",
+            "zh": "门罗币",
+            "nl": "Monero"
+        },
+        "XOF": {
+            "ar": "فرنك غرب أفريقي",
+            "bg": "Западноафрикански CFA франк",
+            "ca": "franc CFA de l'Àfrica Occidental",
+            "de": "CFA-Franc BCEAO",
+            "el": "Φράγκο CFA Δυτικής Αφρικής",
+            "en": "West African CFA franc",
+            "es": "franco CFA de África Occidental",
+            "fa": "فرانک سی اف ای آفریقای باختری",
+            "fr": "franc CFA",
+            "hr": "Zapadnoafrički CFA franak",
+            "ja": "西アフリカCFAフラン",
+            "oc": "Franc CFA d'Africa Occidentala",
+            "pt": "franco CFA da África Ocidental",
+            "ro": "Franc CFA BCEAO",
+            "ru": "франк КФА BCEAO",
+            "sk": "Západoafrický frank",
+            "tr": "Batı Afrika CFA frangı",
+            "uk": "західноафриканський франк",
+            "vi": "CFA franc Tây Phi",
+            "zh": "非洲金融共同体法郎",
+            "eo": "okcident-afrika franko",
+            "he": "פרנק CFA מערב אפריקני",
+            "it": "franco CFA UEMOA",
+            "nl": "West African CFA franc",
+            "pl": "frank CFA",
+            "sv": "CFA Franc",
+            "ta": "மேற்கு ஆபிரிக்க சி.எஃப்.ஏ பிராங்க்"
+        },
+        "XPD": {
+            "ar": "بالاديوم",
+            "bg": "паладий",
+            "bo": "པྰེ་ལེ་ཌིམ།",
+            "ca": "pal·ladi",
+            "cs": "palladium",
+            "cy": "Paladiwm",
+            "da": "palladium",
+            "de": "Palladium",
+            "el": "παλλάδιο",
+            "en": "palladium",
+            "eo": "paladio",
+            "es": "paladio",
+            "et": "Pallaadium",
+            "eu": "paladio",
+            "fa": "پالادیم",
+            "fi": "palladium",
+            "fr": "palladium",
+            "gl": "Paladio",
+            "he": "פלדיום",
+            "hr": "Paladij",
+            "hu": "palládium",
+            "ia": "palladium",
+            "it": "palladio",
+            "ja": "パラジウム",
+            "lt": "Paladis",
+            "nl": "palladium",
+            "oc": "Palladi",
+            "pl": "pallad",
+            "pt": "paládio",
+            "ro": "paladiu",
+            "ru": "палладий",
+            "sk": "Paládium",
+            "sl": "Paladij",
+            "sr": "паладијум",
+            "sv": "palladium",
+            "ta": "பலேடியம்",
+            "te": "పల్లాడియం",
+            "tr": "Paladyum",
+            "uk": "Паладій",
+            "vi": "paladi",
+            "zh": "钯"
+        },
+        "XPF": {
+            "ar": "فرنك س ف ب",
+            "ca": "franc CFP",
+            "cs": "CFP frank",
+            "da": "CFP-franc",
+            "de": "CFP-Franc",
+            "el": "Φράγκο CFP",
+            "en": "CFP Franc",
+            "eo": "pacifika franko",
+            "es": "Franco CFP",
+            "eu": "CFP libera",
+            "fa": "فرانک اقیانوسیه",
+            "fi": "CFP-frangi",
+            "fr": "franc Pacifique",
+            "gl": "Franco CFP",
+            "hr": "CFP franak",
+            "hu": "Csendes-óceáni valutaközösségi frank",
+            "it": "Franco CFP",
+            "ja": "CFPフラン",
+            "lt": "CFP frankas",
+            "nl": "CFP-frank",
+            "pl": "Frank CFP",
+            "pt": "Franco CFP",
+            "ro": "Franc CFP",
+            "ru": "французский тихоокеанский франк",
+            "sk": "CFP frank",
+            "sv": "CFP-franc",
+            "tr": "CFP frangı",
+            "uk": "Французький тихоокеанський франк",
+            "vi": "Franc CFP",
+            "zh": "太平洋法郎",
+            "he": "פרנק צרפתי",
+            "oc": "Franc CFP",
+            "sr": "француски тихоокеански франак"
+        },
+        "XPT": {
+            "ar": "بلاتين",
+            "bg": "платина",
+            "bo": "བེ་ལེ་ཊི་ནམ།",
+            "ca": "platí",
+            "cs": "platina",
+            "cy": "Platinwm",
+            "da": "platin",
+            "de": "Platin",
+            "el": "λευκόχρυσος",
+            "en": "platinum",
+            "eo": "plateno",
+            "es": "platino",
+            "et": "Plaatina",
+            "eu": "platino",
+            "fa": "پلاتین",
+            "fi": "platina",
+            "fr": "platine",
+            "gl": "Platino",
+            "he": "פלטינה",
+            "hr": "Platina",
+            "hu": "platina",
+            "ia": "Platino",
+            "it": "platino",
+            "ja": "白金",
+            "lt": "Platina",
+            "nl": "platina",
+            "oc": "Platin",
+            "pl": "platyna",
+            "pt": "platina",
+            "ro": "platină",
+            "ru": "платина",
+            "sk": "Platina",
+            "sl": "platina",
+            "sr": "платина",
+            "sv": "platina",
+            "ta": "பிளாட்டினம்",
+            "te": "ప్లాటినం",
+            "tr": "Platin",
+            "uk": "платина",
+            "vi": "platin",
+            "zh": "铂"
+        },
+        "XSU": {
+            "de": "SUCRE",
+            "en": "SUCRE",
+            "es": "SUCRE",
+            "eu": "SUCRE",
+            "fi": "Sucre",
+            "fr": "sucre",
+            "hu": "SUCRE",
+            "ja": "域内統一決済システム",
+            "pl": "SUCRE",
+            "pt": "SUCRE",
+            "ru": "Сукре",
+            "tr": "SUCRE",
+            "uk": "Сукре",
+            "nl": "SUCRE"
+        },
+        "YER": {
+            "ar": "ريال يمني",
+            "bg": "Йеменски риал",
+            "ca": "rial iemenita",
+            "de": "Jemen-Rial",
+            "el": "Ριάλ Υεμένης",
+            "en": "Yemeni rial",
+            "eo": "jemena rialo",
+            "es": "rial yemení",
+            "fa": "ریال یمن",
+            "fi": "Jemenin rial",
+            "fr": "rial yéménite",
+            "gl": "Rial iemení",
+            "he": "ריאל תימני",
+            "hr": "Jemenski rijal",
+            "hu": "Jemeni riál",
+            "it": "riyal yemenita",
+            "ja": "イエメン・リアル",
+            "lt": "Jemeno rialas",
+            "nl": "Jemenitische rial",
+            "pl": "Rial jemeński",
+            "pt": "Rial iemenita",
+            "ru": "йеменский риал",
+            "sk": "Jemenský rial",
+            "sr": "јеменски ријал",
+            "sv": "Jemenitisk rial",
+            "tr": "Yemen riyali",
+            "uk": "Єменський ріал",
+            "zh": "葉門里亞爾",
+            "oc": "Rial de Iemèn"
+        },
+        "ZAR": {
+            "ar": "راند جنوب أفريقي",
+            "bg": "Южноафрикански ранд",
+            "ca": "rand",
+            "cs": "Jihoafrický rand",
+            "da": "Rand",
+            "de": "südafrikanischer Rand",
+            "el": "Ραντ (νόμισμα)",
+            "en": "South African rand",
+            "eo": "sudafrika rando",
+            "es": "rand sudafricano",
+            "eu": "Hegoafrikar rand",
+            "fa": "رند آفریقای جنوبی",
+            "fi": "Etelä-Afrikan randi",
+            "fr": "rand",
+            "gl": "Rand surafricano",
+            "he": "ראנד דרום אפריקאי",
+            "hr": "Južnoafrički rand",
+            "hu": "Dél-afrikai rand",
+            "it": "rand sudafricano",
+            "ja": "ランド",
+            "lt": "Randas",
+            "nl": "Zuid-Afrikaanse rand",
+            "oc": "Rand sudafrican",
+            "pl": "Rand",
+            "pt": "rand",
+            "ro": "Rand sud-african",
+            "ru": "южноафриканский рэнд",
+            "sk": "Rand",
+            "sr": "јужноафрички ранд",
+            "sv": "Rand",
+            "tr": "Güney Afrika randı",
+            "uk": "Ранд",
+            "zh": "南非蘭特"
+        },
+        "ZEC": {
+            "cs": "Zcash",
+            "de": "Zcash",
+            "en": "Zcash",
+            "es": "Zcash",
+            "fa": "زیکش",
+            "it": "Zcash",
+            "ja": "Zcash",
+            "pt": "Zcash",
+            "ro": "Zcash",
+            "ru": "Zcash",
+            "uk": "Zcash",
+            "vi": "Zcash",
+            "zh": "Zcash",
+            "ca": "Zcash",
+            "da": "Zcash",
+            "eo": "Zcash",
+            "fi": "Zcash",
+            "fr": "Zcash",
+            "nl": "Zcash",
+            "sv": "Zcash"
+        },
+        "ZMW": {
+            "ar": "كواشا زامبية",
+            "ca": "kwacha zambià",
+            "cs": "Zambijská kwacha",
+            "da": "Zambianske kwacha",
+            "de": "sambischer Kwacha",
+            "el": "Κουάτσα της Ζάμπιας",
+            "en": "Zambian kwacha",
+            "eo": "zambia kvaĉo",
+            "es": "kwacha zambiano",
+            "et": "Sambia kvatša",
+            "fa": "کواچای زامبیا",
+            "fi": "Sambian kwacha",
+            "fr": "kwacha zambien",
+            "gl": "Kwacha zambiano",
+            "he": "קוואצ'ה זמבי",
+            "hr": "Zambijska kvača",
+            "hu": "Zambiai kwacha",
+            "it": "kwacha zambiano",
+            "ja": "ザンビア・クワチャ",
+            "lt": "Zambijos kvača",
+            "nl": "Zambiaanse kwacha",
+            "pl": "Kwacha zambijska",
+            "pt": "kwacha zambiano",
+            "ru": "замбийская квача",
+            "sr": "замбијска квача",
+            "sv": "Zambisk kwacha",
+            "tr": "Zambiya kwachası",
+            "uk": "Замбійська квача",
+            "zh": "尚比亞克瓦查",
+            "oc": "Kwacha zambian"
+        },
+        "CNH": {
+            "en": "renminbi (offshore)",
+            "es": "yuan offshore"
+        },
+        "COU": {
+            "en": "Unidad de Valor Real",
+            "es": "Unidad de Valor Real",
+            "fr": "Unidad de Valor Real colombienne"
+        },
+        "XLM": {
+            "de": "Stellar Lumens",
+            "en": "Stellar Lumens"
         }
     }
 }

--- a/searx/search/processors/online_currency.py
+++ b/searx/search/processors/online_currency.py
@@ -20,6 +20,8 @@ def name_to_iso4217(name):
     global CURRENCIES
     name = normalize_name(name)
     currency = CURRENCIES['names'].get(name, [name])
+    if isinstance(currency, str):
+        return currency
     return currency[0]
 
 

--- a/utils/fetch_currencies.py
+++ b/utils/fetch_currencies.py
@@ -1,163 +1,151 @@
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python
 
-
-import json
 import re
 import unicodedata
-import string
-from urllib.parse import urlencode
-from requests import get
+import json
 
-languages = {'de', 'en', 'es', 'fr', 'hu', 'it', 'nl', 'jp'}
+# set path
+from sys import path
+from os.path import realpath, dirname, join
+path.append(realpath(dirname(realpath(__file__)) + '/../'))
 
-url_template = 'https://www.wikidata.org/w/api.php?action=wbgetentities&format=json&{query}&props=labels%7Cdatatype%7Cclaims%7Caliases&languages=' + '|'.join(languages)
-url_wmflabs_template = 'http://wdq.wmflabs.org/api?q='
-url_wikidata_search_template = 'http://www.wikidata.org/w/api.php?action=query&list=search&format=json&srnamespace=0&srprop=sectiontitle&{query}'
+from searx import searx_dir, settings
+from searx.engines.wikidata import send_wikidata_query
 
-wmflabs_queries = [
-    'CLAIM[31:8142]',  # all devise
-]
 
-db = {
-    'iso4217': {
-    },
-    'names': {
-    }
+# ORDER BY (with all the query fields) is important to keep a deterministic result order
+# so multiple invokation of this script doesn't change currencies.json
+SARQL_REQUEST = """
+SELECT DISTINCT ?iso4217 ?unit ?unicode ?label ?alias WHERE {
+  ?item wdt:P498 ?iso4217; rdfs:label ?label.
+  OPTIONAL { ?item skos:altLabel ?alias FILTER (LANG (?alias) = LANG(?label)). }
+  OPTIONAL { ?item wdt:P5061 ?unit. }
+  OPTIONAL { ?item wdt:P489 ?symbol.
+             ?symbol wdt:P487 ?unicode. }
+  MINUS { ?item wdt:P582 ?end_data . }                  # Ignore monney with an end date
+  MINUS { ?item wdt:P31/wdt:P279* wd:Q15893266 . }      # Ignore "former entity" (obsolete currency)
+  FILTER(LANG(?label) IN (%LANGUAGES_SPARQL%)).
 }
+ORDER BY ?iso4217 ?unit ?unicode ?label ?alias
+"""
+
+# ORDER BY (with all the query fields) is important to keep a deterministic result order
+# so multiple invokation of this script doesn't change currencies.json
+SPARQL_WIKIPEDIA_NAMES_REQUEST = """
+SELECT DISTINCT ?iso4217 ?article_name WHERE {
+  ?item wdt:P498 ?iso4217 .
+  ?article schema:about ?item ;
+           schema:name ?article_name ;
+           schema:isPartOf [ wikibase:wikiGroup "wikipedia" ]
+  MINUS { ?item wdt:P582 ?end_data . }                  # Ignore monney with an end date
+  MINUS { ?item wdt:P31/wdt:P279* wd:Q15893266 . }      # Ignore "former entity" (obsolete currency)
+  FILTER(LANG(?article_name) IN (%LANGUAGES_SPARQL%)).
+}
+ORDER BY ?iso4217 ?article_name
+"""
 
 
-def remove_accents(data):
-    return unicodedata.normalize('NFKD', data).lower()
+LANGUAGES = settings['locales'].keys()
+LANGUAGES_SPARQL = ', '.join(set(map(lambda l: repr(l.split('_')[0]), LANGUAGES)))
 
 
-def normalize_name(name):
-    return re.sub(' +', ' ', remove_accents(name.lower()).replace('-', ' '))
+def remove_accents(name):
+    return unicodedata.normalize('NFKD', name).lower()
 
 
-def add_currency_name(name, iso4217):
-    global db
+def remove_extra(name):
+    for c in ('(', ':'):
+        if c in name:
+            name = name.split(c)[0].strip()
+    return name
 
+
+def _normalize_name(name):
+    name = re.sub(' +', ' ', remove_accents(name.lower()).replace('-', ' '))
+    name = remove_extra(name)
+    return name
+
+
+def add_currency_name(db, name, iso4217, normalize_name=True):
     db_names = db['names']
 
-    if not isinstance(iso4217, str):
-        print("problem", name, iso4217)
-        return
+    if normalize_name:
+        name = _normalize_name(name)
 
-    name = normalize_name(name)
-
-    if name == '':
-        print("name empty", iso4217)
-        return
-
-    iso4217_set = db_names.get(name, None)
-    if iso4217_set is not None and iso4217 not in iso4217_set:
-        db_names[name].append(iso4217)
-    else:
-        db_names[name] = [iso4217]
+    iso4217_set = db_names.setdefault(name, [])
+    if iso4217 not in iso4217_set:
+        iso4217_set.insert(0, iso4217)
 
 
-def add_currency_label(label, iso4217, language):
-    global db
-
-    db['iso4217'][iso4217] = db['iso4217'].get(iso4217, {})
-    db['iso4217'][iso4217][language] = label
+def add_currency_label(db, label, iso4217, language):
+    labels = db['iso4217'].setdefault(iso4217, {})
+    labels[language] = label
 
 
-def get_property_value(data, name):
-    prop = data.get('claims', {}).get(name, {})
-    if len(prop) == 0:
-        return None
-
-    value = prop[0].get('mainsnak', {}).get('datavalue', {}).get('value', '')
-    if value == '':
-        return None
-
-    return value
+def wikidata_request_result_iterator(request):
+    result = send_wikidata_query(request.replace('%LANGUAGES_SPARQL%', LANGUAGES_SPARQL))
+    if result is not None:
+        for r in result['results']['bindings']:
+            yield r
 
 
-def parse_currency(data):
-    iso4217 = get_property_value(data, 'P498')
+def fetch_db():
+    db = {
+        'names': {},
+        'iso4217': {},
+    }
 
-    if iso4217 is not None:
-        unit = get_property_value(data, 'P558')
-        if unit is not None:
-            add_currency_name(unit, iso4217)
+    for r in wikidata_request_result_iterator(SPARQL_WIKIPEDIA_NAMES_REQUEST):
+        iso4217 = r['iso4217']['value']
+        article_name = r['article_name']['value']
+        article_lang = r['article_name']['xml:lang']
+        add_currency_name(db, article_name, iso4217)
+        add_currency_label(db, article_name, iso4217, article_lang)
 
-        labels = data.get('labels', {})
-        for language in languages:
-            name = labels.get(language, {}).get('value', None)
-            if name is not None:
-                add_currency_name(name, iso4217)
-                add_currency_label(name, iso4217, language)
+    for r in wikidata_request_result_iterator(SARQL_REQUEST):
+        iso4217 = r['iso4217']['value']
+        if 'label' in r:
+            label = r['label']['value']
+            label_lang = r['label']['xml:lang']
+            add_currency_name(db, label, iso4217)
+            add_currency_label(db, label, iso4217, label_lang)
 
-        aliases = data.get('aliases', {})
-        for language in aliases:
-            for i in range(0, len(aliases[language])):
-                alias = aliases[language][i].get('value', None)
-                add_currency_name(alias, iso4217)
+        if 'alias' in r:
+            add_currency_name(db, r['alias']['value'], iso4217)
 
+        if 'unicode' in r:
+            add_currency_name(db, r['unicode']['value'], iso4217, normalize_name=False)
 
-def fetch_data(wikidata_ids):
-    url = url_template.format(query=urlencode({'ids': '|'.join(wikidata_ids)}))
-    htmlresponse = get(url)
-    jsonresponse = json.loads(htmlresponse.content)
-    entities = jsonresponse.get('entities', {})
+        if 'unit' in r:
+            add_currency_name(db, r['unit']['value'], iso4217, normalize_name=False)
 
-    for pname in entities:
-        pvalue = entities.get(pname)
-        parse_currency(pvalue)
+    # reduce memory usage:
+    # replace lists with one item by the item.
+    # see searx.search.processors.online_currency.name_to_iso4217
+    for name in db['names']:
+        if len(db['names'][name]) == 1:
+            db['names'][name] = db['names'][name][0]
 
-
-def add_q(i):
-    return "Q" + str(i)
-
-
-def fetch_data_batch(wikidata_ids):
-    while len(wikidata_ids) > 0:
-        if len(wikidata_ids) > 50:
-            fetch_data(wikidata_ids[0:49])
-            wikidata_ids = wikidata_ids[50:]
-        else:
-            fetch_data(wikidata_ids)
-            wikidata_ids = []
+    return db
 
 
-def wdq_query(query):
-    url = url_wmflabs_template + query
-    htmlresponse = get(url)
-    jsonresponse = json.loads(htmlresponse.content)
-    qlist = list(map(add_q, jsonresponse.get('items', {})))
-    error = jsonresponse.get('status', {}).get('error', None)
-    if error is not None and error != 'OK':
-        print("error for query '" + query + "' :" + error)
-
-    fetch_data_batch(qlist)
+def get_filename():
+    return join(join(searx_dir, "data"), "currencies.json")
 
 
-def wd_query(query, offset=0):
-    qlist = []
+def main():
+    #
+    db = fetch_db()
+    # static
+    add_currency_name(db, "euro", 'EUR')
+    add_currency_name(db, "euros", 'EUR')
+    add_currency_name(db, "dollar", 'USD')
+    add_currency_name(db, "dollars", 'USD')
+    add_currency_name(db, "peso", 'MXN')
+    add_currency_name(db, "pesos", 'MXN')
 
-    url = url_wikidata_search_template.format(query=urlencode({'srsearch': query, 'srlimit': 50, 'sroffset': offset}))
-    htmlresponse = get(url)
-    jsonresponse = json.loads(htmlresponse.content)
-    for r in jsonresponse.get('query', {}).get('search', {}):
-        qlist.append(r.get('title', ''))
-    fetch_data_batch(qlist)
+    with open(get_filename(), 'w', encoding='utf8') as f:
+        json.dump(db, f, ensure_ascii=False, indent=4)
 
-
-# fetch #
-for q in wmflabs_queries:
-    wdq_query(q)
-
-# static
-add_currency_name("euro", 'EUR')
-add_currency_name("euros", 'EUR')
-add_currency_name("dollar", 'USD')
-add_currency_name("dollars", 'USD')
-add_currency_name("peso", 'MXN')
-add_currency_name("pesos", 'MXN')
-
-# write
-f = open("currencies.json", "wb")
-json.dump(db, f, indent=4, encoding="utf-8")
-f.close()
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## What does this PR do?

use a sparql request on wikidata to get the list of currencies.

currencies.json contains the translation for all supported searx languages.



## Why is this change important?

In the master branch, `utils/fetch_currencies.py` doesn't work anymore, so it is not possible to update `searx/data/currencies.json`.

## How to test this PR locally?

* `searx-checker currency`
* search for `1 USD in €`

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

* Supersede #993
* Related to #2052
* Related to https://github.com/searx/searx/wiki/Milestones#milestone-110---data-upgrade--build-process
