### PR TITLE
Support flask-babel 3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Brotli==1.0.9
-babel==2.11.0
+babel==2.12.1
 certifi==2022.12.7
-flask-babel==2.0.0
+flask-babel==3.1.0
 flask==2.2.2
 jinja2==3.1.2
 langdetect==1.0.9


### PR DESCRIPTION
## What does this PR do?

Allows searx to run with flask-babel 3.0.  The driving motivation was to fix the package on NixOS which is not honoring dependency versions (https://github.com/NixOS/nixpkgs/issues/216695).

The error:

```
AttributeError: 'Babel' object has no attribute 'localeselector'
```

The fix:

The way the locale selector is added has changed somewhat, and I needed to move `get_locale` up to make use of it.

## Why is this change important?

I just want it to work with NixOS but keeping dependencies up to date is good in general.

## How to test this PR locally?

I just ran `make test` with and without the updated requirements to make sure searx runs with both 2.0 and 3.0 without any errors.

## Related issues

Obviates https://github.com/searx/searx/pull/3497