### PR TITLE
[fix] utils/serax.sh create_pyenv() - drop duplicate 'pip install .'

### DIFF
--- a/utils/searx.sh
+++ b/utils/searx.sh
@@ -503,7 +503,6 @@ pip install -U pip
 pip install -U setuptools
 pip install -U wheel
 pip install -U pyyaml
-pip install -U -e .
 cd ${SEARX_SRC}
 pip install -e .
 EOF


### PR DESCRIPTION
The wrong and unnecessary `pip install .` is executed in `/usr/local/searx` and is responsible for the error message:

    ERROR: File "setup.py" not found. Directory cannot be installed in editable mode: /usr/local/searx

The correct pip-install comes right after changing to `cd ${SEARX_SRC}`.

## How to test this PR locally?

In LXC you can use:

    sudo -H ./utils/lxc.sh install suite searx-ubu1804

Otherwise test by installing on the localhost:

    sudo -H ./utils/searx.sh install user
    sudo -H ./utils/searx.sh install searx-src
    sudo -H ./utils/searx.sh install pyenv

To remove the installation from localhost use:

    sudo -H ./utils/searx.sh remove user
