### PR TITLE
Add core.ac.uk engine

### DIFF
--- a/searx/engines/core.py
+++ b/searx/engines/core.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""
+
+Core Engine (science)
+
+"""
+
+from json import loads
+from datetime import datetime
+from urllib.parse import urlencode
+
+about = {
+    "website": 'https://core.ac.uk',
+    "wikidata_id": None,
+    "official_api_documentation": 'https://core.ac.uk/documentation/api/',
+    "use_official_api": True,
+    "require_api_key": True,
+    "results": 'JSON',
+}
+
+categories = ['science']
+
+paging = True
+nb_per_page = 20
+
+
+# apikey = ''
+apikey = 'MVBozuTX8QF9I1D0GviL5bCn2Ueat6NS'
+
+
+base_url = 'https://core.ac.uk:443/api-v2/search/'
+search_string = '{query}?page={page}&pageSize={nb_per_page}&apiKey={apikey}'
+
+
+def request(query, params):
+
+    search_path = search_string.format(
+        query=urlencode({'q': query}),
+        nb_per_page=nb_per_page,
+        page=params['pageno'],
+        apikey=apikey)
+
+    params['url'] = base_url + search_path
+    return params
+
+
+def response(resp):
+    results = []
+
+    json_data = loads(resp.text)
+    for result in json_data['data']:
+        time = result['_source']['publishedDate']
+        if time is None:
+            date = datetime.now()
+        else:
+            date = datetime.fromtimestamp(time / 1000)
+        results.append({
+            'url': result['_source']['urls'][0],
+            'title': result['_source']['title'],
+            'content': result['_source']['description'],
+            'publishedDate': date})
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -264,6 +264,11 @@ engines:
     categories : images
     shortcut : cce
 
+  - name : core.ac.uk
+    engine : core
+    categories : science
+    shortcut : cor
+
   - name : crossref
     engine : json_engine
     paging : True


### PR DESCRIPTION
## What does this PR do?

Add a search engine for core.ac.uk  : https://core.ac.uk/


## Why is this change important?

Core is the world’s largest collection of open access research papers
Plus it has a lot of options for text mining


## How to test this PR locally?

First get your API key following this page: https://core.ac.uk/api-keys/register/
In searx/engines/core.py :
I left my own key, commented out on line 28. Feel free to use it, if needed.

In searx in the science category, try search using the core.ac.uk engine.


In this engine, not all the published dates are correct. When there is no date linked to an article in the engine, the search result will display " 0 minute ago" for the published date

