### PR TITLE
fix(sec): upgrade certifi to 2022.12.07

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Brotli==1.0.9
 babel==2.11.0
-certifi==2022.12.7
+certifi==2022.12.07
 flask-babel==2.0.0
 flask==2.2.2
 jinja2==3.1.2


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in certifi 2022.12.7
- [CVE-2022-23491](https://www.oscs1024.com/hd/CVE-2022-23491)


### What did I do？
Upgrade certifi from 2022.12.7 to 2022.12.07 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS