### PR TITLE
Preserve cookies after query

### DIFF
--- a/searx/templates/oscar/preferences.html
+++ b/searx/templates/oscar/preferences.html
@@ -367,6 +367,16 @@
 	  <small class="text-muted">({{ _('Note: specifying custom settings in the search URL can reduce privacy by leaking data to the clicked result sites.') }})</small>:
         </p>
 
+        <div class="row">
+            <div class="col-sm-1" style="margin-right: 2rem;">
+                {{- checkbox_toggle("save_preferences", cookies["save_preferences"] != "on") -}}
+            </div>
+            <div class="col-sm-10">
+                <p> Save my preferences with cookies </p>
+            </div>
+
+        </div>
+
 	<div class="tab-pane">
           <input readonly="" class="form-control select-all-on-click cursor-text" type="url" value="{{ url_for('index', _external=True) }}?preferences={{ preferences_url_params|e }}{% raw %}&amp;q=%s{% endraw %}">
           <input type="submit" class="btn btn-primary" value="{{ _('save') }}" />

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -765,10 +765,12 @@ def search():
         timeout_limit=request.form.get('timeout_limit', None)
     )
     resp = make_response(rendered_page)
-    if request.form.get('preferences'):
+    if __should_save_preferences(request):
         request.preferences.save(resp)
     return resp
 
+def __should_save_preferences(request):
+    return request.form.get('preferences') and request.form.get('save_preferences') != 'on'
 
 def __get_translated_errors(unresponsive_engines):
     translated_errors = set()

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -769,8 +769,10 @@ def search():
         request.preferences.save(resp)
     return resp
 
+
 def __should_save_preferences(request):
     return request.form.get('preferences') and request.form.get('save_preferences') != 'on'
+
 
 def __get_translated_errors(unresponsive_engines):
     translated_errors = set()

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -741,7 +741,7 @@ def search():
                                },
                                result_container.corrections))
     #
-    return render(
+    rendered_page = render(
         'results.html',
         results=results,
         q=request.form['q'],
@@ -764,6 +764,10 @@ def search():
         favicons=global_favicons[themes.index(get_current_theme_name())],
         timeout_limit=request.form.get('timeout_limit', None)
     )
+    resp = make_response(rendered_page)
+    if request.form.get('preferences'):
+        request.preferences.save(resp)
+    return resp
 
 
 def __get_translated_errors(unresponsive_engines):


### PR DESCRIPTION
## What does this PR do?

Implements the "preserve preferences URL parameter as cookies" https://github.com/searx/searx/issues/2958 

## Why is this change important?

After making a search with the url preferences, the user expects it's settings to persist across more searches. The current behavior does not persist the user configuration.

This branch allows the user to have it's, e.g. dark mode ON even after the first query

## How to test this PR locally?

1. Set your theme to dark mode
1. Go to the /preferences page
1. Copy the preferences URL
1. Open an anonymous browser tab
1. Paste the preferences URL and update the last q=%s to q=dog

At the search results page, confirm that you are in dark mode
Go to the images page, confirm that you still have the dark mode

## Related issues

https://github.com/searx/searx/issues/2958
https://gitlab.e.foundation/e/backlog/-/issues/1154
