### PR TITLE
[mod] Drop Ubuntu 16.04 (Xenial Xerus) support

### DIFF
--- a/utils/lxc-searx.env
+++ b/utils/lxc-searx.env
@@ -21,7 +21,6 @@ lxc_set_suite_env() {
         # to disable containers, comment out lines ..
 
         # end of standard support see https://wiki.ubuntu.com/Releases
-        "$LINUXCONTAINERS_ORG_NAME:ubuntu/16.04"  "ubu1604" # April 2021
         "$LINUXCONTAINERS_ORG_NAME:ubuntu/18.04"  "ubu1804" # April 2023
         "$LINUXCONTAINERS_ORG_NAME:ubuntu/20.04"  "ubu2004" # April 2025
         "$LINUXCONTAINERS_ORG_NAME:ubuntu/20.10"  "ubu2010" # July 2021

--- a/utils/lxc.sh
+++ b/utils/lxc.sh
@@ -24,13 +24,12 @@ LXC_HOST_PREFIX="${LXC_HOST_PREFIX:-test}"
 LXC_SHARE_FOLDER="/share"
 LXC_REPO_ROOT="${LXC_SHARE_FOLDER}/$(basename "${REPO_ROOT}")"
 
-ubu1604_boilerplate="
+ubu1804_boilerplate="
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
 apt-get upgrade -y
 apt-get install -y git curl wget
 "
-ubu1804_boilerplate="$ubu1604_boilerplate"
 ubu1904_boilerplate="$ubu1804_boilerplate"
 
 # shellcheck disable=SC2034


### PR DESCRIPTION
EOL of Ubuntu 16.04 (Xenial Xerus) is in April 2021 but we do not support 16.04
since a longer time.  Issues are coming from dependencies (e.g. pip)::

    [searx-ubu1604]   |searx| SyntaxError: invalid syntax
    [searx-ubu1604]   |searx| Traceback (most recent call last):
    [searx-ubu1604]   |searx|   File "/usr/local/searx/searx-pyenv/bin/pip", line 7, in <module>
    [searx-ubu1604]   |searx|     from pip._internal.cli.main import main
    [searx-ubu1604]   |searx|   File "/usr/local/searx/searx-pyenv/lib/python3.5/site-packages/pip/_internal/cli/main.py", line 60
    [searx-ubu1604]   |searx|     sys.stderr.write(f"ERROR: {exc}")
    [searx-ubu1604]   |searx|                                    ^
    [searx-ubu1604]   |searx| SyntaxError: invalid syntax


