### PR TITLE
No change to variable name

### DIFF
--- a/searx/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/searx/translations/pt_BR/LC_MESSAGES/messages.po
@@ -81,7 +81,7 @@ msgstr "erro de busca"
 
 #: searx/webapp.py:634
 msgid "{minutes} minute(s) ago"
-msgstr "{minutos} minuto(s) atrás"
+msgstr "{minutes} minuto(s) atrás"
 
 #: searx/webapp.py:636
 msgid "{hours} hour(s), {minutes} minute(s) ago"


### PR DESCRIPTION
There's no need to change variable name in translation

## What does this PR do?
Bug fix: Someone in translations team has changed variable name during translation. Because of this change in variable name, the app throws an exception KeyError 'minutos`

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
