### PR TITLE
added icons to search results

### DIFF
--- a/searx/templates/oscar/macros.html
+++ b/searx/templates/oscar/macros.html
@@ -43,7 +43,12 @@
         {%- endif -%}
     </div>
     {%- if result.pretty_url -%}
-    <div class="external-link">{{ result.pretty_url }}</div>
+    <div class="external-link">
+        {%- if result.parsed_url -%}
+        <img src="{{result.parsed_url.scheme}}://{{result.parsed_url.netloc}}/favicon.ico" height="14" alt="" style="margin-right: 2px;">
+        {%- endif -%} 
+        {{ result.pretty_url }}
+    </div>
     {%- endif -%}
 {%- endmacro %}
 
@@ -58,7 +63,12 @@
     <small>{{ result_link(proxify(result.url), icon('sort') + _('proxied'), "text-info") }}</small>
     {%- endif -%}
 </div>{{- "" -}}
-<div class="external-link">{{ result.pretty_url }}</div>
+<div class="external-link">
+    {%- if result.parsed_url -%}
+    <img src="{{result.parsed_url.scheme}}://{{result.parsed_url.netloc}}/favicon.ico" height="14" alt="" style="margin-right: 2px;">
+    {%- endif -%} 
+    {{ result.pretty_url }}
+</div>
 {%- endmacro %}
 
 <!-- Draw result footer -->
@@ -78,7 +88,15 @@
     <small>{{ result_link(proxify(result.url), icon('sort') + _('proxied'), "text-info", id) }}</small>
     {%- endif -%}
     {%- if result.pretty_url -%}
-    <div class="external-link">{{ result.pretty_url }}</div>
+    {%- if result.parsed_url -%}
+    {{result.parsed_url.scheme}}://{{result.parsed_url.netloc}}/favicon.ico
+    {%- endif -%} 
+    <div class="external-link">
+        {%- if result.parsed_url -%}
+        <img src="{{result.parsed_url.scheme}}://{{result.parsed_url.netloc}}/favicon.ico" height="14" alt="" style="margin-right: 2px;">
+        {%- endif -%}      
+        {{ result.pretty_url }}
+    </div>
     {%- endif -%}
 {%- endmacro %}
 
@@ -91,7 +109,12 @@
     {%- if proxify -%}
     <small>{{ result_link(proxify(result.url), icon('sort') + _('proxied'), "text-info") }}</small>
     {%- endif -%}
-    <div class="external-link">{{ result.pretty_url }}</div>
+    <div class="external-link">
+        {%- if result.parsed_url -%}
+        <img src="{{result.parsed_url.scheme}}://{{result.parsed_url.netloc}}/favicon.ico" height="14" alt="" style="margin-right: 2px;">
+        {%- endif -%} 
+        {{ result.pretty_url }}
+    </div>
 {%- endmacro %}
 
 {% macro preferences_item_header(info, label, rtl, id) -%}


### PR DESCRIPTION
## What does this PR do?

Adds icons next to search result urls. changes are only made in macros.html.  websitename.com/favicon.ico is assumed to have the icon image. dynamically get the images for each website and minor css to adjust with the inline link. 

## Why is this change important?

This was stated as a performance enhancement.  [Feature request] Show icon of domain URLs #1690  

## How to test this PR locally?

all normal testing as stated in the docs.

## Author's checklist

I am a first time open source contributor. Any reviews or mistakes are welcome

## Related issues

 [Feature request] Show icon of domain URLs #1690 

