### PR TITLE
[fix] fix PR 2656

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -1133,11 +1133,14 @@ class ReverseProxyPathFix:
 
             base_url = urlparse(settings['server']['base_url'])
             self.script_name = base_url.path
+            if self.script_name.endswith('/'):
+                # remove trailing slash to avoid infinite redirect on the index
+                # see https://github.com/searx/searx/issues/2729
+                self.script_name = self.script_name[:-1]
             self.scheme = base_url.scheme
             self.server = base_url.netloc
 
     def __call__(self, environ, start_response):
-
         script_name = self.script_name or environ.get('HTTP_X_SCRIPT_NAME', '')
         if script_name:
             environ['SCRIPT_NAME'] = script_name


### PR DESCRIPTION
## What does this PR do?

SCRIPT_NAME remove trailing slash to avoid infinite redirect

## Why is this change important?

See #2729

## How to test this PR locally?

With and without this PR:
```
make docker
export PORT=8888
docker run --rm -d -v ${PWD}/searx:/etc/searx -p $PORT:8080 -e BASE_URL=http://localhost:$PORT/ searx/searx
```

Visit `http://localhost:8888/`.

(Side note: I think the issue is related to uwsgi rather then docker).

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

* Close https://github.com/searx/searx/issues/2729
* Fix #2656
