### PR TITLE
[fix] Qwant: Remove extra q from URL

### DIFF
--- a/searx/engines/qwant.py
+++ b/searx/engines/qwant.py
@@ -59,7 +59,7 @@ category_to_keyword = {
 }
 
 # search-url
-url = 'https://api.qwant.com/v3/search/{keyword}?q={query}&count={count}&offset={offset}'
+url = 'https://api.qwant.com/v3/search/{keyword}?{query}&count={count}&offset={offset}'
 
 
 def request(query, params):


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

Remove an extra `q=` from the search URL of Qwant.

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

Qwant is returning results for the letter Q if no other results are found.

## How to test this PR locally?

Compare `!qwant DNTWLOCK` with and without this PR.

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

N/A
<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
Fixes #3090 