### PR TITLE
[enh] Add autocompleter from Brave

### DIFF
--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -29,11 +29,13 @@ from searx.exceptions import SearxEngineResponseException
 
 from searx.utils import searx_useragent
 
+
 def get(*args, **kwargs):
     if 'timeout' not in kwargs:
         kwargs['timeout'] = settings['outgoing']['request_timeout']
     kwargs['raise_for_httperror'] = True
     return http_get(*args, **kwargs)
+
 
 def brave(query, params):
     # brave search autocompleter
@@ -49,8 +51,10 @@ def brave(query, params):
     if resp.ok:
         data = loads(resp.text)
         for item in data[1]:
-                results.append(item)
-    return results 
+            results.append(item)
+
+    return results
+
 
 def dbpedia(query, lang):
     # dbpedia autocompleter, no HTTPS

--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -28,7 +28,6 @@ from searx.network import get as http_get
 from searx.exceptions import SearxEngineResponseException
 
 
-
 def get(*args, **kwargs):
     if 'timeout' not in kwargs:
         kwargs['timeout'] = settings['outgoing']['request_timeout']

--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -45,7 +45,7 @@ def brave(query, lang):
 
     if resp.ok:
         data = loads(resp.text)
-        for suggeestion in data[1]:
+        for suggestion in data[1]:
             results.append(suggestion)
 
     return results

--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -27,7 +27,6 @@ from searx import settings
 from searx.network import get as http_get
 from searx.exceptions import SearxEngineResponseException
 
-from searx.utils import searx_useragent
 
 
 def get(*args, **kwargs):
@@ -37,12 +36,9 @@ def get(*args, **kwargs):
     return http_get(*args, **kwargs)
 
 
-def brave(query, params):
+def brave(query, lang):
     # brave search autocompleter
     url = 'https://search.brave.com/api/suggest?{query}'
-
-    # use searx user-agent
-    params['headers']['User-Agent'] = searx_useragent()
 
     resp = get(url.format(query=urlencode({'q': query})))
 
@@ -50,8 +46,8 @@ def brave(query, params):
 
     if resp.ok:
         data = loads(resp.text)
-        for item in data[1]:
-            results.append(item)
+        for suggeestion in data[1]:
+            results.append(suggestion)
 
     return results
 

--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -27,6 +27,7 @@ from searx import settings
 from searx.network import get as http_get
 from searx.exceptions import SearxEngineResponseException
 
+from searx.utils import searx_useragent
 
 def get(*args, **kwargs):
     if 'timeout' not in kwargs:
@@ -34,6 +35,22 @@ def get(*args, **kwargs):
     kwargs['raise_for_httperror'] = True
     return http_get(*args, **kwargs)
 
+def brave(query, params):
+    # brave search autocompleter
+    url = 'https://search.brave.com/api/suggest?{query}'
+
+    # use searx user-agent
+    params['headers']['User-Agent'] = searx_useragent()
+
+    resp = get(url.format(query=urlencode({'q': query})))
+
+    results = []
+
+    if resp.ok:
+        data = loads(resp.text)
+        for item in data[1]:
+                results.append(item)
+    return results 
 
 def dbpedia(query, lang):
     # dbpedia autocompleter, no HTTPS
@@ -120,7 +137,8 @@ def wikipedia(query, lang):
     return []
 
 
-backends = {'dbpedia': dbpedia,
+backends = {'brave': brave,
+            'dbpedia': dbpedia,
             'duckduckgo': duckduckgo,
             'google': google,
             'startpage': startpage,


### PR DESCRIPTION
Raw response example: https://search.brave.com/api/suggest?q=how%20to:%20with%20j

Headers are needed in order to get a 200 response, thus Searx user-agent is used.

Other URL param could be  '&rich=false' or  '&rich=true'.

## What does this PR do?

Add autocompleter from Brave.

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

Imports searx_useragent.
## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

More options to choose from.

## How to test this PR locally?

Type something in te search box.

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

<!-- additional notes for reviewiers -->

N/A
## Related issues

<!--
Closes #234
-->
N/A