### PR TITLE
Fix Tor proxy when using httpx 0.21.x

### DIFF
--- a/searx/network/network.py
+++ b/searx/network/network.py
@@ -167,8 +167,7 @@ class Network:
         for transport in client._mounts.values():  # pylint: disable=protected-access
             if isinstance(transport, AsyncHTTPTransportNoHttp):
                 continue
-            if not getattr(transport, '_pool') and getattr(transport._pool, '_rdns', False):
-                result = False
+            if getattr(transport, '_pool') and getattr(transport._pool, '_rdns', False):
                 continue
             return False
         response = await client.get("https://check.torproject.org/api/ip", timeout=10)


### PR DESCRIPTION
## What does this PR do?

This should fix #3164.
The problem is that `httpx` keeps making breaking changes to their library, so we just have to adjust the code a little bit to make it work with the new version of the library.

## How to test this PR locally?

1. In the `settings.yml` add an outgoing proxy such as `all:// : socks5h://127.0.0.1:9050` and run Tor in that port.
1. Set the `using_tor_proxy` setting as true.
1. Increase the `request_timeout` to make it up for Tor's slowness.
1. Run searx.
1. Try to run a query like `!onions searx`.
1. It should work.


## Related issues
Closes  #3164