### PR TITLE
[mod] oscar: remove space

### DIFF
--- a/searx/templates/oscar/macros.html
+++ b/searx/templates/oscar/macros.html
@@ -19,9 +19,9 @@
 
 <!-- Draw result sub header -->
 {% macro result_sub_header(result, id) -%}
-    {% if result.publishedDate %}<time class="text-muted" datetime="{{ result.pubdate }}" >{{ result.publishedDate }}</time>{% endif %}
-    {% if result.magnetlink %}<small> &bull; {{ result_link(result.magnetlink, icon('magnet') + _('magnet link'), "magnetlink", id) }}</small>{% endif %}
-    {% if result.torrentfile %}<small> &bull; {{ result_link(result.torrentfile, icon('download-alt') + _('torrent file'), "torrentfile", id) }}</small>{% endif %}
+    {%- if result.publishedDate %}<time class="text-muted" datetime="{{ result.pubdate }}" >{{ result.publishedDate }}</time>{% endif -%}
+    {%- if result.magnetlink %}<small> &bull; {{ result_link(result.magnetlink, icon('magnet') + _('magnet link'), "magnetlink", id) }}</small>{% endif -%}
+    {%- if result.torrentfile %}<small> &bull; {{ result_link(result.torrentfile, icon('download-alt') + _('torrent file'), "torrentfile", id) }}</small>{% endif -%}
 {%- endmacro %}
 
 <!-- Draw result footer -->
@@ -32,11 +32,11 @@
             <span class="label label-default">{{ engine }}</span>
         {%- endfor -%}
         {%- if result.url -%}
-            {% if result.cached_url %}
+            {%- if result.cached_url -%}
             <small>{{ result_link(result.cached_url, icon('link') + _('cached'), "text-info", id) }}</small>
-            {% elif not result.is_onion %}
+            {%- elif not result.is_onion -%}
             <small>{{ result_link("https://web.archive.org/web/" + result.url, icon('link') + _('cached'), "text-info", id) }}</small>
-            {% endif %}
+            {%- endif -%}
         {%- endif -%}
         {%- if proxify -%}
         <small>{{ result_link(proxify(result.url), icon('sort') + _('proxied'), "text-info", id) }}</small>
@@ -49,73 +49,73 @@
 
 <!-- Draw result footer without cache link -->
 {% macro result_footer_nocache(result) -%}
-    <div class="clearfix"></div>
+    <div class="clearfix"></div>{{- ""  -}}
     <div class="pull-right">
-    {% for engine in result.engines %}
+    {%- for engine in result.engines -%}
         <span class="label label-default">{{ engine }}</span>
-    {% endfor %}
-    {% if proxify %}
+    {%- endfor -%}
+    {%- if proxify -%}
     <small>{{ result_link(proxify(result.url), icon('sort') + _('proxied'), "text-info") }}</small>
-    {% endif %}
-</div>
+    {%- endif -%}
+</div>{{- "" -}}
 <div class="external-link">{{ result.pretty_url }}</div>
 {%- endmacro %}
 
 <!-- Draw result footer -->
 {% macro result_footer_rtl(result, id) -%}
-    <div class="clearfix"></div>{{- "" -}}
-    {% for engine in result.engines -%}
+    <div class="clearfix"></div>
+    {%- for engine in result.engines -%}
         <span class="label label-default">{{ engine }}</span>
-    {%- endfor %}
+    {%- endfor -%}
     {%- if result.url -%}
-        {% if result.cached_url %}
+        {%- if result.cached_url -%}
         <small>{{ result_link(result.cached_url, icon('link') + _('cached'), "text-info", id) }}</small>
-        {% elif not result.is_onion %}
+        {%- elif not result.is_onion -%}
         <small>{{ result_link("https://web.archive.org/web/" + result.url, icon('link') + _('cached'), "text-info", id) }}</small>
-        {% endif %}
+        {%- endif -%}
     {%- endif -%}
-    {% if proxify -%}
+    {%- if proxify -%}
     <small>{{ result_link(proxify(result.url), icon('sort') + _('proxied'), "text-info", id) }}</small>
-    {%- endif %}
+    {%- endif -%}
     {%- if result.pretty_url -%}
     <div class="external-link">{{ result.pretty_url }}</div>
-    {%- endif %}
+    {%- endif -%}
 {%- endmacro %}
 
 <!-- Draw result footer without cache link -->
 {% macro result_footer_nocache_rtl(result) -%}
     <div class="clearfix"></div>
-    {% for engine in result.engines %}
+    {%- for engine in result.engines -%}
         <span class="label label-default">{{ engine }}</span>
-    {% endfor %}
-    {% if proxify %}
+    {%- endfor -%}
+    {%- if proxify -%}
     <small>{{ result_link(proxify(result.url), icon('sort') + _('proxied'), "text-info") }}</small>
-    {% endif %}
+    {%- endif -%}
     <div class="external-link">{{ result.pretty_url }}</div>
 {%- endmacro %}
 
 {% macro preferences_item_header(info, label, rtl, id) -%}
-    {% if rtl %}
-    <div class="row form-group">
-        <label class="col-sm-3 col-md-2 pull-right"{% if id %} for="{{id}}"{% endif %}>{{ label }}</label>
-        <span class="col-sm-5 col-md-6 help-block pull-left">{{ info }}</span>
+    {%- if rtl -%}
+    <div class="row form-group">{{- "" -}}
+        <label class="col-sm-3 col-md-2 pull-right"{% if id %} for="{{id}}"{% endif %}>{{ label }}</label>{{- "" -}}
+        <span class="col-sm-5 col-md-6 help-block pull-left">{{ info }}</span>{{- "" -}}
         <div class="col-sm-4 col-md-4">
-    {% else %}
-    <div class="row form-group">
-        <label class="col-sm-3 col-md-2"{% if id %} for="{{id}}"{% endif %}>{{ label }}</label>
+    {%- else -%}
+    <div class="row form-group">{{- "" -}}
+        <label class="col-sm-3 col-md-2"{% if id %} for="{{id}}"{% endif %}>{{ label }}</label>{{- "" -}}
         <div class="col-sm-4 col-md-4">
-    {% endif %}
+    {%- endif -%}
 {%- endmacro %}
 
 {% macro preferences_item_footer(info, label, rtl) -%}
-    {% if rtl %}
-        </div>
+    {%- if rtl -%}
+        </div>{{- "" -}}
     </div>
-    {% else %}
+    {%- else -%}
         </div>
-        <span class="col-sm-5 col-md-6 help-block">{{ info }}</span>
+        <span class="col-sm-5 col-md-6 help-block">{{ info }}</span>{{- "" -}}
     </div>
-    {% endif %}
+    {%- endif -%}
 {%- endmacro %}
 
 {% macro custom_select_class(rtl) -%}
@@ -123,24 +123,24 @@ custom-select{% if rtl %}-rtl{% endif %}
 {%- endmacro %}
 
 {% macro checkbox_toggle(id, blocked) -%}
-    <div class="onoffswitch">
-        <input type="checkbox" id="{{ id }}" name="{{ id }}"{% if blocked %} checked="checked"{% endif %} class="onoffswitch-checkbox">
-        <label class="onoffswitch-label" for="{{ id }}">
-            <span class="onoffswitch-inner"></span>
-            <span class="onoffswitch-switch"></span>
-        </label>
-        <label class="visually-hidden" for="{{ id }}">{{ _('Allow') }}</label>
-    </div>
+    <div class="onoffswitch">{{- "" -}}
+        <input type="checkbox" id="{{ id }}" name="{{ id }}"{% if blocked %} checked="checked"{% endif %} class="onoffswitch-checkbox">{{- "" -}}
+        <label class="onoffswitch-label" for="{{ id }}">{{- "" -}}
+            <span class="onoffswitch-inner"></span>{{- "" -}}
+            <span class="onoffswitch-switch"></span>{{- "" -}}
+        </label>{{- "" -}}
+        <label class="visually-hidden" for="{{ id }}">{{ _('Allow') }}</label>{{- "" -}}
+    </div>{{- "" -}}
 {%- endmacro %}
 
 {% macro support_toggle(supports) -%}
-    {% if supports %}
+    {%- if supports -%}
     <span class="label label-success">
-        {{ _("supported") }}
+        {{- _("supported") -}}
     </span>
-    {% else %}
+    {%- else -%}
     <span class="label label-danger">
-        {{ _("not supported") }}
+        {{- _("not supported") -}}
     </span>
-    {% endif %}
+    {%- endif -%}
 {%- endmacro %}

--- a/searx/templates/oscar/result_templates/default.html
+++ b/searx/templates/oscar/result_templates/default.html
@@ -9,16 +9,16 @@
 
 {%- if result.embedded -%}
 <div id="result-media-{{ index }}" class="collapse">
-   {{ result.embedded|safe }}
+   {{- result.embedded|safe -}}
 </div>
 {%- endif -%}
 
 {%- if result.img_src -%}
-<div class="container-fluid">
-    <div class="row">
-<img src="{{ image_proxify(result.img_src) }}" title="{{ result.title|striptags }}" style="width: auto; max-height: 60px; min-height: 60px;" class="col-xs-2 col-sm-4 col-md-4 result-content">
-{% if result.content %}<p class="result-content col-xs-8 col-sm-8 col-md-8">{{ result.content|safe }}</p>{% endif -%}
-    </div>
+<div class="container-fluid">{{- "" -}}
+    <div class="row">{{- "" -}}
+        <img src="{{ image_proxify(result.img_src) }}" title="{{ result.title|striptags }}" style="width: auto; max-height: 60px; min-height: 60px;" class="col-xs-2 col-sm-4 col-md-4 result-content">
+        {%- if result.content %}<p class="result-content col-xs-8 col-sm-8 col-md-8">{{ result.content|safe }}</p>{% endif -%}
+    </div>{{- "" -}}
 </div>
 {%- else -%}
 {%- if result.content %}<p class="result-content">{{ result.content|safe }}</p>{% endif -%}

--- a/searx/templates/oscar/result_templates/files.html
+++ b/searx/templates/oscar/result_templates/files.html
@@ -1,55 +1,55 @@
 {% from 'oscar/macros.html' import result_header, result_sub_header, result_footer_nocache, result_footer_nocache_rtl, icon with context %}
 
-{{ result_header(result, favicons) }}
-{{ result_sub_header(result) }}
+{{- result_header(result, favicons) -}}
+{{- result_sub_header(result) -}}
 
-{% if result.embedded %}
+{%- if result.embedded -%}
     <small> &bull; <a class="text-info btn-collapse collapsed cursor-pointer media-loader disabled_if_nojs" data-toggle="collapse" data-target="#result-media-{{ index }}" data-btn-text-collapsed="{{ _('show media') }}" data-btn-text-not-collapsed="{{ _('hide media') }}">
-    {% if result.mtype == 'audio' %}{{ icon('music') }}
-    {% elif result.mtype == 'video' %} {{ icon('film') }}
-    {% endif %} {{ _('show media') }}</a></small>
-{% endif %}
+    {%- if result.mtype == 'audio' %}{{ icon('music') -}}
+    {%- elif result.mtype == 'video' %} {{ icon('film') -}}
+    {%- endif %} {{ _('show media') }}</a></small>
+{%- endif -%}
 
-{% if result.embedded %}
+{%- if result.embedded -%}
 <div id="result-media-{{ index }}" class="collapse">
-   {{ result.embedded|safe }}
+   {{- result.embedded|safe -}}
 </div>
-{% endif %}
+{%- endif -%}
 
-{% if result.abstract %}<p class="result-content result-abstract">{{ result.abstract|safe }}</p>{% endif %}
+{%- if result.abstract %}<p class="result-content result-abstract">{{ result.abstract|safe }}</p>{% endif -%}
 
-{% if result.img_src %}
+{%- if result.img_src -%}
 <div class="container-fluid">
     <div class="row">
 <img src="{{ image_proxify(result.img_src) }}" alt="{{ result.title|striptags }}" title="{{ result.title|striptags }}" style="width: auto; max-height: 60px; min-height: 60px;" class="col-xs-2 col-sm-4 col-md-4 result-content">
-{% if result.content %}<p class="result-content col-xs-8 col-sm-8 col-md-8">{{ result.content|safe }}</p>{% endif %}
+{%- if result.content %}<p class="result-content col-xs-8 col-sm-8 col-md-8">{{ result.content|safe }}</p>{% endif -%}
     </div>
 </div>
-{% else %}
-{% if result.content %}<p class="result-content">{{ result.content|safe }}</p>{% endif %}
-{% endif %}
+{%- else -%}
+{%- if result.content %}<p class="result-content">{{ result.content|safe }}</p>{% endif -%}
+{%- endif -%}
 
 <table class="result-metadata result-content">
-{% if result.author %}<tr><td>{{ _('Author') }}</td><td>{{ result.author|safe }}</td></tr>{% endif %}
+{%- if result.author %}<tr><td>{{ _('Author') }}</td><td>{{ result.author|safe }}</td></tr>{% endif -%}
 
-{% if result.filename %}<tr><td>{{ _('Filename') }}</td><td>{{ result.filename|safe }}</td></tr>{% endif %}
+{%- if result.filename %}<tr><td>{{ _('Filename') }}</td><td>{{ result.filename|safe }}</td></tr>{% endif -%}
 
-{% if result.size %}<tr><td>{{ _('Filesize') }}</td><td>
-        {% if result.size < 1024 %}{{ result.size }} {{ _('Bytes') }}
-        {% elif result.size < 1024*1024 %}{{ '{0:0.2f}'.format(result.size/1024) }} {{ _('kiB') }}
-        {% elif result.size < 1024*1024*1024 %}{{ '{0:0.2f}'.format(result.size/1024/1024) }} {{ _('MiB') }}
-        {% elif result.size < 1024*1024*1024*1024 %}{{ '{0:0.2f}'.format(result.size/1024/1024/1024) }} {{ _('GiB') }}
-        {% else %}{{ '{0:0.2f}'.format(result.size/1024/1024/1024/1024) }} {{ _('TiB') }}{% endif %}
+{%- if result.size %}<tr><td>{{ _('Filesize') }}</td><td>
+        {%- if result.size < 1024 %}{{ result.size }} {{ _('Bytes') -}}
+        {%- elif result.size < 1024*1024 %}{{ '{0:0.2f}'.format(result.size/1024) }} {{ _('kiB') -}}
+        {%- elif result.size < 1024*1024*1024 %}{{ '{0:0.2f}'.format(result.size/1024/1024) }} {{ _('MiB') -}}
+        {%- elif result.size < 1024*1024*1024*1024 %}{{ '{0:0.2f}'.format(result.size/1024/1024/1024) }} {{ _('GiB') -}}
+        {%- else %}{{ '{0:0.2f}'.format(result.size/1024/1024/1024/1024) }} {{ _('TiB') }}{% endif -%}
     </td></tr>
-{% endif %}
+{%- endif -%}
 
-{% if result.time %}<tr><td>{{ _('Date') }}</td><td>{{ result.time|safe }}</td></tr>{% endif %}
+{%- if result.time %}<tr><td>{{ _('Date') }}</td><td>{{ result.time|safe }}</td></tr>{% endif -%}
 
-{% if result.mtype %}<tr><td>{{ _('Type') }}</td><td>{{ result.mtype|safe }}/{{ result.subtype|safe }}</td></tr>{% endif %}
+{%- if result.mtype %}<tr><td>{{ _('Type') }}</td><td>{{ result.mtype|safe }}/{{ result.subtype|safe }}</td></tr>{% endif -%}
 </table>
 
-{% if rtl %}
+{%- if rtl -%}
 {{ result_footer_nocache_rtl(result) }}
-{% else %}
+{%- else -%}
 {{ result_footer_nocache(result) }}
-{% endif %}
+{%- endif -%}

--- a/searx/templates/oscar/result_templates/map.html
+++ b/searx/templates/oscar/result_templates/map.html
@@ -1,15 +1,15 @@
 {% from 'oscar/macros.html' import result_header, result_sub_header, result_footer, result_footer_rtl, icon %}
 
-{{ result_header(result, favicons, loop.index) }}
-{{ result_sub_header(result, loop.index) }}
+{{- result_header(result, favicons, loop.index) -}}
+{{- result_sub_header(result, loop.index) -}}
 
-{% if (result.latitude and result.longitude) or result.boundingbox %}
+{%- if (result.latitude and result.longitude) or result.boundingbox -%}
     <small> &bull; <a class="text-info btn-collapse collapsed searx_init_map cursor-pointer disabled_if_nojs" data-toggle="collapse" data-target="#result-map-{{ index }}" data-leaflet-target="osm-map-{{ index }}" data-map-lon="{{ result.longitude }}" data-map-lat="{{ result.latitude }}" {% if result.boundingbox %}data-map-boundingbox='{{ result.boundingbox|tojson|safe }}'{% endif %} {% if result.geojson %}data-map-geojson='{{ result.geojson|tojson|safe }}'{% endif %} data-btn-text-collapsed="{{ _('show map') }}" data-btn-text-not-collapsed="{{ _('hide map') }}">{{ icon('globe') }} {{ _('show map') }}</a></small>
-{% endif %}
+{%- endif -%}
 
-{% if result.osm and (result.osm.type and result.osm.id) %}
+{%- if result.osm and (result.osm.type and result.osm.id) -%}
     <small> &bull; <a class="text-info btn-collapse collapsed cursor-pointer searx_overpass_request disabled_if_nojs" data-toggle="collapse" data-target="#result-overpass-{{ index }}" data-osm-type="{{ result.osm.type }}" data-osm-id="{{ result.osm.id }}" data-result-table="result-overpass-table-{{ index }}" data-result-table-loadicon="result-overpass-table-loading-{{ index }}" data-btn-text-collapsed="{{ _('show details') }}" data-btn-text-not-collapsed="{{ _('hide details') }}">{{ icon('map-marker') }} {{ _('show details') }}</a></small>
-{% endif %}
+{%- endif -%}
 
 {# {% if (result.latitude and result.longitude) %}
     <small> &bull; <a class="text-info btn-collapse collapsed cursor-pointer disabled_if_nojs" data-toggle="collapse" data-target="#result-geodata-{{ index }}" data-btn-text-collapsed="{{ _('show geodata') }}" data-btn-text-not-collapsed="{{ _('hide geodata') }}">{{ icon('map-marker') }} {{ _('show geodata') }}</a></small>
@@ -17,36 +17,36 @@
 
 <div class="container-fluid">
 
-{% if result.address %}
+{%- if result.address -%}
 <p class="row result-content result-adress col-xs-12 col-sm-5 col-md-4" itemscope itemtype="http://schema.org/PostalAddress">
-    {% if result.address.name %}
+    {%- if result.address.name -%}
         <strong itemprop="name">{{ result.address.name }}</strong><br/>
-    {% endif %}
-    {% if result.address.road %}
+    {%- endif -%}
+    {%- if result.address.road -%}
         <span itemprop="streetAddress">
-            {% if result.address.house_number %}{{ result.address.house_number }}, {% endif %}
-            {{ result.address.road }}
+            {%- if result.address.house_number %}{{ result.address.house_number }}, {% endif -%}
+            {{- result.address.road -}}
         </span><br/>
-    {% endif %}
-    {% if result.address.locality %}
+    {%- endif -%}
+    {%- if result.address.locality -%}
         <span itemprop="addressLocality">{{ result.address.locality }}</span>
-        {% if result.address.postcode %}, <span itemprop="postalCode">{{ result.address.postcode }}</span>{% endif %}
+        {%- if result.address.postcode %}, <span itemprop="postalCode">{{ result.address.postcode }}</span>{% endif -%}
         <br/>
-    {% endif %}
-    {% if result.address.country %}
+    {%- endif -%}
+    {%- if result.address.country -%}
         <span itemprop="addressCountry">{{ result.address.country }}</span>
-    {% endif %}
+    {%- endif -%}
 </p>
-{% endif %}
+{%- endif %}
 
-{% if result.osm and (result.osm.type and result.osm.id) %}
+{%- if result.osm and (result.osm.type and result.osm.id) -%}
     <div class="row result-content collapse col-xs-12 col-sm-7 col-md-8" id="result-overpass-{{ index }}"{% if rtl %} dir="ltr"{% endif %}>
         <div class="text-center" id="result-overpass-table-loading-{{ index }}"><img src="{{ url_for('static', filename='img/loader.gif') }}" alt="Loading ..."/></div>
         <table class="table table-striped table-condensed hidden" id="result-overpass-table-{{ index }}">
             <tr><th>key</th><th>value</th></tr>
         </table>
     </div>
-{% endif %}
+{%- endif -%}
 
 {# {% if (result.latitude and result.longitude) %}
     <div class="row collapse col-xs-12 col-sm-5 col-md-4" id="result-geodata-{{ index }}">
@@ -55,18 +55,18 @@
     </div>
 {% endif %} #}
 
-{% if result.content %}<p class="row result-content col-xs-12 col-sm-12 col-md-12">{{ result.content|safe }}</p>{% endif %}
+{%- if result.content %}<p class="row result-content col-xs-12 col-sm-12 col-md-12">{{ result.content|safe }}</p>{% endif -%}
 
 </div>
 
-{% if (result.latitude and result.longitude) or result.boundingbox %}
+{%- if (result.latitude and result.longitude) or result.boundingbox -%}
     <div class="collapse" id="result-map-{{ index }}">
         <div style="height:300px; width:100%; margin: 10px 0;" id="osm-map-{{ index }}"></div>
     </div>
-{% endif %}
+{%- endif -%}
 
-{% if rtl %}
-{{ result_footer_rtl(result, loop.index) }}
+{%- if rtl -%}
+{{- result_footer_rtl(result, loop.index) -}}
 {% else %}
-{{ result_footer(result, loop.index) }}
-{% endif %}
+{{- result_footer(result, loop.index) -}}
+{%- endif -%}

--- a/searx/templates/oscar/result_templates/torrent.html
+++ b/searx/templates/oscar/result_templates/torrent.html
@@ -1,25 +1,25 @@
 {% from 'oscar/macros.html' import result_header, result_sub_header, result_footer, result_footer_rtl, icon %}
 
-{{ result_header(result, favicons, loop.index) }}
-{{ result_sub_header(result, loop.index) }}
+{{- result_header(result, favicons, loop.index) -}}
+{{- result_sub_header(result, loop.index) -}}
 
-{% if result.seed is defined %}<p class="result-content">{{ icon('transfer') }} {{ _('Seeder') }} <span class="badge">{{ result.seed }}</span> &bull; {{ _('Leecher') }} <span class="badge">{{ result.leech }}</span>{% endif %}
-{% if result.filesize %}<br />{{ icon('floppy-disk') }} {{ _('Filesize') }} 
+{%- if result.seed is defined %}<p class="result-content">{{ icon('transfer') }} {{ _('Seeder') }} <span class="badge">{{ result.seed }}</span> &bull; {{ _('Leecher') }} <span class="badge">{{ result.leech }}</span>{% endif -%}
+{%- if result.filesize %}<br />{{ icon('floppy-disk') }} {{ _('Filesize') -}} 
     <span class="badge">
-        {% if result.filesize < 1024 %}{{ result.filesize }} {{ _('Bytes') }}
-        {% elif result.filesize < 1024*1024 %}{{ '{0:0.2f}'.format(result.filesize/1024) }} {{ _('kiB') }}
-        {% elif result.filesize < 1024*1024*1024 %}{{ '{0:0.2f}'.format(result.filesize/1024/1024) }} {{ _('MiB') }}
-        {% elif result.filesize < 1024*1024*1024*1024 %}{{ '{0:0.2f}'.format(result.filesize/1024/1024/1024) }} {{ _('GiB') }}
-        {% else %}{{ '{0:0.2f}'.format(result.filesize/1024/1024/1024/1024) }} {{ _('TiB') }}{% endif %}
-    </span>{% endif %}
-{% if result.files %}<br />{{ icon('file') }} {{ _('Number of Files') }} <span class="badge">{{ result.files }}</span>{% endif %}
+        {%- if result.filesize < 1024 %}{{ result.filesize }} {{ _('Bytes') -}}
+        {%- elif result.filesize < 1024*1024 %}{{ '{0:0.2f}'.format(result.filesize/1024) }} {{ _('kiB') -}}
+        {%- elif result.filesize < 1024*1024*1024 %}{{ '{0:0.2f}'.format(result.filesize/1024/1024) }} {{ _('MiB') -}}
+        {%- elif result.filesize < 1024*1024*1024*1024 %}{{ '{0:0.2f}'.format(result.filesize/1024/1024/1024) }} {{ _('GiB') -}}
+        {%- else %}{{ '{0:0.2f}'.format(result.filesize/1024/1024/1024/1024) }} {{ _('TiB') }}{% endif -%}
+    </span>{% endif -%}
+{%- if result.files %}<br />{{ icon('file') }} {{ _('Number of Files') }} <span class="badge">{{ result.files }}</span>{% endif -%}
 
-{% if result.content %}<br />{{ result.content|safe }}{% endif %}
+{%- if result.content %}<br />{{ result.content|safe }}{% endif -%}
 
 </p>
 
-{% if rtl %}
+{%- if rtl -%}
 {{ result_footer_rtl(result, loop.index) }}
-{% else %}
+{%- else -%}
 {{ result_footer(result, loop.index) }}
-{% endif %}
+{%- endif -%}

--- a/searx/templates/oscar/result_templates/videos.html
+++ b/searx/templates/oscar/result_templates/videos.html
@@ -1,29 +1,29 @@
 {% from 'oscar/macros.html' import result_header, result_sub_header, result_footer, result_footer_rtl, icon %}
 
-{{ result_header(result, favicons, loop.index) }}
-{{ result_sub_header(result, loop.index) }}
+{{- result_header(result, favicons, loop.index) -}}
+{{- result_sub_header(result, loop.index) -}}
 
-{% if result.embedded %}
+{%- if result.embedded -%}
     <small> &bull; <a class="text-info btn-collapse collapsed cursor-pointer media-loader disabled_if_nojs" data-toggle="collapse" data-target="#result-video-{{ index }}" data-btn-text-collapsed="{{ _('show video') }}" data-btn-text-not-collapsed="{{ _('hide video') }}" aria-labelledby="result-{{loop.index}}">{{ icon('film') }} {{ _('show video') }}</a></small>
-{% endif %}
+{%- endif -%}
 
-{% if result.embedded %}
+{%- if result.embedded -%}
 <div id="result-video-{{ index }}" class="collapse">
-   {{ result.embedded|safe }}
+   {{- result.embedded|safe -}}
 </div>
-{% endif %}
+{%- endif -%}
 
-<div class="container-fluid">
-    <div class="row">
+<div class="container-fluid">{{- "" -}}
+    <div class="row">{{- "" -}}
         <a href="{{ result.url }}" {% if results_on_new_tab %}target="_blank" rel="noopener noreferrer"{% else %}rel="noreferrer"{% endif %}><img class="thumbnail col-xs-6 col-sm-4 col-md-4 result-content" src="{{ image_proxify(result.thumbnail) }}" aria-labelledby="result-{{loop.index}}" /></a>
-        {% if result.author %}<p class="col-xs-12 col-sm-8 col-md-8 result-content"><b>{{ _('Author') }}</b>: {{ result.author }}</p>{% endif %}
-        {% if result.length %}<p class="col-xs-12 col-sm-8 col-md-8 result-content"><b>{{ _('Length') }}</b>: {{ result.length }}</p>{% endif %}
-        {% if result.content %}<p class="col-xs-12 col-sm-8 col-md-8 result-content">{{ result.content|safe }}</p>{% endif %}
-    </div>
+        {%- if result.author %}<p class="col-xs-12 col-sm-8 col-md-8 result-content"><b>{{ _('Author') }}</b>: {{ result.author }}</p>{% endif -%}
+        {%- if result.length %}<p class="col-xs-12 col-sm-8 col-md-8 result-content"><b>{{ _('Length') }}</b>: {{ result.length }}</p>{% endif -%}
+        {%- if result.content %}<p class="col-xs-12 col-sm-8 col-md-8 result-content">{{ result.content|safe }}</p>{% endif -%}
+    </div>{{- "" -}}
 </div>
 
-{% if rtl %}
+{%- if rtl -%}
 {{ result_footer_rtl(result, loop.index) }}
-{% else %}
+{%- else -%}
 {{ result_footer(result, loop.index) }}
-{% endif %}
+{%- endif -%}


### PR DESCRIPTION
## What does this PR do?

* reduce by 15% the uncompressed output on average (result page, preferences).
* dos2unix searx/templates/oscar/result_templates/files.html

## Why is this change important?

Just replacing `{{` and `}}` by `{{-` and `-}}`, the output pages are smaller.

## How to test this PR locally?

Check the different pages of the oscar theme.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
