### PR TITLE
[fix] default_doi_resolver in preferences

### DIFF
--- a/searx/plugins/oa_doi_rewrite.py
+++ b/searx/plugins/oa_doi_rewrite.py
@@ -29,7 +29,7 @@ def get_doi_resolver(args, preference_doi_resolver):
     doi_resolvers = settings['doi_resolvers']
     doi_resolver = args.get('doi_resolver', preference_doi_resolver)[0]
     if doi_resolver not in doi_resolvers:
-        doi_resolvers = settings['default_doi_resolver']
+        doi_resolver = settings['default_doi_resolver']
     doi_resolver_url = doi_resolvers[doi_resolver]
     return doi_resolver_url
 
@@ -40,7 +40,7 @@ def on_result(request, search, result):
 
     doi = extract_doi(result['parsed_url'])
     if doi and len(doi) < 50:
-        for suffix in ('/', '.pdf', '/full', '/meta', '/abstract'):
+        for suffix in ('/', '.pdf', '.xml', '/full', '/meta', '/abstract'):
             if doi.endswith(suffix):
                 doi = doi[:-len(suffix)]
         result['url'] = get_doi_resolver(request.args, request.preferences.get_value('doi_resolver')) + doi

--- a/searx/preferences.py
+++ b/searx/preferences.py
@@ -387,7 +387,7 @@ class Preferences:
                 }
             ),
             'doi_resolver': MultipleChoiceSetting(
-                ['oadoi.org'],
+                [settings['default_doi_resolver'], ],
                 is_locked('doi_resolver'),
                 choices=DOI_RESOLVERS
             ),

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1395,4 +1395,4 @@ doi_resolvers :
   doai.io  : 'https://dissem.in/'
   sci-hub.tw : 'https://sci-hub.tw/'
 
-default_doi_resolver : 'sci-hub.tw'
+default_doi_resolver : 'oadoi.org'

--- a/searx/templates/oscar/preferences.html
+++ b/searx/templates/oscar/preferences.html
@@ -165,7 +165,7 @@
                     {{ preferences_item_header(info, label, rtl, 'doi_resolver') }}
                         <select class="form-control {{ custom_select_class(rtl) }}" name="doi_resolver" id="doi_resolver">
                             {% for doi_resolver_name,doi_resolver_url in doi_resolvers.items() %}
-                            <option value="{{ doi_resolver_name }}" {% if doi_resolver_name == current_doi_resolver %}selected="selected"{% endif %}>
+                            <option value="{{ doi_resolver_name }}" {% if doi_resolver_url == current_doi_resolver %}selected="selected"{% endif %}>
                                     {{ doi_resolver_name }} - {{ doi_resolver_url }}
                             </option>
                              {% endfor %}

--- a/searx/templates/simple/preferences.html
+++ b/searx/templates/simple/preferences.html
@@ -96,7 +96,7 @@
     <p class="value">
       <select id='doi_resolver' name='doi_resolver'>
       {%- for doi_resolver_name,doi_resolver_url in doi_resolvers.items() -%}
-         <option value="{{ doi_resolver_name }}" {% if doi_resolver_name == current_doi_resolver %}selected="selected"{% endif %}>
+         <option value="{{ doi_resolver_name }}" {% if doi_resolver_url == current_doi_resolver %}selected="selected"{% endif %}>
          {{- doi_resolver_name }} - {{ doi_resolver_url -}}
          </option>
       {%- endfor -%}


### PR DESCRIPTION

## What does this PR do?

Instead of a hard-coded `oadoi.org` default, use the default value from
`settings.yml`.

Fix an issue in the themes: The replacement 'current_doi_resolver' contains the
doi_resolver_url, not the name of the DOI resolver.  Compare return value of::

    searx.plugins.oa_doi_rewrite.get_doi_resolver(...)

Fix a typo in `get_doi_resolver(..)`:  suggested by @kvch:

  *L32 should set doi_resolver not doi_resolvers*

## Why is this change important?

To get in use of the setting `default_doi_resolver`.

## How to test this PR locally?

In `settings.yml` change the value of `default_doi_resolver`, after

    make run

Open preferences and 

- reset all preferences
- Check Tab "General" pre-selected "Open Access DOI resolver"  .. should be the default from settings.yml 
- Save / run a query in category 'science' and check DOI URLs
