### PR TITLE
Fix proxy requests issues with httpx >= 0.18.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ httpx[http2]==0.19.0
 Brotli==1.0.9
 uvloop==0.16.0; python_version >= '3.7'
 uvloop==0.14.0; python_version < '3.7'
-httpx-socks[asyncio]==0.3.1
+httpx-socks[asyncio]==0.4.1
 langdetect==1.0.9
 setproctitle==1.2.2


### PR DESCRIPTION
## What does this PR do?

Fixes bug #2968 where proxies no longer work after the httpx update.
Version 0.18 refactored a bunch of stuff that breaks backwards compatibility which causes this issue: https://github.com/encode/httpx/pull/1522#issuecomment-830709342

## Why is this change important?

Any searx instance with this bug will bypass their proxies and make all the outgoing requests directly.

## How to test this PR locally?

Using master:

1. Run Wireshark or some similar tool.
1. Run Tor.
1. Start searx with a socks5h proxy pointing to the Tor port, for example: `socks5h://127.0.0.1:9050`.
1. Wireshark immediately shows DNS lookups from the client IP.

Using branch:

1. Update dependencies in virtual environment. 
1. Repeat previous steps.
1. Wireshark should not show DNS lookups to any engine.

## Author's checklist

* As searx starts, it should validate that the proxies are actually being used to avoid this bug from happening in the future.

## Related issues
Closes #2968
There's a draft for a different implementation of this in searxng: https://github.com/searxng/searxng/pull/261