### PR TITLE
Add xpath configuration for PyPI

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -219,7 +219,7 @@ engines:
     engine : wikipedia
     shortcut : wp
     base_url : 'https://{language}.wikipedia.org/'
-    
+
     #The fulltext and title parameter is necessary for Wikimini because sometimes it will not show the results and redirect instead
   - name: wikimini
     engine: xpath
@@ -892,6 +892,26 @@ engines:
     categories: science
     timeout : 3.0
 
+  - name : pypi
+    shortcut: pypi
+    engine: xpath
+    paging : True
+    search_url : https://pypi.org/search?q={query}&page={pageno}
+    results_xpath: /html/body/main/div/div/div/form/div/ul/li/a[@class="package-snippet"]
+    url_xpath : ./@href
+    title_xpath : ./h3/span[@class="package-snippet__name"]
+    content_xpath : ./p
+    suggestion_xpath : /html/body/main/div/div/div/form/div/div[@class="callout-block"]/p/span/a[@class="link"]
+    first_page_num : 1
+    categories: it
+    about:
+      website: https://pypi.org
+      wikidata_id: Q2984686
+      official_api_documentation: https://warehouse.readthedocs.io/api-reference/index.html
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+
   - name : qwant
     engine : qwant
     shortcut : qw
@@ -1281,7 +1301,7 @@ engines:
       use_official_api: false
       require_api_key: false
       results: HTML
- 
+
   - name : dogpile
     shortcut : dp
     engine : xpath


### PR DESCRIPTION
## What does this PR do?

This adds a `xpath` configuration for [PyPI](https://pypi.org/) (Python Package Index)

## Why is this change important?

There were configurations for NPM and for RubyGems and I got jealous. Since searx is written in Python it should support searching PyPI too :)

## How to test this PR locally?

Add it to your `settings.yml`
