### PR TITLE
Fix scraping of 'sc' value from homepage

### DIFF
--- a/searx/engines/startpage.py
+++ b/searx/engines/startpage.py
@@ -91,8 +91,7 @@ def get_sc_code(headers):
         dom = html.fromstring(resp.text)
 
         try:
-            # href --> '/?sc=adrKJMgF8xwp20'
-            href = eval_xpath(dom, '//a[@class="footer-home__logo"]')[0].get('href')
+            href = eval_xpath(dom, '//input[@name="sc"]')[0].get('value')
         except IndexError as exc:
             # suspend startpage API --> https://github.com/searxng/searxng/pull/695
             raise SearxEngineResponseException(


### PR DESCRIPTION
Looking at the current HTML for the Startpage front page, the previous footer logo element is no longer present.  This change scrapes the "sc" parameter from one of the hidden HTML form elements, which should (hopefully) be a bit more stable long term, since that form is used by Startpage to submit requests to the engine.

## What does this PR do?

Prior to this change, the Startpage engine simply doesn't work because the scraping of the 'sc' value fails and raises an exception.  This change corrects the issue.

## Why is this change important?

Without this change the engine crashes.

## How to test this PR locally?

A basic search against Startpage triggers the issue.