### PR TITLE
Fix bug for 'FileNotFoundError' in 'standalone_searx.py' 

### DIFF
--- a/searx_extra/standalone_searx.py
+++ b/searx_extra/standalone_searx.py
@@ -31,7 +31,7 @@ Example to run it from python:
 ... engine_cs = list(searx.engines.categories.keys())
 ... # load module
 ... spec = importlib.util.spec_from_file_location(
-...     'utils.standalone_searx', 'utils/standalone_searx.py')
+...     'utils.standalone_searx', 'searx_extra/standalone_searx.py')
 ... sas = importlib.util.module_from_spec(spec)
 ... spec.loader.exec_module(sas)
 ... # use function from module


### PR DESCRIPTION
Fix bug for 'FileNotFoundError - No such file or directory: 'utils/standalone_searx.py' ' in example to run standalone_searx.py from python

## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

The changes made in this PR fix a bug present in [standalone_searx.py](https://github.com/searx/searx/blob/master/searx_extra/standalone_searx.py) which caused a FileNotFoundError. The reason is that the _standalone_searx.py_ file previously was located in the _utils/_ directory. This file was later moved to the _searx_extra/_ directory, but the paths present in the example remained unchanged. 

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

This change is important because it keeps the script bug-free so users can test the standalone search without errors.

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

Follow the steps shown in #2762 

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Closes #2762
