### PR TITLE
[mod] Fix Libgen + Uncomment Ebay and Urbandictionary

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -434,11 +434,11 @@ engines:
       require_api_key: false
       results: HTML
 
-#  - name : ebay
-#    engine : ebay
-#    shortcut : eb
-#    disabled : True
-#    timeout: 5
+  - name : ebay
+    engine : ebay
+    shortcut : eb
+    disabled : True
+    timeout: 5
 
   - name : 1x
     engine : www1x
@@ -724,9 +724,8 @@ engines:
     engine : xpath
     paging : True
     page_size : 25
-    enable_http: True
-    search_url : http://libgen.rs/search.php?req={query}&page={pageno}
-    url_xpath : //a[contains(@href,"bookfi.net/md5")]/@href
+    search_url : https://libgen.rs/search.php?req={query}&page={pageno}
+    url_xpath : //a[contains(@href,"library.lol/main")]/@href
     title_xpath : //a[contains(@href,"book/")]/text()[1]
     content_xpath : //td/a[1][contains(@href,"=author")]/text()
     categories : general, files
@@ -1162,14 +1161,15 @@ engines:
 #    base_url : https://uncyclopedia.wikia.com/
 #    number_of_results : 5
 
-# tmp suspended - too slow, too many errors
-#  - name : urbandictionary
-#    engine        : xpath
-#    search_url    : https://www.urbandictionary.com/define.php?term={query}
-#    url_xpath     : //*[@class="word"]/@href
-#    title_xpath   : //*[@class="def-header"]
-#    content_xpath : //*[@class="meaning"]
-#    shortcut : ud
+
+  - name : urbandictionary
+    engine        : xpath
+    search_url    : https://www.urbandictionary.com/define.php?term={query}
+    url_xpath     : //*[@class="word"]/@href
+    title_xpath   : //*[@class="def-header"]
+    content_xpath : //*[@class="meaning"]
+    shortcut : ud
+    disabled : True
 
   - name : unsplash
     engine : unsplash


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

- Change Libgen provider and use https by default.
- Umcomment Urbandictionary but disable it by default, it is working.
- Uncomment Ebay as it is working correctly.
- 
(For ebay in the future: base_url should be changed from settings.yml just like peertube or invidious)

## Why is this change important?
Working Libgen results.

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->
Have a working Urbandictionary engine.

## How to test this PR locally?

!eb test
!ud lgtm
!lg permanent record

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
