### PR TITLE
Update settings_loader.get_user_settings_path()

### DIFF
--- a/searx/settings_loader.py
+++ b/searx/settings_loader.py
@@ -41,7 +41,7 @@ def get_user_settings_path():
         return check_settings_yml(environ['SEARX_SETTINGS_PATH'])
 
     # if not, get it from searx code base or last solution from /etc/searx
-    return check_settings_yml('/etc/searx/settings.yml')
+    return check_settings_yml('settings.yml') or check_settings_yml('/etc/searx/settings.yml')
 
 
 def update_dict(default_dict, user_dict):


### PR DESCRIPTION
## What does this PR do?

- In settings_loader.py, the settings.yml file from /etc/searx is prioritised before the codebase's settings.yml file.
- The comment above this line even states choose /etc/searx as a 'last solution' but try the codebase file first.

## Why is this change important?

It allows the codebase's settings.yml file to be edited and loaded when running searx. 

## How to test this PR locally?

Leave the settings.yml file unedited; running searx should trigger the error from [webapp.py#L108](https://github.com/searx/searx/blob/master/searx/webapp.py#L108) about the secret key being unchanged.

## Author's checklist

## Related issues
