### PR TITLE
Added rumble.com video search engine.

### DIFF
--- a/searx/engines/rumble.py
+++ b/searx/engines/rumble.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""
+ Wikipedia (Web
+"""
+from urllib.parse import urlencode
+from lxml import html
+from datetime import datetime
+
+# about
+from searx.utils import extract_text
+
+about = {
+    "website": 'https://rumble.com/',
+    "wikidata_id": 'Q104765127',
+    "official_api_documentation": 'https://help.rumble.com/',
+    "use_official_api": False,
+    "require_api_key": False,
+    "results": 'HTML',
+}
+
+# engine dependent config
+categories = ['videos']
+paging = True
+
+# search-url
+base_url = 'https://rumble.com'
+# https://rumble.com/search/video?q=searx&page=3
+search_url = base_url + '/search/video?{query}&page={pageno}'
+
+url_xpath = './/a[@class="video-item--a"]/@href'
+thumbnail_xpath = './/img[@class="video-item--img"]/@src'
+title_xpath = './/h3[@class="video-item--title"]'
+published_date = './/time[@class="video-item--meta video-item--time"]/@datetime'
+earned_xpath = './/span[@class="video-item--meta video-item--earned"]/@data-value'
+views_xpath = './/span[@class="video-item--meta video-item--views"]/@data-value'
+rumbles_xpath = './/span[@class="video-item--meta video-item--rumbles"]/@data-value'
+author_xpath = './/div[@class="ellipsis-1"]'
+length_xpath = './/span[@class="video-item--duration"]/@data-value'
+
+
+def request(query, params):
+    params['url'] = search_url.format(pageno=params['pageno'], query=urlencode({'q': query}))
+    return params
+
+
+def response(resp):
+    results = []
+    dom = html.fromstring(resp.text)
+    results_dom = dom.xpath('//li[contains(@class, "video-listing-entry")]')
+
+    if not results_dom:
+        return []
+
+    for result_dom in results_dom:
+        url = base_url + extract_text(result_dom.xpath(url_xpath))
+        thumbnail = extract_text(result_dom.xpath(thumbnail_xpath))
+        title = extract_text(result_dom.xpath(title_xpath))
+        p_date = extract_text(result_dom.xpath(published_date))
+        # fix offset date for line 644 webapp.py check
+        fixed_date = datetime.strptime(p_date, '%Y-%m-%dT%H:%M:%S%z')
+        earned = extract_text(result_dom.xpath(earned_xpath))
+        views = extract_text(result_dom.xpath(views_xpath))
+        rumbles = extract_text(result_dom.xpath(rumbles_xpath))
+        author = extract_text(result_dom.xpath(author_xpath))
+        length = extract_text(result_dom.xpath(length_xpath))
+        if earned:
+            content = f"{views} views - {rumbles} rumbles - ${earned}"
+        else:
+            content = f"{views} views - {rumbles} rumbles"
+
+        results.append({
+            'url': url,
+            'title': title,
+            'content': content,
+            'author': author,
+            'length': length,
+            'template': 'videos.html',
+            'publishedDate': fixed_date,
+            'thumbnail': thumbnail,
+        })
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1251,6 +1251,14 @@ engines:
 #    number_of_results : 5
 #    timeout : 3.0
 
+  - name : rumble
+    engine : rumble
+    shortcut : ru
+    base_url : https://rumble.com/
+    paging : True
+    categories: videos
+    disabled : True
+
 # Doku engine lets you access to any Doku wiki instance:
 # A public one or a privete/corporate one.
 #  - name : ubuntuwiki


### PR DESCRIPTION
New video search engine: rumble.com
Added rumble.py to searx/engines/
Add rumble.com to sears/settings.yml -1254
Same style + xpath processing using lxml as other engines.
No changes anywhere else.