### PR TITLE
Add imdb support

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -165,3 +165,4 @@ generally made searx better:
 - @jhigginbotham
 - @xenrox
 - @OliveiraHermogenes
+- Paul Alcock @Guilvareux

--- a/searx/engines/imdb.py
+++ b/searx/engines/imdb.py
@@ -32,7 +32,6 @@ search_categories = {
 
 def request(query, params):
     query = query.replace(" ", "_").lower()
-    print(query)
     params['url'] = suggestion_url.format(letter=query[0], query=query) 
     return params
 

--- a/searx/engines/imdb.py
+++ b/searx/engines/imdb.py
@@ -19,7 +19,6 @@ about = {
 
 categories = ['general']
 paging = False
-
 base_url = 'https://imdb.com/{category}/{id}'
 suggestion_url = "https://v2.sg.media-imdb.com/suggestion/{letter}/{query}.json"
 search_categories = {
@@ -30,10 +29,12 @@ search_categories = {
     "ep": "episode"
 }
 
+
 def request(query, params):
     query = query.replace(" ", "_").lower()
-    params['url'] = suggestion_url.format(letter=query[0], query=query) 
+    params['url'] = suggestion_url.format(letter=query[0], query=query)
     return params
+
 
 def response(resp):
     suggestions = json.loads(resp.text)

--- a/searx/engines/imdb.py
+++ b/searx/engines/imdb.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+IMDB - Internet Movie Database
+Retrieves results from a basic search
+Advanced search options are not supported
+"""
+
+import json
+
+about = {
+    "website": 'https://imdb.com/',
+    "wikidata_id": 'Q37312',
+    "official_api_documentation": None,
+    "use_official_api": False,
+    "require_api_key": False,
+    "results": 'HTML',
+}
+
+categories = ['general']
+paging = False
+
+base_url = 'https://imdb.com/{category}/{id}'
+suggestion_url = "https://v2.sg.media-imdb.com/suggestion/{letter}/{query}.json"
+search_categories = {
+    "nm": "name",
+    "tt": "title",
+    "kw": "keyword",
+    "co": "company",
+    "ep": "episode"
+}
+
+def request(query, params):
+    query = query.replace(" ", "_").lower()
+    print(query)
+    params['url'] = suggestion_url.format(letter=query[0], query=query) 
+    return params
+
+def response(resp):
+    suggestions = json.loads(resp.text)
+    results = []
+    for entry in suggestions['d']:
+        content = ""
+        if entry['id'][:2] in search_categories:
+            href = base_url.format(category=search_categories[entry['id'][:2]], id=entry['id'])
+        if 'y' in entry:
+            content += str(entry['y']) + " - "
+        if 's' in entry:
+            content += entry['s']
+        results.append({
+            "title": entry['l'],
+            "url": href,
+            "content": content
+        })
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -699,6 +699,12 @@ engines:
       require_api_key: false
       results: JSON
 
+  - name : imdb
+    engine : imdb
+    shortcut : imdb
+    timeout : 6.0
+    disabled : True
+
   - name : ina
     engine : ina
     shortcut : in


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

1 file addition - engines/imdb.py
The imdb engine gives a limited but decent mix of results (names, tvshows, movies) which are more forgiving than 'general' (if the name is not exact). e.g. 'Guardians' in default 'general' only returns 'The Guardians (2017)' whereas imdb returns pages sorted by popularity: Guardians of the galaxy, vol 2, vol 3, Rise of the Guardians etc. 

The actual search page has lackluster results so this engine takes the results from the 'suggested' dropdown (via the json endpoint) on imdb.com

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

<!-- MANDATORY -->

I usually use imdb to search for names in films, tv shows or vice versa. This engine gives some limited support but provides 'more popular' results.

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

Enable imdb in settings and run "!imdb <query>"

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

Open to any feedback and especially with how the listings are formatted

<!-- additional notes for reviewiers -->

## Related issues
Closes #1145
<!--
Closes #234
-->
