### PR TITLE
[fix] use engine-type when looking up supported_languages from JSON files

### DIFF
--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -108,8 +108,8 @@ def load_engine(engine_data):
             sys.exit(1)
 
     # assign supported languages from json file
-    if engine_data['name'] in ENGINES_LANGUAGES:
-        setattr(engine, 'supported_languages', ENGINES_LANGUAGES[engine_data['name']])
+    if engine_data['engine'] in ENGINES_LANGUAGES:
+        setattr(engine, 'supported_languages', ENGINES_LANGUAGES[engine_data['engine']])
 
     # find custom aliases for non standard language codes
     if hasattr(engine, 'supported_languages'):


### PR DESCRIPTION
## What does this PR do?

searx/data stores language information for several searchengines in a
json-encoded dict that maps engine-"types" to their supported languages,
for instance there is a entry "google", mapping to the supported languages
of the google engine.

However, the lookup code did not use the engine 'type' (as in: the
filename searx/engines/<enginetype>.py), but instead the manually
configured engine name from settings.yml when querying. This is
problematic as soon as users start to specify additional engine
instances with custom names in the config file, as for instance
suggested as a workaround for multilingual search in the manual [0]:

> engines:
>   - name : google english
>     engine : google
>     language : english

Here, the engine name "google english" will be used for the lookup in
the json file, which does not exist. The empty supported_languages then
lead to an type error later in the processing chain.

This patch changes the behaviour to use the engine entry "google" for
the lookup.

0: https://searx.github.io/searx/user/search_syntax.html#multilingual-search

## Why is this change important?

This should fix bug #2928

## How to test this PR locally?

See #2928 for a full reproducer. Basically add the above searchengine
snippet to `settings.yml`

## Author's checklist

I did only test with my local instance using a small set of enabled engines.
There might be other engines that depend on the old (in my opinion buggy behavior), but I could not imagine how this might be the case.

## Related issues

Closes #2928
