### PR TITLE
Fix typo

### DIFF
--- a/docs/build-templates/morty.rst
+++ b/docs/build-templates/morty.rst
@@ -32,7 +32,7 @@
        (${SERVICE_USER}) $ mkdir ${SERVICE_HOME}/local
        (${SERVICE_USER}) $ wget --progress=bar -O \"${GO_TAR}\" \\
                    \"${GO_PKG_URL}\"
-       (${SERVICE_USER}) $ tar -C ${SERVICE_HOME}/local/go -xzf \"${GO_TAR}\"
+       (${SERVICE_USER}) $ tar -C ${SERVICE_HOME}/local -xzf \"${GO_TAR}\"
        (${SERVICE_USER}) $ which go
        ${SERVICE_HOME}/local/go/bin/go
 


### PR DESCRIPTION
## What does this PR do?

Fix typo in go path for morty install

## Why is this change important?

Was going through the install process step by setup when I found this typo. Took me a few minutes to figure out the problem cause I'm not as smart as I think I am. The tar gzip contains the go folder so that shouldn't be in the tar destination path. This same line in filtron install is correct btw

## How to test this PR locally?

Ran the setup manually on my server

## Author's checklist

## Related issues

<!--
Closes #234
-->
