### PR TITLE
[py2to3] use unittest from py3, remove unittest2 from py2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,6 @@ pycodestyle==2.6.0
 pylint==2.6.2
 splinter==0.14.0
 transifex-client==0.14.2
-unittest2==1.1.0
 selenium==3.141.0
 twine==3.3.0
 Pallets-Sphinx-Themes==1.2.3

--- a/searx/testing.py
+++ b/searx/testing.py
@@ -10,8 +10,8 @@ import traceback
 
 from os.path import dirname, join, abspath, realpath
 
+from unittest import TestCase
 from splinter import Browser
-from unittest2 import TestCase
 
 
 class SearxTestLayer:


### PR DESCRIPTION
- unittest2 is a backport of the new features added to the unittest testing framework in Python 2.7
- unittest2 was only needed in py2 and can be dropped now
