### PR TITLE
[mod] soundcloud: faster initialization

### DIFF
--- a/searx/engines/soundcloud.py
+++ b/searx/engines/soundcloud.py
@@ -55,7 +55,7 @@ def get_client_id():
         app_js_urls = [script_tag.get('src') for script_tag in script_tags if script_tag is not None]
 
         # extracts valid app_js urls from soundcloud.com content
-        for app_js_url in app_js_urls:
+        for app_js_url in app_js_urls[::-1]:
             # gets app_js and searches for the clientid
             response = http_get(app_js_url)
             if response.ok:


### PR DESCRIPTION
## What does this PR do?

The get_cliend_id() function:
* fetches https://soundcloud.com
* then fetches each referenced javascript URL to get the client id.

This commit fetches the javascript URLs in the reverse order: the client id is in the last javascript URL.

## Why is this change important?

Faster searx initialization (and less HTTP requests).

## How to test this PR locally?

* `!soundcloud time`

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
