### PR TITLE
[enh] Add T-mobile.de and Zapmeta autocompleters

### DIFF
--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -125,8 +125,8 @@ def zapmeta(query, lang):
     return results
 
 
-def tmobile(query, lang):
-    # suche.t-mobile.de autocompleter
+def tonline(query, lang):
+    # suche.t-online.de autocompleter
     url = 'https://suggest.t-online.de/www_suggestion_group/ariadne/suggestion?{query}'
     resp = get(url.format(query=urlencode({'q': query})))
 
@@ -169,7 +169,7 @@ backends = {'dbpedia': dbpedia,
             'swisscows': swisscows,
             'qwant': qwant,
             'zapmeta': zapmeta,
-            'tmobile', tmobile,
+            'tonline', tonline,
             'wikipedia': wikipedia
             }
 

--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -134,7 +134,7 @@ def tonline(query, lang):
     bytes_to_string = resp.content.decode()
 
     # Get proper JSON
-    url = bytes_to_string.replace("viewSugg( ", "").replace(" )", "")
+    url = bytes_to_string.replace('viewSugg( ', '').replace(' )', '')
 
 
     results = []
@@ -142,8 +142,8 @@ def tonline(query, lang):
     if resp.ok:
         data = loads(url)
         try:
-            for item in data["suggestions"]["Suggests"]:
-                    results.append(item["suggest"][2])
+            for item in data['suggestions']['Suggests']:
+                    results.append(item['suggest'][2])
 
         # Pass if no suggestion is found
         except KeyError:

--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -109,6 +109,21 @@ def qwant(query, lang):
 
     return results
 
+def zapmeta(query, lang):
+    # zapmeta autocompleter
+    url = 'https://www.zapmeta.com/suggest?{query}'
+
+    resp = get(url.format(query=urlencode({'q': query, 'lang': lang})))
+
+    results = []
+
+    if resp.ok:
+        data = loads(resp.text)
+        for suggestion in data:
+                results.append(suggestion[0])
+
+    return results
+
 
 def tmobile(query, lang):
     # suche.t-mobile.de autocompleter
@@ -153,6 +168,7 @@ backends = {'dbpedia': dbpedia,
             'startpage': startpage,
             'swisscows': swisscows,
             'qwant': qwant,
+            'zapmeta': zapmeta,
             'tmobile', tmobile,
             'wikipedia': wikipedia
             }

--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -110,6 +110,33 @@ def qwant(query, lang):
     return results
 
 
+def tmobile(query, lang):
+    # suche.t-mobile.de autocompleter
+    url = 'https://suggest.t-online.de/www_suggestion_group/ariadne/suggestion?{query}'
+    resp = get(url.format(query=urlencode({'q': query})))
+
+    # Convert Bytes object to string
+    bytes_to_string = resp.content.decode()
+
+    # Get proper JSON
+    url = bytes_to_string.replace("viewSugg( ", "").replace(" )", "")
+
+
+    results = []
+
+    if resp.ok:
+        data = loads(url)
+        try:
+            for item in data["suggestions"]["Suggests"]:
+                    results.append(item["suggest"][2])
+
+        # Pass if no suggestion is found
+        except KeyError:
+           pass
+
+    return results
+
+
 def wikipedia(query, lang):
     # wikipedia autocompleter
     url = 'https://' + lang + '.wikipedia.org/w/api.php?action=opensearch&{0}&limit=10&namespace=0&format=json'
@@ -126,6 +153,7 @@ backends = {'dbpedia': dbpedia,
             'startpage': startpage,
             'swisscows': swisscows,
             'qwant': qwant,
+            'tmobile', tmobile,
             'wikipedia': wikipedia
             }
 


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->
Adds to more engines to autocomplete queries.

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->
Sometime !go autocompleter is blocked, take a look at [this](https://github.com/searx/searx/discussions/2977).

We now have t-online which itself uses !go and zapmeta which uses !bing.

They should do less blocking.
## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->
Change the autocomplete engine from preferenes to any of those.
## Author's checklist
N/A
<!-- additional notes for reviewiers -->

## Related issues
https://github.com/searx/searx/discussions/2977
<!--
Closes #234
-->
