### PR TITLE
[enh] Add woxikon.de synonyme (xpath)

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1424,6 +1424,23 @@ engines:
     timeout: 5.0
     disabled: True
 
+  - name : woxikon.de synonyme
+    engine : xpath
+    shortcut : woxi
+    categories : general
+    timeout : 5.0
+    disabled : True
+    search_url : https://synonyme.woxikon.de/synonyme/{query}.php
+    url_xpath : //div[@class="upper-synonyms"]/a/@href
+    content_xpath : //div[@class="synonyms-list-group"]
+    title_xpath : //div[@class="upper-synonyms"]/a
+    about:
+      website: https://www.woxikon.de/
+      wikidata_id: # No Wikidata ID
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+
   - name: słownik języka polskiego
     engine: sjp
     shortcut: sjp


### PR DESCRIPTION
Upstream example query:
https://synonyme.woxikon.de/synonyme/test.php

## What does this PR do?

Add synonyme.woxikon.de as optional engine.

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->
Added synonyme.woxikon.de using the ``` xpath ``` engine.

## Why is this change important?

Adds a site which returns word synonyms although just in German.

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->
Make Searx better.

## How to test this PR locally?

Do a search with:
``` !woxi test```

## Author's checklist

<!-- additional notes for reviewiers -->

Depending on the query not all synonyms are shown because of not the best xpath selection.

But should do the job just fine.

## Related issues
Related, not the same:

https://github.com/searx/searx/issues/334