### PR TITLE
Revert "[mod] searx.network.client: the same configuration reuses the…

### DIFF
--- a/searx/network/client.py
+++ b/searx/network/client.py
@@ -23,7 +23,6 @@ else:
 
 logger = logger.getChild('searx.http.client')
 LOOP = None
-SSLCONTEXTS = {}
 TRANSPORT_KWARGS = {
     'backend': 'asyncio',
     'trust_env': False,
@@ -40,14 +39,6 @@ async def close_connections_for_url(connection_pool: httpcore.AsyncConnectionPoo
             await connection.aclose()
         except httpcore.NetworkError as e:
             logger.warning('Error closing an existing connection', exc_info=e)
-
-
-def get_sslcontexts(proxy_url=None, cert=None, verify=True, trust_env=True, http2=False):
-    global SSLCONTEXTS
-    key = (proxy_url, cert, verify, trust_env, http2)
-    if key not in SSLCONTEXTS:
-        SSLCONTEXTS[key] = httpx.create_ssl_context(cert, verify, trust_env, http2)
-    return SSLCONTEXTS[key]
 
 
 class AsyncHTTPTransportNoHttp(httpcore.AsyncHTTPTransport):
@@ -140,7 +131,7 @@ def get_transport_for_socks_proxy(verify, http2, local_address, proxy_url, limit
         rdns = True
 
     proxy_type, proxy_host, proxy_port, proxy_username, proxy_password = parse_proxy_url(proxy_url)
-    verify = get_sslcontexts(proxy_url, None, True, False, http2) if verify is True else verify
+
     return AsyncProxyTransportFixed(proxy_type=proxy_type, proxy_host=proxy_host, proxy_port=proxy_port,
                                     username=proxy_username, password=proxy_password,
                                     rdns=rdns,
@@ -156,7 +147,6 @@ def get_transport_for_socks_proxy(verify, http2, local_address, proxy_url, limit
 
 
 def get_transport(verify, http2, local_address, proxy_url, limit, retries):
-    verify = get_sslcontexts(None, None, True, False, http2) if verify is True else verify
     return AsyncHTTPTransportFixed(verify=verify,
                                    http2=http2,
                                    local_address=local_address,


### PR DESCRIPTION
With the cherry-picking of 5e53e9412d118a3a9b17eabd47f8e55612e17a7a master has started to fail:
```
./manage test.unit
TEST      tests/unit
PYENV     [check] import yaml --> OK
PYENV     OK
+ local/py3/bin/python -c 'import sys; sys.path.pop(0); import searx;'
+ python -m nose2 -s tests/unit
........E................................................................................................................................................................
======================================================================
ERROR: test_ipaddress_cycle (tests.unit.network.test_network.TestNetwork)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/searx/searx/tests/unit/network/test_network.py", line 20, in test_ipaddress_cycle
    network = NETWORKS['ipv6']
KeyError: 'ipv6'

----------------------------------------------------------------------
Ran 169 tests in 3.313s

FAILED (errors=1)
ERROR: test.unit exit with error (1)
make: *** [Makefile:88: test.unit] Error 1
Error: Process completed with exit code 2.
```

The PR reverts the commit to give me some more time to figure out what else is missing.