### PR TITLE
fix duckduckgo engine

### DIFF
--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -73,7 +73,9 @@ def request(query, params):
     # link again and again ..
 
     params['headers']['Content-Type'] = 'application/x-www-form-urlencoded'
+    params['headers']['Origin'] = 'https://lite.duckduckgo.com'
     params['headers']['Referer'] = 'https://lite.duckduckgo.com/'
+    params['headers']['User-Agent'] = 'Mozilla/5.0'
 
     # initial page does not have an offset
     if params['pageno'] == 2:


### PR DESCRIPTION
## What does this PR do?

Added more headers to the search request in order to make Duck Duck Go happy.
 
## Why is this change important?

Duck Duck Go seems to become more and more picky with respect to the headers send with search requests. This time the User-Agent need to be set.

Looking at the request for the second page of a ddg search using a regular browser, I decided to add the Origin header as well - doesn’t harm and we come more close to what a browser does.

## How to test this PR locally?

Activate the Duck Duck Go engine and run a searx query. With out the fix the query is blocked by duckduckgo. With the fix, duckduckgo operates as expected.