### PR TITLE
[enh] archive.today option for results page

### DIFF
--- a/searx/preferences.py
+++ b/searx/preferences.py
@@ -354,6 +354,16 @@ class Preferences:
                     'True': True
                 }
             ),
+            'archive_today': MapSetting(
+                settings['ui'].get('archive_today', True),
+                is_locked('archive_today'),
+                map={
+                    '0': False,
+                    '1': True,
+                    'False': False,
+                    'True': True
+                }
+            ),
             'image_proxy': MapSetting(
                 settings['server'].get('image_proxy', False),
                 is_locked('image_proxy'),

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -38,6 +38,7 @@ server:
 
 ui:
     autofocus : True # Autofocus search input
+    archive_today : False # show archive.today links
     static_path : "" # Custom static path - leave it blank if you didn't change
     templates_path : "" # Custom templates path - leave it blank if you didn't change
     default_theme : oscar # ui theme

--- a/searx/templates/oscar/macros.html
+++ b/searx/templates/oscar/macros.html
@@ -36,6 +36,9 @@
             <small>{{ result_link(result.cached_url, icon('link') + _('cached'), "text-info", id) }}</small>
             {%- elif not result.is_onion -%}
             <small>{{ result_link("https://web.archive.org/web/" + result.url, icon('link') + _('cached'), "text-info", id) }}</small>
+	        {% if archive_today %}
+	    <small>{{ result_link("https://archive.today/" + result.url, icon('link') + _('archive'), "text-info", id) }}</small>
+                {% endif %}
             {%- endif -%}
         {%- endif -%}
         {%- if proxify -%}
@@ -72,6 +75,9 @@
         <small>{{ result_link(result.cached_url, icon('link') + _('cached'), "text-info", id) }}</small>
         {%- elif not result.is_onion -%}
         <small>{{ result_link("https://web.archive.org/web/" + result.url, icon('link') + _('cached'), "text-info", id) }}</small>
+	    {% if archive_today %}
+	<small>{{ result_link("https://archive.today/" + result.url, icon('link') + _('archive'), "text-info", id) }}</small>
+	    {% endif %}
         {%- endif -%}
     {%- endif -%}
     {%- if proxify -%}

--- a/searx/templates/oscar/preferences.html
+++ b/searx/templates/oscar/preferences.html
@@ -161,6 +161,17 @@
                     {{ preferences_item_footer(info, label, rtl) }}
                     {% endif %}
 
+                    {% if 'archive_today' not in locked_preferences %}
+                    {% set label = _('Show archive.today links') %}
+                    {% set info = _('Alternative link cache service') %}
+                    {{ preferences_item_header(info, label, rtl, 'archive_today') }}
+                        <select class="form-control {{ custom_select_class(rtl) }}" name="archive_today" id="archive_today">
+                            <option value="1" {% if archive_today %}selected="selected"{% endif %}>{{ _('On') }}</option>
+                            <option value="0" {% if not archive_today %}selected="selected"{% endif %}>{{ _('Off')}}</option>
+                        </select>
+                    {{ preferences_item_footer(info, label, rtl) }}
+                    {% endif %}
+
                     {% set label = _('Show advanced settings') %}
                     {% set info = _('Show advanced settings panel in the home page by default') %}
                     {{ preferences_item_header(info, label, rtl, 'advanced_search') }}

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -389,6 +389,8 @@ def render(template_name, override_theme=None, **kwargs):
 
     kwargs['autofocus'] = request.preferences.get_value('autofocus')
 
+    kwargs['archive_today'] = request.preferences.get_value('archive_today')
+
     kwargs['safesearch'] = str(request.preferences.get_value('safesearch'))
 
     kwargs['language_codes'] = languages


### PR DESCRIPTION
## What does this PR do?

Adds an option to the oscar theme that puts an archive.today link next to the web.archive.org cache link.

## Why is this change important?

I find it useful to easily access archive.today links and thought other people might find it useful as well.

## How to test this PR locally?

By default the option is off so the extra link should not appear on the results page.

In preferences change 'Show archive.today links' to 'On'

Do a search and on the results page test that the 'archive' links work.

