### PR TITLE
[fix] publishedDate: don't try to get date from empty string or None

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -650,7 +650,7 @@ def search():
             result['pretty_url'] = prettify_url(result['url'])
 
         # TODO, check if timezone is calculated right
-        if 'publishedDate' in result:
+        if result.get('publishedDate'):  # do not try to get a date from an empty string or a None type
             try:  # test if publishedDate >= 1900 (datetime module bug)
                 result['pubdate'] = result['publishedDate'].strftime('%Y-%m-%d %H:%M:%S%z')
             except ValueError:


### PR DESCRIPTION
## What does this PR do?

Avoids exceptions when the `publishedDate` from engines results is an empty string or None.

## Why is this change important?

Makes `publishedDate` typecast more robust and simplifies engine code. ATM the engine code has to filter out these types, otherwise a engine exception is released.
