### PR TITLE
[fix] settings_loader.py - use update_dict only for mapping types

### DIFF
--- a/searx/settings_loader.py
+++ b/searx/settings_loader.py
@@ -57,7 +57,7 @@ def update_settings(default_settings, user_settings):
     # merge everything except the engines
     for k, v in user_settings.items():
         if k not in ('use_default_settings', 'engines'):
-            if k in default_settings:
+            if k in default_settings and isinstance(v, Mapping):
                 update_dict(default_settings[k], v)
             else:
                 default_settings[k] = v


### PR DESCRIPTION
I can't set `default_doi_resolver` in `settings.yml` if I'm using `use_default_settings`.  Searx seems to try to interpret all settings at root level in `settings.yml` as dict, which is correct except for `default_doi_resolver` which is at root level and a string::

    File "/usr/lib/python3.9/site-packages/searx/settings_loader.py", line 125, in load_settings
        update_settings(default_settings, user_settings)
    File "/usr/lib/python3.9/site-packages/searx/settings_loader.py", line 61, in update_settings
        update_dict(default_settings[k], v)
    File "/usr/lib/python3.9/site-packages/searx/settings_loader.py", line 48, in update_dict
        for k, v in user_dict.items():
    AttributeError: 'str' object has no attribute 'items'

Signed-off-by: Markus Heiser <markus@darmarit.de>
Suggested-by:  @0xhtml https://github.com/searx/searx/issues/2722#issuecomment-813391659

## How to test this PR locally?

Set  `default_doi_resolver` and `use_default_settings` in `/etc/searx/settings.yml`

## Related issues

Closes: #2722
