### PR TITLE
Add Apache Solr engine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,7 @@ PYLINT_FILES=\
 	searx/engines/google_images.py \
 	searx/engines/mediathekviewweb.py \
 	searx/engines/solidtorrents.py \
+	searx/engines/solr.py \
 	searx/engines/google_scholar.py \
 	searx/engines/yahoo_news.py \
 	searx/engines/apkmirror.py \

--- a/searx/engines/solr.py
+++ b/searx/engines/solr.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""
+ Solr
+"""
+
+# pylint: disable=global-statement, missing-function-docstring
+
+from json import loads
+from urllib.parse import urlencode
+from searx.exceptions import SearxEngineAPIException
+
+
+base_url = 'http://localhost:8983'
+collection = ''
+rows = 10
+sort = '' # sorting: asc or desc
+field_list = 'name' # list of field names to display on the UI
+default_fields = '' # default field to query
+query_fields = '' # query fields
+_search_url = ''
+paging = True
+
+
+def init(_):
+    if collection == '':
+        raise ValueError('collection cannot be empty')
+
+    global _search_url
+    _search_url = base_url + '/solr/' + collection + '/select?{params}'
+
+
+def request(query, params):
+    query_params = {'q': query, 'rows': rows}
+    if field_list != '':
+        query_params['fl'] = field_list
+    if query_fields != '':
+        query_params['qf'] = query_fields
+    if default_fields != '':
+        query_params['df'] = default_fields
+    if sort != '':
+        query_params['sort'] = sort
+
+    if 'pageno' in params:
+        query_params['start'] = rows * (params['pageno'] - 1)
+
+    params['url'] = _search_url.format(params=urlencode(query_params))
+
+    return params
+
+
+def response(resp):
+    resp_json = __get_response(resp)
+
+    results = []
+    for result in resp_json['response']['docs']:
+        r = {key: str(value) for key, value in result.items()}
+        if len(r) == 0:
+            continue
+        r['template'] = 'key-value.html'
+        results.append(r)
+
+    return results
+
+
+def __get_response(resp):
+    try:
+        resp_json = loads(resp.text)
+    except Exception as e:
+        raise SearxEngineAPIException("failed to parse response") from e
+
+    if 'error' in resp_json:
+        raise SearxEngineAPIException(resp_json['error']['msg'])
+
+    return resp_json

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -943,6 +943,17 @@ engines:
 #    api_client_id : *******
 #    api_client_secret : *******
 
+#  - name : solr
+#    engine : solr
+#    shortcut : slr
+#    base_url : http://localhost:8983
+#    collection : collection_name
+#    sort : '' # sorting: asc or desc
+#    field_list : '' # comma separated list of field names to display on the UI
+#    default_fields : '' # default field to query
+#    query_fields : '' # query fields
+#    enable_http : True
+
   - name : startpage
     engine : startpage
     shortcut : sp


### PR DESCRIPTION
## What does this PR do?

This PR adds a new engine that is able to query Apache Solr collections. Administrators must configure `collection` to use the engine. Also, generic settings are exposed as well:
* `lf` as `field_list`
* `df` as `default_fields`
* `qf` as `query_fields`

The query part users can submit is substituted into `q`. Thus, the generic `*:*` and so on queries work as expected.

Example output on the UI:

![solrengine_000](https://user-images.githubusercontent.com/3876218/111043490-25fdd700-8443-11eb-9030-6e46ed731857.png)


The engine has been tested with Apache Solr v8.8.1.

## Why is this change important?

This is another "offline" engine that relies on a backend that can be hosted on your machine.

## How to test this PR locally?

Install Solr: https://solr.apache.org/guide/8_8/solr-tutorial.html
Uncomment solr section in `settings.yml`.
Search. Example query: `*:*`, `{fieldname}:{value}`
