### PR TITLE
Fix quoting issue in search_operator plugin

### DIFF
--- a/searx/plugins/search_operators.py
+++ b/searx/plugins/search_operators.py
@@ -11,10 +11,10 @@ default_on = False
 
 def on_result(request, search, result):
     q = search.search_query.query
-    # WARN: shlex.quote is designed only for Unix shells and may be vulnerable 
-    # to command injection on non-POSIX complaint shells (Windows)
+    # WARN: shlex.quote is designed only for Unix shells and may be vulnerable
+    # to command injection on non-POSIX compliant shells (Windows)
     # https://docs.python.org/3/library/shlex.html#shlex.quote
-    squote = shlex.quote(q) 
+    squote = shlex.quote(q)
     qs = shlex.split(squote)
     spitems = [x.lower() for x in qs if ' ' in x]
     mitems = [x.lower() for x in qs if x.startswith('-')]

--- a/searx/plugins/search_operators.py
+++ b/searx/plugins/search_operators.py
@@ -11,7 +11,11 @@ default_on = False
 
 def on_result(request, search, result):
     q = search.search_query.query
-    qs = shlex.split(q)
+    # WARN: shlex.quote is designed only for Unix shells and may be vulnerable 
+    # to command injection on non-POSIX complaint shells (Windows)
+    # https://docs.python.org/3/library/shlex.html#shlex.quote
+    squote = shlex.quote(q) 
+    qs = shlex.split(squote)
     spitems = [x.lower() for x in qs if ' ' in x]
     mitems = [x.lower() for x in qs if x.startswith('-')]
     siteitems = [x.lower() for x in qs if x.startswith('site:')]


### PR DESCRIPTION
## What does this PR do?
Fix the apostrophe issue described in #3414 (read diagnosis there) by using `shlex.quote`.

## Why is this change important?

Fixes a 500 Server Error issue when Search Operator is being used with apostrophes.

## How to test this PR locally?

1. Make a request with an apostrophe (')
2. Ensure the following cookies are set

```
enabled_plugins="Search_operators";
disabled_plugins=;
```

## Author's checklist

## Related issues
Closes #3414 

