### PR TITLE
[fix] wikipedia: remove HTML from the title

### DIFF
--- a/searx/engines/wikipedia.py
+++ b/searx/engines/wikipedia.py
@@ -76,7 +76,7 @@ def response(resp):
     if api_result.get('type') != 'standard':
         return []
 
-    title = api_result['displaytitle']
+    title = api_result['title']
     wikipedia_link = api_result['content_urls']['desktop']['page']
 
     results.append({'url': wikipedia_link, 'title': title})


### PR DESCRIPTION
## What does this PR do?

fr.wikipedia.org (and it seems no other wikipedia websites), adds HTML to `api_result['displayTitle']`.

The commit uses `api_result['title']`.

## Why is this change important?

Remove HTML 

## How to test this PR locally?

Search for 
* `!wp :fr Braid`
* `!wp :fr Dead Cells`

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
