### PR TITLE
[enh] Add gpodder.net (JSON)

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -602,6 +602,26 @@ engines:
       require_api_key: false
       results: HTML
 
+  - name : gpodder
+    engine : json_engine
+    shortcut : gpod
+    timeout : 4.0
+    paging : False
+    search_url : https://gpodder.net/search.json?q={query}
+    url_query : url
+    title_query : title
+    content_query : description
+    page_size : 19
+    categories : social media, files, general
+    disabled: True
+    about:
+      website: https://gpodder.net
+      wikidata_id: Q3093354
+      official_api_documentation: https://gpoddernet.readthedocs.io/en/latest/api/
+      use_official_api: false
+      requires_api_key: false
+      results: JSON
+
   - name : google play movies
     engine : xpath
     search_url : https://play.google.com/store/search?q={query}&c=movies


### PR DESCRIPTION
Upstream query example:
https://gpodder.net/search.json?q=linux

## What does this PR do?

Add gpodder.net as optional engine for Podcasts.

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->
Added gpodder.net using ``` json_engine``` .

## Why is this change important?
Engine just for Podcasts.
An API which returns Podcasts and their Info like: website, author etc.

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->
Make Searx better.

## How to test this PR locally?

Do a search with:

``` !gpod android```

## Author's checklist

<!-- additional notes for reviewiers -->
N/A

## Related issues

<!--
Closes #234
-->

N/A
