### PR TITLE
DuckDuckGo fixes

### DIFF
--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -73,6 +73,7 @@ def request(query, params):
     # link again and again ..
 
     params['headers']['Content-Type'] = 'application/x-www-form-urlencoded'
+    params['headers']['Referer'] = 'https://lite.duckduckgo.com/'
 
     # initial page does not have an offset
     if params['pageno'] == 2:

--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -18,7 +18,7 @@ from searx.poolrequests import get
 
 # about
 about = {
-    "website": 'https://lite.duckduckgo.com/lite',
+    "website": 'https://lite.duckduckgo.com/lite/',
     "wikidata_id": 'Q12805',
     "official_api_documentation": 'https://duckduckgo.com/api',
     "use_official_api": False,
@@ -45,7 +45,7 @@ language_aliases = {
 time_range_dict = {'day': 'd', 'week': 'w', 'month': 'm', 'year': 'y'}
 
 # search-url
-url = 'https://lite.duckduckgo.com/lite'
+url = 'https://lite.duckduckgo.com/lite/'
 url_ping = 'https://duckduckgo.com/t/sl_l'
 
 


### PR DESCRIPTION
## What does this PR do?

Fix duckduckgo blocking: add trailing slash to duckduckgo url (= back ported fix #2035 from https://github.com/searxng/searxng/)

Fix duckduckgo blocking: Add HTTP Referer header to DuckDuckGo requests (= back ported fix #2080 from https://github.com/searxng/searxng/)

## Why is this change important?

This makes duckduckgo work again.

See: DuckDuckGo blocked #3441