### PR TITLE
[fix] support git versions <v2.22

### DIFF
--- a/utils/searx.sh
+++ b/utils/searx.sh
@@ -394,8 +394,8 @@ clone_searx() {
         info_msg "create local branch ${GIT_BRANCH} from start point: origin/${GIT_BRANCH}"
         git branch "${GIT_BRANCH}" "origin/${GIT_BRANCH}"
     fi
-    if [[ ! $(git branch --show-current) == "${GIT_BRANCH}" ]]; then
-        warn_msg "take into account, installing branch $GIT_BRANCH while current branch is $(git branch --show-current)"
+    if [[ ! $(git rev-parse --abbrev-ref HEAD) == "${GIT_BRANCH}" ]]; then
+        warn_msg "take into account, installing branch $GIT_BRANCH while current branch is $(git rev-parse --abbrev-ref HEAD)"
     fi
     export SERVICE_HOME
     git_clone "$REPO_ROOT" "$SEARX_SRC" \


### PR DESCRIPTION
LTS distros like Ubuntu 18.04 do not ship a up-to-date version of git:

    $ sudo -H ./utils/lxc.sh cmd searx-ubu1804 git --version
    ...
    git version 2.17.1

The option `--show-current` was added in git v2.22, the alternative to this option is:

    git rev-parse --abbrev-ref HEAD

Issue when using option `--show-current`:

    [searx-ubu1804] Clone searx sources
    [searx-ubu1804] -------------------
    [searx-ubu1804]
    [searx-ubu1804] error: unknown option `show-current'
    [searx-ubu1804] usage: git branch [<options>] [-r | -a] [--merged | --no-merged]
    ....

## How to test this PR locally?

    sudo -H ./utils/lxc.sh remove searx-ubu1804
    sudo -H ./utils/lxc.sh build searx-ubu1804
    sudo -H ./utils/lxc.sh install suite searx-ubu1804

