### PR TITLE
Add json_engine configuration for ManKier

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -790,6 +790,22 @@ engines:
     shortcut : nt
     disabled : True
 
+  - name : mankier
+    engine : json_engine
+    search_url : https://www.mankier.com/api/v2/mans/?q={query}
+    results_query : results
+    url_query : url
+    title_query : name
+    content_query : description
+    categories : it
+    shortcut : man
+    about:
+      website: https://www.mankier.com/
+      official_api_documentation: https://www.mankier.com/api
+      use_official_api: true
+      require_api_key: false
+      results: JSON
+
   - name : openairedatasets
     engine : json_engine
     paging : True


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

This adds a `json_engine` configuration for [ManKier](https://www.mankier.com/)

## Why is this change important?

ManKier is a very nice website for viewing manpages.

## How to test this PR locally?

Add it to your `settings.yml`
