### PR TITLE
Fix URL to solidtorrent result page

### DIFF
--- a/searx/engines/solidtorrents.py
+++ b/searx/engines/solidtorrents.py
@@ -45,7 +45,7 @@ def response(resp):
             'seed': result["swarm"]["seeders"],
             'leech': result["swarm"]["leechers"],
             'title': result["title"],
-            'link': "https://solidtorrents.net/view/" + result["_id"],
+            'url': "https://solidtorrents.net/view/" + result["_id"],
             'filesize': result["size"],
             'magnetlink': result["magnet"],
             'template': "torrent.html",


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->
Fixes the link to the solidtorrents torrent info page

## Why is this change important?
It's convenient for users to click on the title to get to the torrent info page.
<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?
Search for a torrent and click on the link on a solidtorrents result
