### PR TITLE
Added macOS and Windows thumbnails exceptions in .gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,13 @@ gh-pages/
 searx.egg-info/
 .env
 geckodriver.log
+
+# macOS
+.DS_Store
+._*
+
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db


### PR DESCRIPTION
Added exception for macOS and Windows thumbnails.
Prevents automatically created thumbnail files on local workspace to be automatically considered for commit.
