### PR TITLE
products results: add possibility to show if a product is in stock or not

### DIFF
--- a/searx/templates/oscar/result_templates/products.html
+++ b/searx/templates/oscar/result_templates/products.html
@@ -1,4 +1,4 @@
-{% from 'oscar/macros.html' import draw_favicon, result_header, result_sub_header, result_footer_rtl, result_footer %}
+{% from 'oscar/macros.html' import draw_favicon, icon, result_header, result_sub_header, result_footer_rtl, result_footer %}
 
 {{ result_header(result, favicons) }}
 {{ result_sub_header(result) }}
@@ -11,6 +11,7 @@
         {% if result.shipping %}<small>{{ result.shipping|safe }}</small></br>{% endif %}
         {% if result.source_country %}<small>{{ result.source_country|safe }}</small></br>{% endif %}
         {% if result.content %}{{ result.content|safe }}{% endif %}
+        {% if result.has_stock is defined %}<br>{% if result.has_stock %}{{ icon('check', _('Has stock')) }}{% else %}{{ icon('alert', _('Out of stock')) }}{% endif %}{% endif %}
         </p>
     </div>
 </div>


### PR DESCRIPTION
## What does this PR do?

A simple template enhancement so an engine can show if a product is in stock or not. Often this is easy to determine.

## Why is this change important?

It is important to know if a certain product in the results list is in stock.

## How to test this PR locally?

Hm, not really possible, unless you have an engine that returns the `has_stock` property.

One would be in #3119 

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

This came as part of the example in #3119, but is separate as it's a different concern.