### PR TITLE
[fix] checker: various bug fixes

### DIFF
--- a/searx/search/__init__.py
+++ b/searx/search/__init__.py
@@ -111,8 +111,6 @@ class Search:
             if request_params is None:
                 continue
 
-            request_params['engine_data'] = self.search_query.engine_data.get(engineref.name, {})
-
             with threading.RLock():
                 processor.engine.stats['sent_search_count'] += 1
 

--- a/searx/search/checker/impl.py
+++ b/searx/search/checker/impl.py
@@ -174,7 +174,7 @@ class ResultContainerTests:
     @property
     def result_urls(self):
         results = self.result_container.get_ordered_results()
-        return [result['url'] for result in results]
+        return [result['url'] for result in results if 'url' in result]
 
     def _record_error(self, message: str, *args) -> None:
         sq = _search_query_to_dict(self.search_query)
@@ -197,6 +197,8 @@ class ResultContainerTests:
             self._record_error('HTML in title', repr(result.get('title', '')))
         if not _check_no_html(result.get('content', '')):
             self._record_error('HTML in content', repr(result.get('content', '')))
+        if result.get('url') is None:
+            self._record_error('url is None')
 
         self._add_language(result.get('title', ''))
         self._add_language(result.get('content', ''))
@@ -310,7 +312,7 @@ class CheckerTests:
         self.result_container_tests_list = result_container_tests_list
 
     def unique_results(self):
-        """Check the results of each ResultContain is unique"""
+        """Check the results of each ResultContainer is unique"""
         urls_list = [rct.result_urls for rct in self.result_container_tests_list]
         if len(urls_list[0]) > 0:
             # results on the first page

--- a/searx/search/models.py
+++ b/searx/search/models.py
@@ -36,7 +36,7 @@ class SearchQuery:
                  time_range: typing.Optional[str]=None,
                  timeout_limit: typing.Optional[float]=None,
                  external_bang: typing.Optional[str]=None,
-                 engine_data: typing.Optional[dict]=None):
+                 engine_data: typing.Optional[typing.Dict[str, str]]=None):
         self.query = query
         self.engineref_list = engineref_list
         self.lang = lang
@@ -45,9 +45,7 @@ class SearchQuery:
         self.time_range = time_range
         self.timeout_limit = timeout_limit
         self.external_bang = external_bang
-        self.engine_data = engine_data
-        if engine_data is None:
-            self.engine_data = {}
+        self.engine_data = engine_data or {}
 
     @property
     def categories(self):

--- a/searx/search/processors/abstract.py
+++ b/searx/search/processors/abstract.py
@@ -27,6 +27,7 @@ class EngineProcessor(ABC):
         params['pageno'] = search_query.pageno
         params['safesearch'] = search_query.safesearch
         params['time_range'] = search_query.time_range
+        params['engine_data'] = search_query.engine_data.get(self.engine_name, {})
 
         if hasattr(self.engine, 'language') and self.engine.language:
             params['language'] = self.engine.language


### PR DESCRIPTION
## What does this PR do?

* initialize engine_data (youtube engine)
* don't crash if an engine don't set result['url']

## Why is this change important?

* fix bugs / crash

## How to test this PR locally?

* engine_data: `searx-checker youtube`
* `result['url']` appears on my instance but I can't reproduce the bug locally. The change makes the code more reliable.

## Author's checklist

The checker don't initialize `engine_data`, so these lines
https://github.com/searx/searx/blob/06b754ad67aa6066aed6df77b5ffb74aabebb040/searx/engines/youtube_noapi.py#L51-L57
are not tested.

At least, this PR avoids a crash ( `params['engine_data']` was not initialized)

## Related issues

<!--
Closes #234
-->
