### PR TITLE
Deepl

### DIFF
--- a/searx/engines/deepl.py
+++ b/searx/engines/deepl.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+"""Deepl translation engine"""
+
+from json import loads
+
+about = {
+    "website": 'https://deepl.com',
+    "wikidata_id": 'Q43968444',
+    "official_api_documentation": 'https://www.deepl.com/docs-api',
+    "use_official_api": True,
+    "require_api_key": True,
+    "results": 'JSON',
+}
+
+engine_type = 'online_dictionary'
+categories = ['general']
+
+url = 'https://api-free.deepl.com/v2/translate'
+
+
+def request(query, params):
+    '''pre-request callback
+    params<dict>:
+      method  : POST/GET
+      headers : {}
+      data    : {} # if method == POST
+      url     : ''
+      category: 'search category'
+      pageno  : 1 # number of the requested page
+    '''
+
+    params['url'] = url
+    params['method'] = 'POST'
+    params['data'] = {
+        'auth_key': api_key,
+        'text': params['query'],
+        'target_lang': params['to_lang'][1]
+    }
+
+    return params
+
+
+def response(resp):
+    results = []
+
+    result = loads(resp.text)
+    translations = result['translations']
+
+    infobox = "<dl>"
+
+    for translation in translations:
+        infobox += f"<dd>{translation['text']}</dd>"
+
+    infobox += "</dl>"
+
+    results.append(
+        {
+            'infobox': 'Deepl',
+            'content': infobox,
+        }
+    )
+
+    return results
+

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1401,6 +1401,15 @@ engines:
     # See : https://mymemory.translated.net/doc/usagelimits.php
     # api_key : ''
 
+- name : deepl
+  engine : deepl
+  shortcut : dpl
+  # You can use the engine using the official stable API, but you need an API key
+  # See: https://www.deepl.com/pro-api?cta=header-pro-api
+  # api_key : '' # required!
+  timeout : 5.0
+  disabled : True
+
 # Required dependency: mysql-connector-python
 #  - name : mysql
 #    engine : mysql_server

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1401,14 +1401,14 @@ engines:
     # See : https://mymemory.translated.net/doc/usagelimits.php
     # api_key : ''
 
-- name : deepl
-  engine : deepl
-  shortcut : dpl
-  # You can use the engine using the official stable API, but you need an API key
-  # See: https://www.deepl.com/pro-api?cta=header-pro-api
-  # api_key : '' # required!
-  timeout : 5.0
-  disabled : True
+# - name : deepl
+#   engine : deepl
+#   shortcut : dpl
+#   # You can use the engine using the official stable API, but you need an API key
+#   # See: https://www.deepl.com/pro-api?cta=header-pro-api
+#   # api_key : '' # required!
+#   timeout : 5.0
+#   disabled : True
 
 # Required dependency: mysql-connector-python
 #  - name : mysql


### PR DESCRIPTION
## What does this PR do?

This implements the Deepl Translation engine

It works nearly like lingva but directly to the deepl api. There is a free option to use. See https://www.deepl.com/pro-api?cta=header-pro-api for registering a free account.

This api only needs a to-lang, from-lang is a fake by now

## Why is this change important?

You will have deepl in searx with full phrase and sentence translations

## How to test this PR locally?

Api key needed. Put api key into settings.yml - enable deepl. 

de-en Dies ist ein großartiger Test
en-es This is deepl.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues
