### PR TITLE
[enh] Add Kaufland.de

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1414,6 +1414,25 @@ engines:
     engine : mediathekviewweb
     shortcut : mvw
 
+  - name : kaufland
+    shortcut : kauf
+    engine : xpath
+    timeout : 3.0
+    paging : True
+    search_url : https://www.kaufland.de/item/search/?search_value={query}&page={pageno}
+    title_xpath : //li[@class="product__title"]
+    url_xpath : //div[@class="product"]//a/@href
+    content_xpath : //div[@class="price"]
+    #thumbnail_xpath : '//div[@class="product__image-container"]//img/@data-src'
+    categories : general
+    disabled : True
+    about:
+      website: https://kaufland.de
+      wikidata_id: Q685967
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+
 #  - name : yacy
 #    engine : yacy
 #    shortcut : ya


### PR DESCRIPTION
Upstream example query: 
https://www.kaufland.de/item/search/?search_value=mag%20425

## What does this PR do?
Add Kaufland.de marketplace.


<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->
Using the ``` xpath ``` engine.

## Why is this change important?

More engine to choose from (Shopping).

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->
Make Searx better.

## How to test this PR locally?

Do a search with:
``` !kauf android ```

## Author's checklist

<!-- additional notes for reviewiers -->
Thumbnails could be added.

A category for "Shopping" could be created.

## Related issues
N/A