### PR TITLE
[fix] docutils v0.17 incompatibility to previeous v0.16

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,7 @@ transifex-client==0.14.2
 selenium==3.141.0
 twine==3.4.1
 Pallets-Sphinx-Themes==1.2.3
+docutils==0.16
 Sphinx==3.5.3
 sphinx-issues==1.2.0
 sphinx-jinja==1.1.1


### PR DESCRIPTION
With docutils v0.17 a lot of html markup has been changed (see below) what cause
a lot of problems in CSS from Sphinx and other Sphinx extensions & customizing.

For the first this fix pins to previous v0.16. In sphinx 4.0 these problems will
be addressed [2] and we can relax (drop) in the requirements-dev.

HTML5 writer [1]:

    Use the new semantic tags <main>, <section>, <header>, <footer>, <aside>,
    <figure>, and <figcaption>.  See minimal.css and plain.css for styling rule
    examples.

    Change the initial_header_level setting's default to "2", as browsers use the
    same style for <h1> and <h2> when nested in a section.

    Use HTML text-level tags <small>, <s>, <q>, <dfn>, <var>, <samp>, <kbd>, <i>,
    <b>, <u>, <mark>, and <bdi> if a matching class value is found in inline and
    literal elements.  Use <ins> and <del> if a matching class value is found in
    inline, literal, or container elements.

    New optional style responsive.css, adapts to different screen sizes.

    New option embed_images.

[1] https://docutils.sourceforge.io/RELEASE-NOTES.html
[2] https://github.com/sphinx-doc/sphinx/issues/9056

Related: #2730