### PR TITLE
Reduce redundant docker build steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,20 +4,11 @@ EXPOSE 8080
 VOLUME /etc/searx
 VOLUME /var/log/uwsgi
 
-ARG GIT_URL=unknown
-ARG VERSION_GITCOMMIT=unknown
-ARG SEARX_GIT_VERSION=unknown
-
 ARG SEARX_GID=977
 ARG SEARX_UID=977
 
 RUN addgroup -g ${SEARX_GID} searx && \
     adduser -u ${SEARX_UID} -D -h /usr/local/searx -s /bin/sh -G searx searx
-
-ARG TIMESTAMP_SETTINGS=0
-ARG TIMESTAMP_UWSGI=0
-ARG LABEL_VCS_REF=
-ARG LABEL_VCS_URL=
 
 ENV INSTANCE_NAME=searx \
     AUTOCOMPLETE= \
@@ -60,6 +51,10 @@ RUN apk upgrade --no-cache \
 
 COPY --chown=searx:searx . .
 
+ARG TIMESTAMP_SETTINGS=0
+ARG TIMESTAMP_UWSGI=0
+ARG VERSION_GITCOMMIT=unknown
+
 RUN su searx -c "/usr/bin/python3 -m compileall -q searx"; \
     touch -c --date=@${TIMESTAMP_SETTINGS} searx/settings.yml; \
     touch -c --date=@${TIMESTAMP_UWSGI} dockerfiles/uwsgi.ini; \
@@ -70,8 +65,12 @@ RUN su searx -c "/usr/bin/python3 -m compileall -q searx"; \
     -o -name '*.svg' -o -name '*.ttf' -o -name '*.eot' \) \
     -type f -exec gzip -9 -k {} \+ -exec brotli --best {} \+
 
-# Keep this argument at the end since it change each time
+# Keep these arguments at the end to prevent redundant layer rebuilds
 ARG LABEL_DATE=
+ARG GIT_URL=unknown
+ARG SEARX_GIT_VERSION=unknown
+ARG LABEL_VCS_REF=
+ARG LABEL_VCS_URL=
 LABEL maintainer="searx <${GIT_URL}>" \
       description="A privacy-respecting, hackable metasearch engine." \
       version="${SEARX_GIT_VERSION}" \


### PR DESCRIPTION
## What does this PR do?

Move build-args declaration down in the Dockerfile to where they actually make a difference.


## Why is this change important?

This reduces unnecessary package installation steos when rebuilding during development, saving developer time and environment

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

`make docker`
