### PR TITLE
Add search operators plugin

### DIFF
--- a/searx/plugins/__init__.py
+++ b/searx/plugins/__init__.py
@@ -33,6 +33,7 @@ from searx.plugins import (oa_doi_rewrite,
                            infinite_scroll,
                            self_info,
                            hostname_replace,
+                           query_strings,
                            search_on_category_select,
                            tracker_url_remover,
                            vim_hotkeys)

--- a/searx/plugins/__init__.py
+++ b/searx/plugins/__init__.py
@@ -171,8 +171,10 @@ plugins.register(infinite_scroll)
 plugins.register(self_info)
 plugins.register(hostname_replace)
 plugins.register(search_on_category_select)
+plugins.register(query_strings)
 plugins.register(tracker_url_remover)
 plugins.register(vim_hotkeys)
+
 # load external plugins
 if 'plugins' in settings:
     plugins.register(*settings['plugins'], external=True)

--- a/searx/plugins/__init__.py
+++ b/searx/plugins/__init__.py
@@ -33,8 +33,8 @@ from searx.plugins import (oa_doi_rewrite,
                            infinite_scroll,
                            self_info,
                            hostname_replace,
-                           query_strings,
                            search_on_category_select,
+                           search_operators,
                            tracker_url_remover,
                            vim_hotkeys)
 
@@ -172,7 +172,7 @@ plugins.register(infinite_scroll)
 plugins.register(self_info)
 plugins.register(hostname_replace)
 plugins.register(search_on_category_select)
-plugins.register(query_strings)
+plugins.register(search_operators)
 plugins.register(tracker_url_remover)
 plugins.register(vim_hotkeys)
 

--- a/searx/plugins/query_strings.py
+++ b/searx/plugins/query_strings.py
@@ -1,9 +1,12 @@
-import shlex, string
+import shlex
+import string
+
 from flask_babel import gettext
 
-name = gettext("query strings")
-description = gettext('adds site:, - and "" to searx')
-default_on = True
+name = gettext("Search operators")
+description = gettext('Filter results using quotes, site: and -site:. Please note that you might get less results with the additional filtering.')
+default_on = False
+
 
 def on_result(request, search, result):
     q = search.search_query.query
@@ -12,7 +15,11 @@ def on_result(request, search, result):
     mitems = [x.lower() for x in qs if x.startswith('-')]
     siteitems = [x.lower() for x in qs if x.startswith('site:')]
     msiteitems = [x.lower() for x in qs if x.startswith('-site:')]
-    url, title, content = result["url"].lower(), result["title"].lower(), (result.get("content").lower() if result.get("content") else '')
+    url, title, content = (
+        result["url"].lower(),
+        result["title"].lower(),
+        (result.get("content").lower() if result.get("content") else '')
+    )
     if all((x not in title or x not in content) for x in spitems):
         return False
     if all((x in title or x in content) for x in mitems):

--- a/searx/plugins/query_strings.py
+++ b/searx/plugins/query_strings.py
@@ -13,9 +13,9 @@ def on_result(request, search, result):
     siteitems = [x.lower() for x in qs if x.startswith('site:')]
     msiteitems = [x.lower() for x in qs if x.startswith('-site:')]
     url, title, content = result["url"].lower(), result["title"].lower(), (result.get("content").lower() if result.get("content") else '')
-    if all(x not in (title or content) for x in spitems):
+    if all((x not in title or x not in content) for x in spitems):
         return False
-    if all(x in (title or content) for x in mitems):
+    if all((x in title or x in content) for x in mitems):
         return False
     if all(x not in url for x in siteitems):
         return False

--- a/searx/plugins/query_strings.py
+++ b/searx/plugins/query_strings.py
@@ -1,7 +1,8 @@
 import shlex, string
+from flask_babel import gettext
 
-name = "query strings"
-description = 'adds site:, - and "" to searx'
+name = gettext("query strings")
+description = gettext('adds site:, - and "" to searx')
 default_on = True
 
 def on_result(request, search, result):
@@ -12,9 +13,9 @@ def on_result(request, search, result):
     siteitems = [x.lower() for x in qs if x.startswith('site:')]
     msiteitems = [x.lower() for x in qs if x.startswith('-site:')]
     url, title, content = result["url"].lower(), result["title"].lower(), (result.get("content").lower() if result.get("content") else '')
-    if all(x not in title or content for x in spitems):
+    if all(x not in (title or content) for x in spitems):
         return False
-    if all(x in title or content for x in mitems):
+    if all(x in (title or content) for x in mitems):
         return False
     if all(x not in url for x in siteitems):
         return False

--- a/searx/plugins/query_strings.py
+++ b/searx/plugins/query_strings.py
@@ -1,0 +1,23 @@
+import shlex, string
+
+name = "query strings"
+description = 'adds site:, - and "" to searx'
+default_on = True
+
+def on_result(request, search, result):
+    q = search.search_query.query
+    qs = shlex.split(q)
+    spitems = [x.lower() for x in qs if ' ' in x]
+    mitems = [x.lower() for x in qs if x.startswith('-')]
+    siteitems = [x.lower() for x in qs if x.startswith('site:')]
+    msiteitems = [x.lower() for x in qs if x.startswith('-site:')]
+    url, title, content = result["url"].lower(), result["title"].lower(), (result.get("content").lower() if result.get("content") else '')
+    if all(x not in title or content for x in spitems):
+        return False
+    if all(x in title or content for x in mitems):
+        return False
+    if all(x not in url for x in siteitems):
+        return False
+    if all(x in url for x in msiteitems):
+        return False
+    return True

--- a/searx/plugins/search_operators.py
+++ b/searx/plugins/search_operators.py
@@ -4,7 +4,8 @@ import string
 from flask_babel import gettext
 
 name = gettext("Search operators")
-description = gettext('Filter results using quotes, site: and -site:. Please note that you might get less results with the additional filtering.')
+description = gettext("""Filter results using quotes, site: and -site:.
+Please note that you might get less results with the additional filtering.""")
 default_on = False
 
 

--- a/searx/plugins/search_operators.py
+++ b/searx/plugins/search_operators.py
@@ -4,7 +4,7 @@ import string
 from flask_babel import gettext
 
 name = gettext("Search operators")
-description = gettext("""Filter results using quotes, site: and -site:.
+description = gettext("""Filter results using hyphen, site: and -site:.
 Please note that you might get less results with the additional filtering.""")
 default_on = False
 


### PR DESCRIPTION
## What does this PR do?

This PR adds search operator plugin to searx. By default it is disabled because it
removes results from your result set. Thus, you might end up with an empty result page with
the additional filtering. Original PR is by @DiamondDemon669 

## Why is this change important?

With all of its shortcomings, still is a nifty plugin.

## How to test this PR locally?

```
batman -site:imdb.com
```
