### PR TITLE
 Go to main instead of search page when external bang query is empty

### DIFF
--- a/searx/external_bang.py
+++ b/searx/external_bang.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+from urllib.parse import urljoin
+
 from searx.data import EXTERNAL_BANGS
 
 
@@ -40,6 +42,8 @@ def resolve_bang_definition(bang_definition, query):
     url = url.replace(chr(2), query)
     if url.startswith('//'):
         url = 'https:' + url
+    if not query:  # go to main instead of search page
+        url = urljoin(url, '/')
     rank = int(rank) if len(rank) > 0 else 0
     return (url, rank)
 


### PR DESCRIPTION
## What does this PR do?

Added the check if the query for the external bang is empty.
If yes, then the URL is stripped to base domain.

## Why is this change important?

DDG bangs are also convenient shortcuts to websites.  
With this change, the behaviour is consistent with the original.

## How to test this PR locally?

1. Search `!!gh`
2. Verify it redirects to https://github.com instead of https://github.com/search?utf8=%E2%9C%93&q=