### PR TITLE
allow engines to override pretty_url and use this in bing to show mea…

### DIFF
--- a/searx/engines/bing.py
+++ b/searx/engines/bing.py
@@ -68,11 +68,13 @@ def response(resp):
     for result in eval_xpath(dom, '//div[@class="sa_cc"]'):
         link = eval_xpath(result, './/h3/a')[0]
         url = link.attrib.get('href')
+        pretty_url = extract_text(eval_xpath(result, './/cite'))
         title = extract_text(link)
         content = extract_text(eval_xpath(result, './/p'))
 
         # append result
         results.append({'url': url,
+                        'pretty_url': pretty_url,
                         'title': title,
                         'content': content})
 

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -647,7 +647,7 @@ def search():
             # removing html content and whitespace duplications
             result['title'] = ' '.join(html_to_text(result['title']).strip().split())
 
-        if 'url' in result:
+        if 'url' in result and !('pretty_url' in result):
             result['pretty_url'] = prettify_url(result['url'])
 
         # TODO, check if timezone is calculated right


### PR DESCRIPTION
…ningful urls

## What does this PR do?

it parses the url that bing shows to the user and uses it in searx too as display url (or pretty_url as its called). To achieve this we just need to allow engines to override the pretty_url property that's created for every result

## Why is this change important?

as I laid out in the linked issue I think not making the actual url visible to the user makes the bing engine unusable. I want to see the actual href before I click. 

## How to test this PR locally?

Honestly I have not tested this and I can't even code python but it seems valid to me? please check it out, just a small change.

<!-- additional notes for reviewiers -->

## Related issues

Closes #3335

