### PR TITLE
Disable onesearch by default

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1625,6 +1625,7 @@ engines:
   - name: onesearch
     shortcut: onesearch
     engine: onesearch
+    disabled: True
     about:
       website: https://www.onesearch.com/
       wikidata_id: None


### PR DESCRIPTION
onesearch is not available everywhere and thus display an error by default in searx

Related to https://github.com/searx/searx/pull/3065

![image](https://user-images.githubusercontent.com/4016501/146250694-14773649-b61d-4a9a-aa05-379c749202f4.png)
![image](https://user-images.githubusercontent.com/4016501/146250720-a8a4c86a-d8b3-4970-8782-a00002809eb2.png)
