### PR TITLE
Add hostname_replace plugin

### DIFF
--- a/searx/plugins/__init__.py
+++ b/searx/plugins/__init__.py
@@ -32,6 +32,7 @@ from searx.plugins import (oa_doi_rewrite,
                            https_rewrite,
                            infinite_scroll,
                            self_info,
+                           hostname_replace,
                            search_on_category_select,
                            tracker_url_remover,
                            vim_hotkeys)
@@ -168,6 +169,7 @@ plugins.register(hash_plugin)
 plugins.register(https_rewrite)
 plugins.register(infinite_scroll)
 plugins.register(self_info)
+plugins.register(hostname_replace)
 plugins.register(search_on_category_select)
 plugins.register(tracker_url_remover)
 plugins.register(vim_hotkeys)

--- a/searx/plugins/hostname_replace.py
+++ b/searx/plugins/hostname_replace.py
@@ -1,0 +1,28 @@
+import re
+from urllib.parse import urlunparse
+from searx import settings
+from searx.plugins import logger
+from flask_babel import gettext
+
+name = gettext('Hostname replace')
+description = gettext('Rewrite result hostnames')
+default_on = False
+preference_section = 'general'
+
+plugin_id = 'hostname_replace'
+parsed = 'parsed_url'
+
+replacements = {re.compile(p): r for (p, r) in settings[plugin_id].items()} if plugin_id in settings else {}
+
+logger = logger.getChild(plugin_id)
+
+
+def on_result(request, search, result):
+    if parsed not in result:
+        return True
+    for (pattern, replacement) in replacements.items():
+        if pattern.search(result[parsed].netloc):
+            result[parsed] = result[parsed]._replace(netloc=pattern.sub(replacement, result[parsed].netloc))
+            result['url'] = urlunparse(result[parsed])
+
+    return True

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -104,6 +104,18 @@ outgoing: # communication with search engines
 #   - "HTTPS rewrite"
 #   - ...
 
+# Example to rewrite hostnames in external links
+#
+# enabled_plugins:
+#   - 'Hostname replace'
+# hostname_replace:
+#   '(.*\.)?youtube\.com$':           'invidious.example.com'
+#   '(.*\.)?youtu\.be$':              'invidious.example.com'
+#   '(.*\.)?youtube-noocookie\.com$': 'yotter.example.com'
+#   '(.*\.)?reddit\.com$':            'teddit.example.com'
+#   '(.*\.)?redd\.it$':               'teddit.example.com'
+#   '(www\.)?twitter\.com$':          'nitter.example.com'
+
 checker:
     # disable checker when in debug mode
     off_when_debug: True


### PR DESCRIPTION
## What does this PR do?

This is an alternative to #2638 , borrowing from the existing work done by @anmathew and @evuraan.

It supports replacing the domain/hostname (specifically, `result['parsed_url'].netloc`) based on regular expressions.

* Adds new plugin `hostname_replace`
* Configuration is done via "normal" settings
* Supports regular expressions

## Why is this change important?

Supports generic domain-replacements. Useful for redirecting sites to alternative frontends.

## How to test this PR locally?

To rewrite youtube links to use a specific invidious instance, add to `settings.yml`:
```
hostname_replace:
  '(.*\.)?youtube\.com$': 'invidiou.site'
  '(.*\.)?youtu\.be$': 'invidiou.site'
  '(.*\.)?youtube-noocookie\.com$': 'invidiou.site'
```
(please use on sites you manage or have permission from the owner, this is for illustration only)


## Related issues

Closes #2609, #1710
