### PR TITLE
[fix] brave engine: no search results

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1661,7 +1661,7 @@ engines:
     paging: true
     first_page_num: 0
     search_url: https://search.brave.com/search?q={query}&offset={pageno}&spellcheck=1
-    url_xpath: //div[@class="snippet fdb"]/a/@href
+    url_xpath: //a[@class="result-header"]/@href
     title_xpath: //span[@class="snippet-title"]
     content_xpath: //p[1][@class="snippet-description"]
     suggestion_xpath: //div[@class="text-gray h6"]/a


### PR DESCRIPTION
There were never any results from the Brave search engine so fixed url_xpath and now Brave search results are working.

fixes: #3362