### PR TITLE
healthcheck endpoint

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -584,6 +584,11 @@ def index():
     )
 
 
+@app.route('/healthz', methods=['GET'])
+def health():
+    return Response('OK', mimetype='text/plain')
+
+
 @app.route('/search', methods=['GET', 'POST'])
 def search():
     """Search query in q and return results.

--- a/tests/unit/test_webapp.py
+++ b/tests/unit/test_webapp.py
@@ -188,6 +188,11 @@ class ViewsTestCase(SearxTestCase):
         self.assertEqual(result.status_code, 200)
         self.assertIn(b'<h1>About <a href="/">searx</a></h1>', result.data)
 
+    def test_health(self):
+        result = self.app.get('/healthz')
+        self.assertEqual(result.status_code, 200)
+        self.assertIn(b'OK', result.data)
+
     def test_preferences(self):
         result = self.app.get('/preferences')
         self.assertEqual(result.status_code, 200)


### PR DESCRIPTION
## What does this PR do?

This PR adds a `/health` endpoint which does nothing more than returning plaintext `OK` response. 

## Why is this change important?

It is useful for service discovery tools (consul/kubernetes etc.), to quickly say, that service is alive and running.

## How to test this PR locally?

```
$ curl http://localhost:8080/health -v
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> GET /health HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.64.1
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: text/plain; charset=utf-8
< Content-Length: 2
< Server-Timing: total;dur=8.138
< X-Content-Type-Options: nosniff
< X-XSS-Protection: 1; mode=block
< X-Download-Options: noopen
< X-Robots-Tag: noindex, nofollow
< Referrer-Policy: no-referrer
< Connection: close
<
* Closing connection 0
OK%
```