### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/searx/network/__init__.py
+++ b/searx/network/__init__.py
@@ -4,6 +4,7 @@ import asyncio
 import threading
 import concurrent.futures
 from time import time
+from queue import SimpleQueue
 
 import httpx
 import h2.exceptions
@@ -11,29 +12,6 @@ import h2.exceptions
 from .network import get_network, initialize, check_network_configuration
 from .client import get_loop
 from .raise_for_httperror import raise_for_httperror
-
-# queue.SimpleQueue: Support Python 3.6
-try:
-    from queue import SimpleQueue
-except ImportError:
-    from queue import Empty
-    from collections import deque
-
-    class SimpleQueue:
-        """Minimal backport of queue.SimpleQueue"""
-
-        def __init__(self):
-            self._queue = deque()
-            self._count = threading.Semaphore(0)
-
-        def put(self, item):
-            self._queue.append(item)
-            self._count.release()
-
-        def get(self):
-            if not self._count.acquire(True):
-                raise Empty
-            return self._queue.popleft()
 
 
 THREADLOCAL = threading.local()

--- a/searx/network/client.py
+++ b/searx/network/client.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import threading
+import uvloop
 
 import httpcore
 import httpx
@@ -16,14 +17,6 @@ from python_socks import (
 import python_socks._errors
 
 from searx import logger
-
-# Optional uvloop (support Python 3.6)
-try:
-    import uvloop
-except ImportError:
-    pass
-else:
-    uvloop.install()
 
 
 logger = logger.getChild('searx.http.client')


### PR DESCRIPTION
## What does this PR do?

This PR drops support for Python 3.6. The release is no longer supported since 23/12/2021.

Ref: https://endoflife.date/python

## Why is this change important?

Avoid running tests for old versions.

## How to test this PR locally?

`make ci.test`