### PR TITLE
[mod] don't dump traceback of SearxEngineResponseException on init

### DIFF
--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -26,6 +26,7 @@ from operator import itemgetter
 from searx import settings
 from searx import logger
 from searx.data import ENGINES_LANGUAGES
+from searx.exceptions import SearxEngineResponseException
 from searx.poolrequests import get, get_proxy_cycles
 from searx.utils import load_module, match_language, get_engine_from_settings, gen_useragent
 
@@ -291,6 +292,8 @@ def initialize_engines(engine_list):
     def engine_init(engine_name, init_fn):
         try:
             init_fn(get_engine_from_settings(engine_name))
+        except SearxEngineResponseException as exc:
+            logger.warn('%s engine: Fail to initialize // %s', engine_name, exc)
         except Exception:
             logger.exception('%s engine: Fail to initialize', engine_name)
         else:


### PR DESCRIPTION
## What does this PR do?

don't dump traceback of SearxEngineResponseException on init

## Why is this change important?

When initing engines a `SearxEngineResponseException` is logged very verbose, including full traceback information:

    ERROR:searx.engines:yggtorrent engine: Fail to initialize
    Traceback (most recent call last):
      File "share/searx/searx/engines/__init__.py", line 293, in engine_init
        init_fn(get_engine_from_settings(engine_name))
      File "share/searx/searx/engines/yggtorrent.py", line 42, in init
        resp = http_get(url, allow_redirects=False)
      File "share/searx/searx/poolrequests.py", line 197, in get
        return request('get', url, **kwargs)
      File "share/searx/searx/poolrequests.py", line 190, in request
        raise_for_httperror(response)
      File "share/searx/searx/raise_for_httperror.py", line 60, in raise_for_httperror
        raise_for_captcha(resp)
      File "share/searx/searx/raise_for_httperror.py", line 43, in raise_for_captcha
        raise_for_cloudflare_captcha(resp)
      File "share/searx/searx/raise_for_httperror.py", line 30, in raise_for_cloudflare_captcha
        raise SearxEngineCaptchaException(message='Cloudflare CAPTCHA', suspended_time=3600 * 24 * 15)
    searx.exceptions.SearxEngineCaptchaException: Cloudflare CAPTCHA, suspended_time=1296000

For `SearxEngineResponseException` this is not needed.  Those types of exceptions can be a normal use case.  E.g. for CAPTCHA errors like shown in the example above. It should be enough to log a warning for such issues:

    WARNING:searx.engines:yggtorrent engine: Fail to initialize // Cloudflare CAPTCHA, suspended_time=1296000

## How to test this PR locally?

     make run

## Related issues

closes: #2612
