### PR TITLE
[fix] add package `which` to CentOS-7 boilerplate

### DIFF
--- a/utils/lxc.sh
+++ b/utils/lxc.sh
@@ -59,7 +59,7 @@ echo 'Set disable_coredump false' >> /etc/sudo.conf
 # shellcheck disable=SC2034
 centos7_boilerplate="
 yum update -y
-yum install -y git curl wget hostname sudo
+yum install -y git curl wget hostname sudo which
 echo 'Set disable_coredump false' >> /etc/sudo.conf
 "
 


### PR DESCRIPTION
Newer CentOS-7 images from https://images.linuxcontainers.org do no longer
include the `which` command. Issue:

    $ sudo -H ./utils/lxc.sh cmd searx-centos7 ./utils/filtron.sh install all
    INFO:  [searx-centos7] ./utils/filtron.sh install all
    ...
    Install Go in user's HOME
    -------------------------

    download and install go binary ..
    ...
    -bash: line 1: which: command not found
    -->|ERROR - Go Installation not found in PATH!?!
    -bash: line 2: which: command not found

## How to test this PR locally?

    $ sudo -H ./utils/lxc.sh remove searx-centos7
    $ sudo -H ./utils/lxc.sh build searx-centos7
    $ sudo -H ./utils/lxc.sh cmd searx-centos7 ./utils/filtron.sh install all
