### PR TITLE
Allow overriding Docker repository when building docker image

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -147,7 +147,7 @@ docker_build() {
 
     # define the docker image name
     GITHUB_USER=$(echo "${GIT_URL}" | sed 's/.*github\.com\/\([^\/]*\).*/\1/')
-    SEARX_IMAGE_NAME="${GITHUB_USER:-searx}/searx"
+    SEARX_IMAGE_NAME="${SEARX_IMAGE_NAME:-${GITHUB_USER:-searx}/searx}"
 
     # build Docker image
     echo "Building image ${SEARX_IMAGE_NAME}:${SEARX_GIT_VERSION}"


### PR DESCRIPTION
## What does this PR do?

Allows overriding env var `SEARX_IMAGE_NAME` to target custom docker repo


## Why is this change important?

Useful both during development and when deploying to custom docker repository

## How to test this PR locally?

`SEARX_IMAGE_NAME=docker.example.com/searx make docker.push`