### PR TITLE
Fix regression in retrieving sc code

### DIFF
--- a/searx/engines/startpage.py
+++ b/searx/engines/startpage.py
@@ -91,14 +91,13 @@ def get_sc_code(headers):
         dom = html.fromstring(resp.text)
 
         try:
-            href = eval_xpath(dom, '//input[@name="sc"]')[0].get('value')
+            sc_code = eval_xpath(dom, '//input[@name="sc"]')[0].get('value')
         except IndexError as exc:
             # suspend startpage API --> https://github.com/searxng/searxng/pull/695
             raise SearxEngineResponseException(
                 suspended_time=7 * 24 * 3600, message="PR-695: query new sc time-stamp failed!"
             ) from exc
 
-        sc_code = href[5:]
         sc_code_ts = time()
         logger.debug("new value is: %s", sc_code)
 


### PR DESCRIPTION
## What does this PR do?

This PR restores the startpage engine to working order.

I broke the code when I tried to fix the engine in my last PR.  The old codepath did some trimming of the sc value and I didn't kill that line when updating the engine to pull the sc value from one of the form input elements, so the value was being clipped.  As a consequence, the captcha was being triggered.

## Why is this change important?

It makes the startpage engine work again.

## How to test this PR locally?

A simple attempt to query startpage from searx will do the job.

## Related issues

Closes #3430 
