### PR TITLE
[fix] make targets engines.languages and useragents.update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,15 +94,14 @@ project: buildenv useragents.update engines.languages
 
 engines.languages:  pyenvinstall
 	$(Q)echo "fetch languages .."
-	$(Q)$(PY_ENV_ACT); python utils/fetch_languages.py
-	$(Q)echo "update searx/data/engines_languages.json"
-	$(Q)mv engines_languages.json searx/data/engines_languages.json
-	$(Q)echo "update searx/languages.py"
-	$(Q)mv languages.py searx/languages.py
+	$(Q)$(PY_ENV_ACT); python ./searx_extra/update/update_languages.py
+	$(Q)echo "updated searx/data/engines_languages.json"
+	$(Q)echo "updated searx/languages.py"
 
 useragents.update:  pyenvinstall
-	$(Q)echo "Update searx/data/useragents.json with the most recent versions of Firefox."
-	$(Q)$(PY_ENV_ACT); python utils/fetch_firefox_version.py
+	$(Q)echo "fetch useragents .."
+	$(Q)$(PY_ENV_ACT); python ./searx_extra/update/update_firefox_version.py
+	$(Q)echo "updated searx/data/useragents.json with the most recent versions of Firefox."
 
 buildenv: pyenv
 	$(Q)$(PY_ENV_ACT); SEARX_DEBUG=1 python utils/build_env.py


### PR DESCRIPTION
## What does this PR do?

Fix make targets `engines.languages` and `useragents.update`

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

Since PR #2600 is merged the update scripts for languages and useragent has been moved to folder:

    searx_extra/update/

## How to test this PR locally?

    make engines.languages useragents.update
