### PR TITLE
New files engine: Prowlarr

### DIFF
--- a/searx/engines/prowlarr.py
+++ b/searx/engines/prowlarr.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""
+
+ Prowlarr search (Files)
+
+"""
+
+from json import loads
+from urllib.parse import urlencode
+from searx.exceptions import SearxEngineAPIException
+
+categories = ''
+
+paging = False
+api_key = ''
+indexer_ids = ''
+search_type = 'search'
+search_categories = ''
+base_url = ''
+
+
+def request(query, params):
+    if not base_url:
+        raise SearxEngineAPIException('missing prowlarr base url')
+
+    if not api_key:
+        raise SearxEngineAPIException('missing prowlarr API key')
+
+    query_args = {
+        'query': query,
+        'apikey': api_key,
+        'type': search_type
+    }
+
+    if indexer_ids:
+        query_args['indexerIds'] = indexer_ids
+
+    if search_categories:
+        query_args['categories'] = search_categories
+
+    params['url'] = base_url + urlencode(query_args)
+
+    return params
+
+
+def response(resp):
+    results = []
+
+    json_data = loads(resp.text)
+
+    for result in json_data:
+
+        newResult = {
+            'title': result['title'],
+            'url': result['infoUrl'],
+            'template': 'torrent.html'
+        }
+
+        if 'files' in result:
+            newResult['files'] = result['files']
+
+        if 'size' in result:
+            newResult['filesize'] = result['size']
+
+        if 'seeders' in result:
+            newResult['seed'] = result['seeders']
+
+        if 'leechers' in result:
+            newResult['leech'] = result['leechers']
+
+        if 'downloadUrl' in result:
+            newResult['torrentfile'] = result['downloadUrl']
+
+        # magnet link *may* be in guid, but it may be also idential to infoUrl
+        if 'guid' in result and isinstance(result['guid'], str) and result['guid'].startswith('magnet'):
+            newResult['magnetlink'] = result['guid']
+
+        results.append(newResult)
+
+    return results

--- a/searx/engines/prowlarr.py
+++ b/searx/engines/prowlarr.py
@@ -50,31 +50,31 @@ def response(resp):
 
     for result in json_data:
 
-        newResult = {
+        new_result = {
             'title': result['title'],
             'url': result['infoUrl'],
             'template': 'torrent.html'
         }
 
         if 'files' in result:
-            newResult['files'] = result['files']
+            new_result['files'] = result['files']
 
         if 'size' in result:
-            newResult['filesize'] = result['size']
+            new_result['filesize'] = result['size']
 
         if 'seeders' in result:
-            newResult['seed'] = result['seeders']
+            new_result['seed'] = result['seeders']
 
         if 'leechers' in result:
-            newResult['leech'] = result['leechers']
+            new_result['leech'] = result['leechers']
 
         if 'downloadUrl' in result:
-            newResult['torrentfile'] = result['downloadUrl']
+            new_result['torrentfile'] = result['downloadUrl']
 
         # magnet link *may* be in guid, but it may be also idential to infoUrl
         if 'guid' in result and isinstance(result['guid'], str) and result['guid'].startswith('magnet'):
-            newResult['magnetlink'] = result['guid']
+            new_result['magnetlink'] = result['guid']
 
-        results.append(newResult)
+        results.append(new_result)
 
     return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -908,6 +908,26 @@ engines:
     engine : openstreetmap
     shortcut : osm
 
+#  - name : prowlarr
+#    engine : prowlarr
+#    shortcut : prow
+#    categories : files
+#    enable_http : True
+#    api_key : ''
+#    indexer_ids : 5 # comma separated list of indexer ids
+#    search_categories : '' # comma separated list of categories
+#    search_type : search
+#    base_url: http://localhost:9696/api/v1/search?
+#    timeout : 50.0
+#    disabled : True,
+#    about :
+#      website : https://wiki.servarr.com/prowlarr
+#      wikidata_id : None
+#      official_api_documentation : https://wiki.servarr.com/prowlarr/search
+#      use_official_api : true
+#      require_api_key : true
+#      results : JSON
+
   - name : openrepos
     engine : xpath
     paging : True


### PR DESCRIPTION
## What does this PR do?

Gives the user the possibility to search their own prowlarr instances.

Info: https://wiki.servarr.com/en/prowlarr
Github: https://github.com/Prowlarr/Prowlarr

## Why is this change important?

Prowlarr searchs multiple upstream search providers, thus allows to use that functionality through searx.

## How to test this PR locally?

* Run sudo make run
* Go to /preferences
* Enable prowlarr search engine
* Make some search
* Assert that it works as expected

## Author's checklist

This uses the prowlarr search API; it does not support pagination.

## Related issues

(none)
