### PR TITLE
[fix] redirect when saving preferences

### DIFF
--- a/searx/templates/oscar/preferences.html
+++ b/searx/templates/oscar/preferences.html
@@ -368,7 +368,7 @@
         </p>
 
 	<div class="tab-pane">
-          <input readonly="" class="form-control select-all-on-click cursor-text" type="url" value="{{ base_url }}?preferences={{ preferences_url_params|e }}{% raw %}&amp;q=%s{% endraw %}">
+          <input readonly="" class="form-control select-all-on-click cursor-text" type="url" value="{{ url_for('index', _external=True) }}?preferences={{ preferences_url_params|e }}{% raw %}&amp;q=%s{% endraw %}">
           <input type="submit" class="btn btn-primary" value="{{ _('save') }}" />
         <a href="{{ url_for('index') }}"><div class="btn btn-default">{{ _('back') }}</div></a>
         <a href="{{ url_for('clear_cookies') }}"><div class="btn btn-default">{{ _('Reset defaults') }}</div></a>

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -813,7 +813,7 @@ def preferences():
 
     # save preferences
     if request.method == 'POST':
-        resp = make_response(url_for('index', _external=True))
+        resp = make_response(redirect(url_for('index', _external=True)))
         try:
             request.preferences.parse_form(request.form)
         except ValidationException:


### PR DESCRIPTION
## What does this PR do?

Since #2656 has been merged, we have issues with:

- saving the preferences will cause an error (blank page)
- https-scheme missing in preferences-page

## Why is this change important?

- Erroneously commit 87e4c4762 dropped the 302 redirect.
- in PR #2656  I forgot to remove one usage of `base_url` in the HTML template of the preferences-page

## How to test this PR locally?

Open preferences,

- check cookie URL 
- click on the "save" button.

## Related issues

closes: #2740
