### PR TITLE
[fix] Prevent missing setting error in ranking

### DIFF
--- a/searx/results.py
+++ b/searx/results.py
@@ -137,7 +137,7 @@ def result_score(result, language):
         if hasattr(engines[result_engine], 'weight'):
             weight *= float(engines[result_engine].weight)
 
-    if settings['search']['prefer_configured_language']:
+    if settings['search'].get('prefer_configured_language', False):
         domain_parts = result['parsed_url'].netloc.split('.')
         if language in domain_parts:
             weight *= 1.1


### PR DESCRIPTION
Prevent error when the `prefer_configured_language` setting is missing.

## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

Don't rely on existence of `prefer_configured_language` setting.

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

Docker users have reported errors since 8c3454fd1be4b578db5693ff1e939af238da6ac8 due to missing setting in the `settings.yml`. See #3063 

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->
- Build docker image
- Start searx (docker)
- Stop searx
- Remove `prefer_configured_language` out of settings.yml
- Start searx (docker) again
- Check if search is working

## Author's checklist

<!-- additional notes for reviewiers -->

Question for later: Aren't new settings automatically added to the `settings.yml`?

## Related issues

<!--
Closes #234
-->


Fixes #3063