### PR TITLE
[mod] LXC switch to Fedora 33 / Fedora 31 reached its EOL

### DIFF
--- a/utils/lxc-searx.env
+++ b/utils/lxc-searx.env
@@ -26,7 +26,7 @@ lxc_set_suite_env() {
         "$LINUXCONTAINERS_ORG_NAME:ubuntu/20.10"  "ubu2010" # July 2021
 
         # EOL see https://fedoraproject.org/wiki/Releases
-        "$LINUXCONTAINERS_ORG_NAME:fedora/31"     "fedora31"
+        "$LINUXCONTAINERS_ORG_NAME:fedora/33"     "fedora33"
 
         # rolling releases see https://www.archlinux.org/releng/releases/
         "$LINUXCONTAINERS_ORG_NAME:archlinux"     "archlinux"

--- a/utils/lxc.sh
+++ b/utils/lxc.sh
@@ -49,7 +49,7 @@ echo 'Set disable_coredump false' >> /etc/sudo.conf
 "
 
 # shellcheck disable=SC2034
-fedora31_boilerplate="
+fedora33_boilerplate="
 dnf update -y
 dnf install -y git curl wget hostname
 echo 'Set disable_coredump false' >> /etc/sudo.conf


### PR DESCRIPTION
## What does this PR do?

switch to Fedora 33 / Fedora 31 reached its EOL

## Why is this change important?

Fedora 31 images are no longer available

## How to test this PR locally?

     sudo -H ./utils/lxc.sh build searx-fedora33
     sudo -H ./utils/lxc.sh install suite searx-fedora33
     sudo -H ./utils/lxc.sh cmd searx-fedora33 ./utils/filtron.sh nginx install

