### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/data-update.yml
+++ b/.github/workflows/data-update.yml
@@ -4,6 +4,9 @@ on:
     - cron: "05 06 1 * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   updateData:
     name: Update data - ${{ matrix.fetch }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["master"]
 
+permissions:
+  contents: read
+
 jobs:
   python:
     name: Python ${{ matrix.python-version }}
@@ -73,6 +76,8 @@ jobs:
       run: make V=1 themes.all
 
   documentation:
+    permissions:
+      contents: write  # for JamesIves/github-pages-deploy-action to push changes in repo
     name: Documentation
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
