### PR TITLE
[mod] by default allow only HTTPS, not HTTP

### DIFF
--- a/docs/dev/engine_overview.rst
+++ b/docs/dev/engine_overview.rst
@@ -58,6 +58,8 @@ argument                type        information
 name                    string      name of search-engine
 engine                  string      name of searx-engine
                                     (filename without ``.py``)
+enable_http             bool        enable HTTP
+                                    (by default only HTTPS is enabled).
 shortcut                string      shortcut of search-engine
 timeout                 string      specific timeout for search-engine
 display_error_messages  boolean     display error messages on the web UI

--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -50,6 +50,7 @@ engine_default_args = {'paging': False,
                        'timeout': settings['outgoing']['request_timeout'],
                        'shortcut': '-',
                        'disabled': False,
+                       'enable_http': False,
                        'suspend_end_time': 0,
                        'continuous_errors': 0,
                        'time_range_support': False,
@@ -305,35 +306,3 @@ def initialize_engines(engine_list):
             if init_fn:
                 logger.debug('%s engine: Starting background initialization', engine_name)
                 threading.Thread(target=engine_init, args=(engine_name, init_fn)).start()
-
-        _set_https_support_for_engine(engine)
-
-
-def _set_https_support_for_engine(engine):
-    # check HTTPS support if it is not disabled
-    if engine.engine_type != 'offline' and not hasattr(engine, 'https_support'):
-        params = engine.request('http_test', {
-            'method': 'GET',
-            'headers': {},
-            'data': {},
-            'url': '',
-            'cookies': {},
-            'verify': True,
-            'auth': None,
-            'pageno': 1,
-            'time_range': None,
-            'language': '',
-            'safesearch': False,
-            'is_test': True,
-            'category': 'files',
-            'raise_for_status': True,
-            'engine_data': {},
-        })
-
-        if 'url' not in params:
-            return
-
-        parsed_url = urlparse(params['url'])
-        https_support = parsed_url.scheme == 'https'
-
-        setattr(engine, 'https_support', https_support)

--- a/searx/poolrequests.py
+++ b/searx/poolrequests.py
@@ -91,9 +91,10 @@ class SessionSinglePool(requests.Session):
         self.adapters.clear()
 
         https_adapter = threadLocal.__dict__.setdefault('https_adapter', next(https_adapters))
-        http_adapter = threadLocal.__dict__.setdefault('http_adapter', next(http_adapters))
         self.mount('https://', https_adapter)
-        self.mount('http://', http_adapter)
+        if get_enable_http_protocol():
+            http_adapter = threadLocal.__dict__.setdefault('http_adapter', next(http_adapters))
+            self.mount('http://', http_adapter)
 
     def close(self):
         """Call super, but clear adapters since there are managed globaly"""
@@ -104,6 +105,17 @@ class SessionSinglePool(requests.Session):
 def set_timeout_for_thread(timeout, start_time=None):
     threadLocal.timeout = timeout
     threadLocal.start_time = start_time
+
+
+def set_enable_http_protocol(enable_http):
+    threadLocal.enable_http = enable_http
+
+
+def get_enable_http_protocol():
+    try:
+        return threadLocal.enable_http
+    except AttributeError:
+        return False
 
 
 def reset_time_for_thread():

--- a/searx/search/processors/online.py
+++ b/searx/search/processors/online.py
@@ -131,6 +131,8 @@ class OnlineProcessor(EngineProcessor):
         poolrequests.set_timeout_for_thread(timeout_limit, start_time=start_time)
         # reset the HTTP total time
         poolrequests.reset_time_for_thread()
+        # enable HTTP only if explicitly enabled
+        poolrequests.set_enable_http_protocol(self.engine.enable_http)
 
         # suppose everything will be alright
         requests_exception = False

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -656,6 +656,7 @@ engines:
 
   - name : library genesis
     engine : xpath
+    enable_http: True
     search_url : http://libgen.rs/search.php?req={query}
     url_xpath : //a[contains(@href,"bookfi.net/md5")]/@href
     title_xpath : //a[contains(@href,"book/")]/text()[1]

--- a/searx/templates/oscar/preferences.html
+++ b/searx/templates/oscar/preferences.html
@@ -230,7 +230,7 @@
                                     <td class="onoff-checkbox">
                                         {{ checkbox_toggle('engine_' + search_engine.name|replace(' ', '_') + '__' + categ|replace(' ', '_'), (search_engine.name, categ) in disabled_engines) }}
                                     </td>
-                                    <th scope="row">{% if not search_engine.https_support %}{{ icon('exclamation-sign', 'No HTTPS') }}{% endif %} {{ search_engine.name }}</td></th>
+                                    <th scope="row">{% if search_engine.enable_http %}{{ icon('exclamation-sign', 'No HTTPS') }}{% endif %} {{ search_engine.name }}</td></th>
                                     <td class="name">{{ shortcuts[search_engine.name] }}
                                         <td>{{ support_toggle(stats[search_engine.name].supports_selected_language) }}</td>
                                         <td>{{ support_toggle(search_engine.safesearch==True) }}</td>

--- a/searx/templates/simple/preferences.html
+++ b/searx/templates/simple/preferences.html
@@ -121,7 +121,7 @@
       {% set engine_id = 'engine_' + search_engine.name|replace(' ', '_') + '__' + categ|replace(' ', '_') %}
       <tr>
         <td class="engine_checkbox">{{ checkbox_onoff(engine_id, (search_engine.name, categ) in disabled_engines) }}</td>
-        <th class="name">{% if not search_engine.https_support %}{{ icon('warning', 'No HTTPS') }}{% endif %} {{ search_engine.name }}</th>
+        <th class="name">{% if search_engine.enable_http %}{{ icon('warning', 'No HTTPS') }}{% endif %} {{ search_engine.name }}</th>
         <td class="shortcut">{{ shortcuts[search_engine.name] }}</td>
         <td>{{ checkbox(engine_id + '_supported_languages', current_language == 'all' or current_language in search_engine.supported_languages or current_language.split('-')[0] in search_engine.supported_languages, true, true) }}</td>
         <td>{{ checkbox(engine_id + '_safesearch', search_engine.safesearch==True, true, true) }}</td>


### PR DESCRIPTION
## What does this PR do?

This PR disable HTTP by default, and allows only the HTTPS protocol.

The HTTP can be explicitly enable using `enable_http: True`.

## Why is this change important?

The PR https://github.com/searx/searx/pull/2373 detects if engine use HTTP instead of HTTPS using the `request` function of each engine.

But some engine send HTTP(S) requests in the `request` function:
* https://github.com/searx/searx/blob/0d8b369b5b300e8a575d6715fc75067d09db63a5/searx/engines/duckduckgo_images.py#L40
* https://github.com/searx/searx/blob/0d8b369b5b300e8a575d6715fc75067d09db63a5/searx/engines/seznam.py#L26

Also, some other engines send additional request in the `response` function:
* https://github.com/searx/searx/blob/0d8b369b5b300e8a575d6715fc75067d09db63a5/searx/engines/duckduckgo.py#L92
* https://github.com/searx/searx/blob/0d8b369b5b300e8a575d6715fc75067d09db63a5/searx/engines/pubmed.py#L66

This PR minimize the number of HTTP(S) requests each time searx starts (and tested too).

In addition it makes sure searx never sends HTTP request even if an engine sends more than one request (except if explicitly enabled).

## How to test this PR locally?

* In `settings.yml`, set `enable_http: False` in the `library genesis` section.
* Search using this engine
* The response should be:
![image](https://user-images.githubusercontent.com/1594191/110310739-28a39b00-8003-11eb-8e52-e3bc5e62250e.png)
* the log:
```
ERROR:searx.search.processor.online:engine library genesis : requests exception(search duration : 0.08051466941833496 s, timeout: 7.0 s) : No connection adapters were found for 'http://libgen.rs/search.php?req=time'
Traceback (most recent call last):
  File "/home/alexandre/code/searx/searx/search/processors/online.py", line 143, in search
    search_results = self._search_basic(query, params)
  File "/home/alexandre/code/searx/searx/search/processors/online.py", line 123, in _search_basic
    response = self._send_http_request(params)
  File "/home/alexandre/code/searx/searx/search/processors/online.py", line 95, in _send_http_request
    response = req(params['url'], **request_args)
  File "/home/alexandre/code/searx/searx/poolrequests.py", line 209, in get
    return request('get', url, **kwargs)
  File "/home/alexandre/code/searx/searx/poolrequests.py", line 181, in request
    response = session.request(method=method, url=url, **kwargs)
  File "/home/alexandre/code/searx/local/py3/lib/python3.8/site-packages/requests/sessions.py", line 542, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/alexandre/code/searx/local/py3/lib/python3.8/site-packages/requests/sessions.py", line 649, in send
    adapter = self.get_adapter(url=request.url)
  File "/home/alexandre/code/searx/local/py3/lib/python3.8/site-packages/requests/sessions.py", line 742, in get_adapter
    raise InvalidSchema("No connection adapters were found for {!r}".format(url))
requests.exceptions.InvalidSchema: No connection adapters were found for 'http://libgen.rs/search.php?req=time'
```

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Related to 
* https://github.com/searx/searx/pull/2373
* https://github.com/searx/searx/issues/302#issuecomment-247315796
