### PR TITLE
Update settings.yml to enable HTTP for yacy engine

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1257,6 +1257,7 @@ engines:
 #    engine : yacy
 #    shortcut : ya
 #    base_url : 'http://localhost:8090'
+#    enable_http: True # required if you aren't using HTTPS for your local yacy instance
 #    number_of_results : 5
 #    timeout : 3.0
 


### PR DESCRIPTION
Added a line to the yacy entry to enable HTTP if the local yacy instance isn't using HTTPS. Otherwise, an error will be thrown in the logs: "No connection adapters were found for 'http://localhost:8090/yacysearch.json...'". This is likely related to ticket searx#2641 that forces HTTPS by default.