### PR TITLE
Reword the TLDR as it is misleading

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,8 +85,8 @@ of turning it off.
 What is the difference between searx and SearxNG?
 #################################################
 
-TL;DR: If you want to run a public instance, go with SearxNG. If you want to
-self host your own instance, choose searx.
+TL;DR: SearXNG is for users that want more features and bugs getting fixed quicker.
+If you prefer a minimalist software and stable experience, use searx.
 
 SearxNG is a fork of searx, created by a former maintainer of searx. The fork
 was created because the majority of the maintainers at the time did not find


### PR DESCRIPTION
The current TLDR in the README is misleading as it applies that SearXNG is not suited for users that self-host, but that is not true. There are plenty of ways to easily self-host SearXNG: https://docs.searxng.org/admin/installation.html

I reworded, so it reflects the current situation between the development of SearXNG and Searx. Please suggest any modification if the words used doesn't suit you.

Please see the examples of the misleading:
- https://github.com/searx/searx/discussions/3475#discussioncomment-5106229
- https://github.com/searx/searx/discussions/3457#discussioncomment-4884694