### PR TITLE
Fixed Hoogle engine

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -683,22 +683,19 @@ engines:
 
   - name : hoogle
     engine : xpath
-    paging : True
     search_url : https://hoogle.haskell.org/?hoogle={query}&start={pageno}
     results_xpath : '//div[@class="result"]'
-    title_xpath : './/div[@class="ans"]//a'
-    url_xpath : './/div[@class="ans"]//a/@href'
-    content_xpath : './/div[@class="from"]'
-    page_size : 20
+    title_xpath : './div[@class="ans"]'
+    url_xpath : './div[@class="ans"]//a/@href'
+    content_xpath : './div[contains(@class, "doc")]'
     categories : it
     shortcut : ho
     about:
-      website: https://www.haskell.org/
+      website: https://hoogle.haskell.org/
       wikidata_id: Q34010
-      official_api_documentation: https://hackage.haskell.org/api
       use_official_api: false
       require_api_key: false
-      results: JSON
+      results: HTML
 
   - name : imdb
     engine : imdb


### PR DESCRIPTION
## What does this PR do?

The Hoogle engine was incorrect in a number of places. 

The things this PR does:
1. In the result content: Currently it returns the list of names of links to modules. I changed it to display the documentation of the entry the result actually links to.

   <details>
       <summary>Before</summary>

   ![Screenshot 2022-01-22 at 10 23 19](https://user-images.githubusercontent.com/6209627/150629362-35ea7592-3cc9-42cc-975f-8ff424f17c24.png)


   </details>


   <details>
       <summary>After</summary>

   ![Screenshot 2022-01-22 at 10 23 27](https://user-images.githubusercontent.com/6209627/150629367-771caf1a-60b4-4168-8087-1348e3c11271.png)

   </details>


2. The metadata was incorrect:
   1. The link to API was linking to the Hackage API. It is a completely different service. Hoogle does not have an API as far as I am aware.
   2. The engine uses HTML instead of JSON
   3. The link provided didn't link to Hoogle, but linked to the Haskell website.
   4. Hoogle returns all results on one page. There is no paging.



## Why is this change important?

The metadata will be correct and the results will be more informative.

## How to test this PR locally?

1. ```shell
   make run
   ```
2. Search for `!ho fmap`
